### PR TITLE
unordered_base: Workaround while loop timeouts

### DIFF
--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -731,10 +731,18 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::insert(const unordered
 {
     thrust::pair<iterator, bool> result = thrust::make_pair(end(), false);
 
-    while (!contains(_key_from_value(value))
-        && !full() && !_excess_list_positions.empty())
+    // Use for loop with a high range over while loop to workaround kernel timeouts caused by GPU compilation/scheduling issues
+    for (index_t i = 0; i < 1000; ++i)
     {
-        result = try_insert(value);
+        if (!contains(_key_from_value(value))
+            && !full() && !_excess_list_positions.empty())
+        {
+            result = try_insert(value);
+        }
+        else
+        {
+            break;
+        }
     }
 
     return result;
@@ -767,9 +775,17 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::erase(const unordered_
 {
     index_t result = 0;
 
-    while (contains(key))
+    // Use for loop with a high range over while loop to workaround kernel timeouts caused by GPU compilation/scheduling issues
+    for (index_t i = 0; i < 1000; ++i)
     {
-        result = try_erase(key);
+        if (contains(key))
+        {
+            result = try_erase(key);
+        }
+        else
+        {
+            break;
+        }
     }
 
     return result;


### PR DESCRIPTION
In certain circumstances, a kernel timeout may occur when calling the blocking `insert` and `erase` functions. Since the internal while loops run until the execution of the respective operation was successful (or stop if this is not possible), an infinite loop must not occur. Use a for loop with a sufficient range to workaround possible compiler/scheduler issues that may still lead to infinite loops.