### PR TITLE
bitset,unordered_base: Use atomic_ref over raw function

### DIFF
--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -175,13 +175,13 @@ struct count_visits
     {
         index_t linked_list = i;
 
-        atomicAdd(&(flags[linked_list]), 1);
+        stdgpu::atomic_ref<int>(flags[linked_list]).fetch_add(1);
 
         while (base._offsets[linked_list] != 0)
         {
             linked_list += base._offsets[linked_list];
 
-            atomicAdd(&(flags[linked_list]), 1);
+            stdgpu::atomic_ref<int>(flags[linked_list]).fetch_add(1);
 
             // Prevent potential endless loop and print warning
             if (flags[linked_list] > 1)


### PR DESCRIPTION
The raw functions `atomicX` defined by the CUDA backend are used in `bitset` and `unordered_set`. Replace them by calls to `atomic_ref` to reduce the coupling to the CUDA backend.