### PR TITLE
memory: Cleanup detail header

### DIFF
--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -18,11 +18,8 @@
 
 #include <cstdio>
 #include <type_traits>
-#include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/uninitialized_fill.h>
-#include <thrust/version.h>
-#include <cuda_runtime_api.h>   // Include after thrust to avoid redefinition warning for __host__ and __device__ in .cpp files
 
 #include <stdgpu/attribute.h>
 #include <stdgpu/cstddef.h>
@@ -65,26 +62,11 @@ struct destroy_value
     }
 };
 
-
-/**
- * \brief A macro that automatically sets information about the caller
- * \param[in] error A CUDA error object
- */
-#define STDGPU_DETAIL_SAFE_CALL(error) stdgpu::detail::safe_call(error, __FILE__, __LINE__, STDGPU_FUNC)
-
-
-/**
-* \brief Checks whether the CUDA call was successful and stops the whole program on failure
-* \param[in] error An CUDA error object
-* \param[in] file The file from which this function was called
-* \param[in] line The line from which this function was called
-* \param[in] function The function from which this function was called
-*/
 void
-safe_call(const cudaError_t error,
-          const char* file,
-          const int line,
-          const char* function);
+workaround_synchronize_device_thrust();
+
+void
+workaround_synchronize_managed_memory();
 
 } // namespace detail
 
@@ -112,9 +94,7 @@ createDeviceArray(const stdgpu::index64_t count,
         thrust::uninitialized_fill(stdgpu::device_begin(device_array), stdgpu::device_end(device_array),
                                    default_value);
 
-        #if THRUST_VERSION <= 100903    // CUDA 10.0 and below
-            STDGPU_DETAIL_SAFE_CALL(cudaDeviceSynchronize());
-        #endif
+        stdgpu::detail::workaround_synchronize_device_thrust();
     #else
         #if STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING
             printf("createDeviceArray : Creating auxiliary array on host to enable execution on host compiler ...\n");
@@ -179,9 +159,7 @@ createManagedArray(const stdgpu::index64_t count,
                 thrust::uninitialized_fill(stdgpu::device_begin(managed_array), stdgpu::device_end(managed_array),
                                            default_value);
 
-                #if THRUST_VERSION <= 100903    // CUDA 10.0 and below
-                    STDGPU_DETAIL_SAFE_CALL(cudaDeviceSynchronize());
-                #endif
+                stdgpu::detail::workaround_synchronize_device_thrust();
             }
             break;
         #else
@@ -196,16 +174,7 @@ createManagedArray(const stdgpu::index64_t count,
 
         case Initialization::HOST :
         {
-            // WORKAROUND : We need to synchronize the whole device before accessing managed memory on pre-Pascal GPUs
-            int current_device;
-            int hash_concurrent_managed_access;
-            STDGPU_DETAIL_SAFE_CALL( cudaGetDevice(&current_device) );
-            STDGPU_DETAIL_SAFE_CALL( cudaDeviceGetAttribute( &hash_concurrent_managed_access, cudaDevAttrConcurrentManagedAccess, current_device ) );
-            if(hash_concurrent_managed_access == 0)
-            {
-                printf("createManagedArray : Synchronizing the whole GPU in order to access the data on the host ...\n");
-                STDGPU_DETAIL_SAFE_CALL(cudaDeviceSynchronize());
-            }
+            stdgpu::detail::workaround_synchronize_managed_memory();
 
             thrust::uninitialized_fill(stdgpu::host_begin(managed_array), stdgpu::host_end(managed_array),
                                        default_value);
@@ -230,6 +199,8 @@ destroyDeviceArray(T*& device_array)
         #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC
             thrust::for_each(stdgpu::device_begin(device_array), stdgpu::device_end(device_array),
                              stdgpu::detail::destroy_value<T>());
+
+            stdgpu::detail::workaround_synchronize_device_thrust();
         #else
             #if STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING
                 printf("destroyDeviceArray : Creating auxiliary array on host to enable execution on host compiler ...\n");

--- a/src/stdgpu/iterator.h
+++ b/src/stdgpu/iterator.h
@@ -21,6 +21,7 @@
  */
 
 #include <thrust/detail/pointer.h>
+#include <thrust/detail/reference.h> // Only forward declaration included by thrust/detail/pointer.h
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/iterator_adaptor.h>
 


### PR DESCRIPTION
The macro function `STDGPU_DETAIL_SAFE_CALL` is only used by the workarounds in `memory_detail.h`. Move the workarounds into dedicated functions to `memory.cpp`. This allows to move the macro `STDGPU_DETAIL_SAFE_CALL` as well to avoid exposing this internal detail to users.