### PR TITLE
platform: Add STDGPU_DEVICE_ONLY annotation macro

### DIFF
--- a/examples/thrust_towards_ranges.cu
+++ b/examples/thrust_towards_ranges.cu
@@ -45,7 +45,7 @@ struct atomic_sum
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         sum.fetch_add(x);

--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -115,7 +115,7 @@ class atomic
          * \param[in] desired The value to exchange with the atomic object
          * \return The old value
          */
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         exchange(const T desired);
 
 
@@ -125,7 +125,7 @@ class atomic
          * \param[in] desired The value to exchange with the atomic object
          * \return The old value
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         compare_exchange_weak(T& expected,
                               const T desired);
 
@@ -135,7 +135,7 @@ class atomic
          * \param[in] desired The value to exchange with the atomic object
          * \return The old value
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         compare_exchange_strong(T& expected,
                                 const T desired);
 
@@ -146,7 +146,7 @@ class atomic
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_add(const T arg);
 
         /**
@@ -155,7 +155,7 @@ class atomic
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_sub(const T arg);
 
         /**
@@ -164,7 +164,7 @@ class atomic
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_and(const T arg);
 
         /**
@@ -173,7 +173,7 @@ class atomic
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_or(const T arg);
 
         /**
@@ -182,7 +182,7 @@ class atomic
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_xor(const T arg);
 
 
@@ -192,7 +192,7 @@ class atomic
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_min(const T arg);
 
         /**
@@ -201,7 +201,7 @@ class atomic
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_max(const T arg);
 
         /**
@@ -210,7 +210,7 @@ class atomic
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_same<U, unsigned int>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_inc_mod(const T arg);
 
         /**
@@ -219,7 +219,7 @@ class atomic
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_same<U, unsigned int>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_dec_mod(const T arg);
 
 
@@ -228,7 +228,7 @@ class atomic
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator++();
 
         /**
@@ -236,7 +236,7 @@ class atomic
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator++(int);
 
         /**
@@ -244,7 +244,7 @@ class atomic
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator--();
 
         /**
@@ -252,7 +252,7 @@ class atomic
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator--(int);
 
 
@@ -262,7 +262,7 @@ class atomic
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator+=(const T arg);
 
         /**
@@ -271,7 +271,7 @@ class atomic
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator-=(const T arg);
 
         /**
@@ -280,7 +280,7 @@ class atomic
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator&=(const T arg);
 
         /**
@@ -289,7 +289,7 @@ class atomic
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator|=(const T arg);
 
         /**
@@ -298,7 +298,7 @@ class atomic
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator^=(const T arg);
 
     private:
@@ -377,7 +377,7 @@ class atomic_ref
          * \param[in] desired The value to exchange with the atomic object
          * \return The old value
          */
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         exchange(const T desired);
 
 
@@ -387,7 +387,7 @@ class atomic_ref
          * \param[in] desired The value to exchange with the atomic object
          * \return The old value
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         compare_exchange_weak(T& expected,
                               const T desired);
 
@@ -397,7 +397,7 @@ class atomic_ref
          * \param[in] desired The value to exchange with the atomic object
          * \return The old value
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         compare_exchange_strong(T& expected,
                                 const T desired);
 
@@ -408,7 +408,7 @@ class atomic_ref
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_add(const T arg);
 
         /**
@@ -417,7 +417,7 @@ class atomic_ref
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_sub(const T arg);
 
         /**
@@ -426,7 +426,7 @@ class atomic_ref
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_and(const T arg);
 
         /**
@@ -435,7 +435,7 @@ class atomic_ref
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_or(const T arg);
 
         /**
@@ -444,7 +444,7 @@ class atomic_ref
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_xor(const T arg);
 
 
@@ -454,7 +454,7 @@ class atomic_ref
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_min(const T arg);
 
         /**
@@ -463,7 +463,7 @@ class atomic_ref
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_max(const T arg);
 
         /**
@@ -472,7 +472,7 @@ class atomic_ref
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_same<U, unsigned int>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_inc_mod(const T arg);
 
         /**
@@ -481,7 +481,7 @@ class atomic_ref
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_same<U, unsigned int>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         fetch_dec_mod(const T arg);
 
 
@@ -490,7 +490,7 @@ class atomic_ref
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator++();
 
         /**
@@ -498,7 +498,7 @@ class atomic_ref
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator++(int);
 
         /**
@@ -506,7 +506,7 @@ class atomic_ref
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator--();
 
         /**
@@ -514,7 +514,7 @@ class atomic_ref
          * \return The old value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator--(int);
 
 
@@ -524,7 +524,7 @@ class atomic_ref
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator+=(const T arg);
 
         /**
@@ -533,7 +533,7 @@ class atomic_ref
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator-=(const T arg);
 
         /**
@@ -542,7 +542,7 @@ class atomic_ref
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator&=(const T arg);
 
         /**
@@ -551,7 +551,7 @@ class atomic_ref
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator|=(const T arg);
 
         /**
@@ -560,7 +560,7 @@ class atomic_ref
          * \return The new value
          */
         template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
-        __device__ T
+        STDGPU_DEVICE_ONLY T
         operator^=(const T arg);
 
     private:

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -87,7 +87,7 @@ class bitset
          * \return The old value of the bit
          * \pre 0 <= n < size()
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         set(const index_t n,
             const bool value = true);
 
@@ -104,7 +104,7 @@ class bitset
          * \return The old value of the bit
          * \pre 0 <= n < size()
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         reset(const index_t n);
 
         /**
@@ -119,7 +119,7 @@ class bitset
          * \return The old value of the bit
          * \pre 0 <= n < size()
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         flip(const index_t n);
 
         /**
@@ -128,7 +128,7 @@ class bitset
          * \return The bit at this position
          * \pre 0 <= n < size()
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         operator[](const index_t n) const;
 
 

--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -102,7 +102,7 @@ class deque
          * \return The value at this position
          * \pre 0 <= n < size()
          */
-        __device__ reference
+        STDGPU_DEVICE_ONLY reference
         operator[](const index_type n);
 
         /**
@@ -111,35 +111,35 @@ class deque
          * \return The value at this position
          * \pre 0 <= n < size()
          */
-        __device__ const_reference
+        STDGPU_DEVICE_ONLY const_reference
         operator[](const index_type n) const;
 
         /**
          * \brief Reads the first value
          * \return The first value
          */
-        __device__ reference
+        STDGPU_DEVICE_ONLY reference
         front();
 
         /**
          * \brief Reads the first value
          * \return The first value
          */
-        __device__ const_reference
+        STDGPU_DEVICE_ONLY const_reference
         front() const;
 
         /**
          * \brief Reads the last value
          * \return The last value
          */
-        __device__ reference
+        STDGPU_DEVICE_ONLY reference
         back();
 
         /**
          * \brief Reads the last value
          * \return The last value
          */
-        __device__ const_reference
+        STDGPU_DEVICE_ONLY const_reference
         back() const;
 
         /**
@@ -148,7 +148,7 @@ class deque
          * \return True if not full, false otherwise
          */
         template <class... Args>
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         emplace_back(Args&&... args);
 
         /**
@@ -156,14 +156,14 @@ class deque
          * \param[in] element An element
          * \return True if not full, false otherwise
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         push_back(const T& element);
 
         /**
          * \brief Removes and returns the current element from end of the object
          * \return The currently popped element and true if not empty, an empty element T() and false otherwise
          */
-        __device__ thrust::pair<T, bool>
+        STDGPU_DEVICE_ONLY thrust::pair<T, bool>
         pop_back();
 
         /**
@@ -172,7 +172,7 @@ class deque
          * \return True if not full, false otherwise
          */
         template <class... Args>
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         emplace_front(Args&&... args);
 
         /**
@@ -180,14 +180,14 @@ class deque
          * \param[in] element An element
          * \return True if not full, false otherwise
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         push_front(const T& element);
 
         /**
          * \brief Removes and returns the current element from front of the object
          * \return The currently popped element and true if not empty, an empty element T() and false otherwise
          */
-        __device__ thrust::pair<T, bool>
+        STDGPU_DEVICE_ONLY thrust::pair<T, bool>
         pop_front();
 
         /**
@@ -269,7 +269,7 @@ class deque
 
     private:
 
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         occupied(const index_t n) const;
 
         bool

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -83,7 +83,7 @@ atomic<T>::store(const T desired)
 
 
 template <typename T>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::exchange(const T desired)
 {
     return _value_ref.exchange(desired);
@@ -92,7 +92,7 @@ atomic<T>::exchange(const T desired)
 
 
 template <typename T>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 atomic<T>::compare_exchange_weak(T& expected,
                                  const T desired)
 {
@@ -101,7 +101,7 @@ atomic<T>::compare_exchange_weak(T& expected,
 
 
 template <typename T>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 atomic<T>::compare_exchange_strong(T& expected,
                                    const T desired)
 {
@@ -111,7 +111,7 @@ atomic<T>::compare_exchange_strong(T& expected,
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_add(const T arg)
 {
     return _value_ref.fetch_add(arg);
@@ -120,7 +120,7 @@ atomic<T>::fetch_add(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_sub(const T arg)
 {
     return _value_ref.fetch_sub(arg);
@@ -129,7 +129,7 @@ atomic<T>::fetch_sub(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_and(const T arg)
 {
     return _value_ref.fetch_and(arg);
@@ -138,7 +138,7 @@ atomic<T>::fetch_and(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_or(const T arg)
 {
     return _value_ref.fetch_or(arg);
@@ -147,7 +147,7 @@ atomic<T>::fetch_or(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_xor(const T arg)
 {
     return _value_ref.fetch_xor(arg);
@@ -156,7 +156,7 @@ atomic<T>::fetch_xor(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_min(const T arg)
 {
     return _value_ref.fetch_min(arg);
@@ -165,7 +165,7 @@ atomic<T>::fetch_min(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_max(const T arg)
 {
     return _value_ref.fetch_max(arg);
@@ -174,7 +174,7 @@ atomic<T>::fetch_max(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_inc_mod(const T arg)
 {
     return _value_ref.fetch_inc_mod(arg);
@@ -183,7 +183,7 @@ atomic<T>::fetch_inc_mod(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_dec_mod(const T arg)
 {
     return _value_ref.fetch_dec_mod(arg);
@@ -192,7 +192,7 @@ atomic<T>::fetch_dec_mod(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator++()
 {
     return ++_value_ref;
@@ -201,7 +201,7 @@ atomic<T>::operator++()
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator++(int)
 {
     return _value_ref++;
@@ -210,7 +210,7 @@ atomic<T>::operator++(int)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator--()
 {
     return --_value_ref;
@@ -219,7 +219,7 @@ atomic<T>::operator--()
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator--(int)
 {
     return _value_ref--;
@@ -228,7 +228,7 @@ atomic<T>::operator--(int)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator+=(const T arg)
 {
     return _value_ref += arg;
@@ -237,7 +237,7 @@ atomic<T>::operator+=(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator-=(const T arg)
 {
     return _value_ref -= arg;
@@ -246,7 +246,7 @@ atomic<T>::operator-=(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator&=(const T arg)
 {
     return _value_ref &= arg;
@@ -255,7 +255,7 @@ atomic<T>::operator&=(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator|=(const T arg)
 {
     return _value_ref |= arg;
@@ -264,7 +264,7 @@ atomic<T>::operator|=(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator^=(const T arg)
 {
     return _value_ref ^= arg;
@@ -320,7 +320,7 @@ atomic_ref<T>::store(const T desired)
 
 
 template <typename T>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::exchange(const T desired)
 {
     return stdgpu::cuda::atomic_exchange(_value, desired);
@@ -329,7 +329,7 @@ atomic_ref<T>::exchange(const T desired)
 
 
 template <typename T>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 atomic_ref<T>::compare_exchange_weak(T& expected,
                                      const T desired)
 {
@@ -338,7 +338,7 @@ atomic_ref<T>::compare_exchange_weak(T& expected,
 
 
 template <typename T>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 atomic_ref<T>::compare_exchange_strong(T& expected,
                                        const T desired)
 {
@@ -348,7 +348,7 @@ atomic_ref<T>::compare_exchange_strong(T& expected,
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_add(const T arg)
 {
     return stdgpu::cuda::atomic_fetch_add(_value, arg);
@@ -357,7 +357,7 @@ atomic_ref<T>::fetch_add(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_sub(const T arg)
 {
     return stdgpu::cuda::atomic_fetch_sub(_value, arg);
@@ -366,7 +366,7 @@ atomic_ref<T>::fetch_sub(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_and(const T arg)
 {
     return stdgpu::cuda::atomic_fetch_and(_value, arg);
@@ -375,7 +375,7 @@ atomic_ref<T>::fetch_and(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_or(const T arg)
 {
     return stdgpu::cuda::atomic_fetch_or(_value, arg);
@@ -384,7 +384,7 @@ atomic_ref<T>::fetch_or(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_xor(const T arg)
 {
     return stdgpu::cuda::atomic_fetch_xor(_value, arg);
@@ -393,7 +393,7 @@ atomic_ref<T>::fetch_xor(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_min(const T arg)
 {
     return stdgpu::cuda::atomic_fetch_min(_value, arg);
@@ -402,7 +402,7 @@ atomic_ref<T>::fetch_min(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_max(const T arg)
 {
     return stdgpu::cuda::atomic_fetch_max(_value, arg);
@@ -411,7 +411,7 @@ atomic_ref<T>::fetch_max(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_inc_mod(const T arg)
 {
     return stdgpu::cuda::atomic_fetch_inc_mod(_value, arg - 1);
@@ -420,7 +420,7 @@ atomic_ref<T>::fetch_inc_mod(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_dec_mod(const T arg)
 {
     return stdgpu::cuda::atomic_fetch_dec_mod(_value, arg - 1);
@@ -429,7 +429,7 @@ atomic_ref<T>::fetch_dec_mod(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator++()
 {
     return fetch_add(1) + 1;
@@ -438,7 +438,7 @@ atomic_ref<T>::operator++()
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator++(int)
 {
     return fetch_add(1);
@@ -447,7 +447,7 @@ atomic_ref<T>::operator++(int)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator--()
 {
     return fetch_sub(1) - 1;
@@ -456,7 +456,7 @@ atomic_ref<T>::operator--()
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator--(int)
 {
     return fetch_sub(1);
@@ -465,7 +465,7 @@ atomic_ref<T>::operator--(int)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator+=(const T arg)
 {
     return fetch_add(arg) + arg;
@@ -474,7 +474,7 @@ atomic_ref<T>::operator+=(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator-=(const T arg)
 {
     return fetch_sub(arg) - arg;
@@ -483,7 +483,7 @@ atomic_ref<T>::operator-=(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator&=(const T arg)
 {
     return fetch_and(arg) & arg;
@@ -492,7 +492,7 @@ atomic_ref<T>::operator&=(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator|=(const T arg)
 {
     return fetch_or(arg) | arg;
@@ -501,7 +501,7 @@ atomic_ref<T>::operator|=(const T arg)
 
 template <typename T>
 template <typename, typename>
-inline __device__ T
+inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator^=(const T arg)
 {
     return fetch_xor(arg) ^ arg;

--- a/src/stdgpu/impl/bitset.cu
+++ b/src/stdgpu/impl/bitset.cu
@@ -59,7 +59,7 @@ struct set_bits
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const index_t i)
     {
         bits.set(i, value);
@@ -76,7 +76,7 @@ struct flip_bits
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const index_t i)
     {
         bits.flip(i);

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -26,7 +26,7 @@
 namespace stdgpu
 {
 
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 bitset::set(const index_t n,
             const bool value)
 {
@@ -55,7 +55,7 @@ bitset::set(const index_t n,
 }
 
 
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 bitset::reset(const index_t n)
 {
     STDGPU_EXPECTS(0 <= n);
@@ -65,7 +65,7 @@ bitset::reset(const index_t n)
 }
 
 
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 bitset::flip(const index_t n)
 {
     STDGPU_EXPECTS(0 <= n);
@@ -84,7 +84,7 @@ bitset::flip(const index_t n)
 }
 
 
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 bitset::operator[](const index_t n) const
 {
     STDGPU_EXPECTS(0 <= n);

--- a/src/stdgpu/impl/cuda/atomic.cuh
+++ b/src/stdgpu/impl/cuda/atomic.cuh
@@ -33,7 +33,7 @@ namespace cuda
  * \return The old value
  */
 template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired);
 
@@ -44,7 +44,7 @@ atomic_exchange(T* address,
  * \return The old value
  */
 template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address,
                         const T expected,
                         const T desired);
@@ -55,7 +55,7 @@ atomic_compare_exchange(T* address,
  * \return The old value
  */
 template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg);
 
@@ -65,7 +65,7 @@ atomic_fetch_add(T* address,
  * \return The old value
  */
 template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg);
 
@@ -75,7 +75,7 @@ atomic_fetch_sub(T* address,
  * \return The old value
  */
 template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg);
 
@@ -85,7 +85,7 @@ atomic_fetch_and(T* address,
  * \return The old value
  */
 template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg);
 
@@ -95,7 +95,7 @@ atomic_fetch_or(T* address,
  * \return The old value
  */
 template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg);
 
@@ -105,7 +105,7 @@ atomic_fetch_xor(T* address,
  * \return The old value
  */
 template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg);
 
@@ -115,7 +115,7 @@ atomic_fetch_min(T* address,
  * \return The old value
  */
 template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg);
 
@@ -125,7 +125,7 @@ atomic_fetch_max(T* address,
  * \return The old value
  */
 template <typename T, typename = std::enable_if_t<std::is_same<T, unsigned int>::value>>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg);
 
@@ -135,7 +135,7 @@ atomic_fetch_inc_mod(T* address,
  * \return The old value
  */
 template <typename T, typename = std::enable_if_t<std::is_same<T, unsigned int>::value>>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg);
 
@@ -151,7 +151,7 @@ atomic_fetch_dec_mod(T* address,
  * \param[in] value A value
  * \return The old value at the given address
  */
-__device__ unsigned long long int
+STDGPU_DEVICE_ONLY unsigned long long int
 atomicSub(unsigned long long int* address,
           const unsigned long long int value);
 
@@ -161,7 +161,7 @@ atomicSub(unsigned long long int* address,
  * \param[in] value A value
  * \return The old value at the given address
  */
-__device__ float
+STDGPU_DEVICE_ONLY float
 atomicSub(float* address,
           const float value);
 
@@ -172,7 +172,7 @@ atomicSub(float* address,
  * \param[in] value A value
  * \return The old value at the given address
  */
-__device__ float
+STDGPU_DEVICE_ONLY float
 atomicMin(float* address,
           const float value);
 
@@ -183,7 +183,7 @@ atomicMin(float* address,
  * \param[in] value A value
  * \return The old value at the given address
  */
-__device__ float
+STDGPU_DEVICE_ONLY float
 atomicMax(float* address,
           const float value);
 

--- a/src/stdgpu/impl/cuda/atomic_detail.cuh
+++ b/src/stdgpu/impl/cuda/atomic_detail.cuh
@@ -29,7 +29,7 @@ namespace cuda
 {
 
 template <typename T, typename>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired)
 {
@@ -38,7 +38,7 @@ atomic_exchange(T* address,
 
 
 template <typename T, typename>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address,
                         const T expected,
                         const T desired)
@@ -48,7 +48,7 @@ atomic_compare_exchange(T* address,
 
 
 template <typename T, typename>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg)
 {
@@ -57,7 +57,7 @@ atomic_fetch_add(T* address,
 
 
 template <typename T, typename>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg)
 {
@@ -66,7 +66,7 @@ atomic_fetch_sub(T* address,
 
 
 template <typename T, typename>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg)
 {
@@ -75,7 +75,7 @@ atomic_fetch_and(T* address,
 
 
 template <typename T, typename>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg)
 {
@@ -84,7 +84,7 @@ atomic_fetch_or(T* address,
 
 
 template <typename T, typename>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg)
 {
@@ -93,7 +93,7 @@ atomic_fetch_xor(T* address,
 
 
 template <typename T, typename>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg)
 {
@@ -102,7 +102,7 @@ atomic_fetch_min(T* address,
 
 
 template <typename T, typename>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg)
 {
@@ -111,7 +111,7 @@ atomic_fetch_max(T* address,
 
 
 template <typename T, typename>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg)
 {
@@ -120,7 +120,7 @@ atomic_fetch_inc_mod(T* address,
 
 
 template <typename T, typename>
-__device__ T
+STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg)
 {
@@ -132,7 +132,7 @@ atomic_fetch_dec_mod(T* address,
 } // namespace stdgpu
 
 
-inline __device__ unsigned long long int
+inline STDGPU_DEVICE_ONLY unsigned long long int
 atomicSub(unsigned long long int* address,
           const unsigned long long int value)
 {
@@ -140,7 +140,7 @@ atomicSub(unsigned long long int* address,
 }
 
 
-inline __device__ float
+inline STDGPU_DEVICE_ONLY float
 atomicSub(float* address,
           const float value)
 {
@@ -148,7 +148,7 @@ atomicSub(float* address,
 }
 
 
-inline __device__ float
+inline STDGPU_DEVICE_ONLY float
 atomicMin(float* address,
           const float value)
 {
@@ -168,7 +168,7 @@ atomicMin(float* address,
 }
 
 
-inline __device__ float
+inline STDGPU_DEVICE_ONLY float
 atomicMax(float* address,
           const float value)
 {

--- a/src/stdgpu/impl/cuda/bit.cuh
+++ b/src/stdgpu/impl/cuda/bit.cuh
@@ -29,7 +29,7 @@ namespace cuda
  * \param[in] number A number
  * \return The base-2 logarithm of the number
  */
-__device__ unsigned int
+STDGPU_DEVICE_ONLY unsigned int
 log2pow2(const unsigned int number);
 
 
@@ -39,7 +39,7 @@ log2pow2(const unsigned int number);
  * \return The base-2 logarithm of the number
  * \pre ispow2(divider)
  */
-__device__ unsigned long long int
+STDGPU_DEVICE_ONLY unsigned long long int
 log2pow2(const unsigned long long int number);
 
 
@@ -48,7 +48,7 @@ log2pow2(const unsigned long long int number);
  * \param[in] number A number
  * \return The number of set bits
  */
-__device__ int
+STDGPU_DEVICE_ONLY int
 popcount(const unsigned int number);
 
 
@@ -57,7 +57,7 @@ popcount(const unsigned int number);
  * \param[in] number A number
  * \return The number of set bits
  */
-__device__ int
+STDGPU_DEVICE_ONLY int
 popcount(const unsigned long long int number);
 
 } // namespace cuda

--- a/src/stdgpu/impl/cuda/bit_detail.cuh
+++ b/src/stdgpu/impl/cuda/bit_detail.cuh
@@ -24,28 +24,28 @@ namespace stdgpu
 namespace cuda
 {
 
-inline __device__ unsigned int
+inline STDGPU_DEVICE_ONLY unsigned int
 log2pow2(const unsigned int number)
 {
     return __ffs(number) - 1;
 }
 
 
-inline __device__ unsigned long long int
+inline STDGPU_DEVICE_ONLY unsigned long long int
 log2pow2(const unsigned long long int number)
 {
     return __ffsll(number) - 1;
 }
 
 
-inline __device__ int
+inline STDGPU_DEVICE_ONLY int
 popcount(const unsigned int number)
 {
     return __popc(number);
 }
 
 
-inline __device__ int
+inline STDGPU_DEVICE_ONLY int
 popcount(const unsigned long long int number)
 {
     return __popcll(number);

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -67,7 +67,7 @@ deque<T>::destroyDeviceObject(deque<T>& device_object)
 
 
 template <typename T>
-inline __device__ deque<T>::reference
+inline STDGPU_DEVICE_ONLY deque<T>::reference
 deque<T>::operator[](const deque<T>::index_type n)
 {
     return const_cast<reference>(static_cast<const deque<T>*>(this)->operator[](n));
@@ -75,7 +75,7 @@ deque<T>::operator[](const deque<T>::index_type n)
 
 
 template <typename T>
-inline __device__ deque<T>::const_reference
+inline STDGPU_DEVICE_ONLY deque<T>::const_reference
 deque<T>::operator[](const deque<T>::index_type n) const
 {
     STDGPU_EXPECTS(0 <= n);
@@ -91,7 +91,7 @@ deque<T>::operator[](const deque<T>::index_type n) const
 
 
 template <typename T>
-inline __device__ deque<T>::reference
+inline STDGPU_DEVICE_ONLY deque<T>::reference
 deque<T>::front()
 {
     return const_cast<reference>(static_cast<const deque<T>*>(this)->front());
@@ -99,7 +99,7 @@ deque<T>::front()
 
 
 template <typename T>
-inline __device__ deque<T>::const_reference
+inline STDGPU_DEVICE_ONLY deque<T>::const_reference
 deque<T>::front() const
 {
     return operator[](0);
@@ -107,7 +107,7 @@ deque<T>::front() const
 
 
 template <typename T>
-inline __device__ deque<T>::reference
+inline STDGPU_DEVICE_ONLY deque<T>::reference
 deque<T>::back()
 {
     return const_cast<reference>(static_cast<const deque<T>*>(this)->back());
@@ -115,7 +115,7 @@ deque<T>::back()
 
 
 template <typename T>
-inline __device__ deque<T>::const_reference
+inline STDGPU_DEVICE_ONLY deque<T>::const_reference
 deque<T>::back() const
 {
     return operator[](size() - 1);
@@ -124,7 +124,7 @@ deque<T>::back() const
 
 template <typename T>
 template <class... Args>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 deque<T>::emplace_back(Args&&... args)
 {
     return push_back(T(forward<Args>(args)...));
@@ -132,7 +132,7 @@ deque<T>::emplace_back(Args&&... args)
 
 
 template <typename T>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 deque<T>::push_back(const T& element)
 {
     bool pushed = false;
@@ -185,7 +185,7 @@ deque<T>::push_back(const T& element)
 
 
 template <typename T>
-inline __device__ thrust::pair<T, bool>
+inline STDGPU_DEVICE_ONLY thrust::pair<T, bool>
 deque<T>::pop_back()
 {
     thrust::pair<T, bool> popped = thrust::make_pair(T(), false);
@@ -241,7 +241,7 @@ deque<T>::pop_back()
 
 template <typename T>
 template <class... Args>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 deque<T>::emplace_front(Args&&... args)
 {
     return push_front(T(forward<Args>(args)...));
@@ -249,7 +249,7 @@ deque<T>::emplace_front(Args&&... args)
 
 
 template <typename T>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 deque<T>::push_front(const T& element)
 {
     bool pushed = false;
@@ -303,7 +303,7 @@ deque<T>::push_front(const T& element)
 
 
 template <typename T>
-inline __device__ thrust::pair<T, bool>
+inline STDGPU_DEVICE_ONLY thrust::pair<T, bool>
 deque<T>::pop_front()
 {
     thrust::pair<T, bool> popped = thrust::make_pair(T(), false);
@@ -474,7 +474,7 @@ struct deque_collect_positions
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const index_t i)
     {
         if (d.occupied(i))
@@ -514,7 +514,7 @@ deque<T>::device_range() const
 
 
 template <typename T>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 deque<T>::occupied(const index_t n) const
 {
     return _occupied[n];

--- a/src/stdgpu/impl/mutex.cu
+++ b/src/stdgpu/impl/mutex.cu
@@ -55,7 +55,7 @@ struct unlocked
 
     }
 
-    __device__ bool
+    STDGPU_DEVICE_ONLY bool
     operator()(const index_t i) const
     {
         return !(lock_bits[i].locked());

--- a/src/stdgpu/impl/mutex_detail.cuh
+++ b/src/stdgpu/impl/mutex_detail.cuh
@@ -33,7 +33,7 @@ mutex_ref::mutex_ref(bitset lock_bits,
 }
 
 
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 mutex_ref::try_lock()
 {
     // Change state to LOCKED
@@ -42,7 +42,7 @@ mutex_ref::try_lock()
 }
 
 
-inline __device__ void
+inline STDGPU_DEVICE_ONLY void
 mutex_ref::unlock()
 {
     // Change state back to UNLOCKED
@@ -50,7 +50,7 @@ mutex_ref::unlock()
 }
 
 
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 mutex_ref::locked() const
 {
     return _lock_bits[_n];
@@ -58,7 +58,7 @@ mutex_ref::locked() const
 
 
 
-inline __device__ mutex_ref
+inline STDGPU_DEVICE_ONLY mutex_ref
 mutex_array::operator[](const index_t n)
 {
     STDGPU_EXPECTS(0 <= n);
@@ -68,7 +68,7 @@ mutex_array::operator[](const index_t n)
 }
 
 
-inline __device__ const mutex_ref
+inline STDGPU_DEVICE_ONLY const mutex_ref
 mutex_array::operator[](const index_t n) const
 {
     STDGPU_EXPECTS(0 <= n);
@@ -97,7 +97,7 @@ namespace detail
 {
 
 template <typename Lockable1>
-inline __device__ int
+inline STDGPU_DEVICE_ONLY int
 try_lock(int i,
          Lockable1 lock1)
 {
@@ -105,7 +105,7 @@ try_lock(int i,
 }
 
 template <typename Lockable1, typename... LockableN>
-inline __device__ int
+inline STDGPU_DEVICE_ONLY int
 try_lock(int i,
          Lockable1 lock1,
          LockableN... lockn)
@@ -131,7 +131,7 @@ try_lock(int i,
 
 
 template <typename Lockable1, typename Lockable2, typename... LockableN>
-inline __device__ int
+inline STDGPU_DEVICE_ONLY int
 try_lock(Lockable1 lock1,
                  Lockable2 lock2,
                  LockableN... lockn)

--- a/src/stdgpu/impl/queue_detail.cuh
+++ b/src/stdgpu/impl/queue_detail.cuh
@@ -45,7 +45,7 @@ queue<T, ContainerT>::destroyDeviceObject(queue<T, ContainerT>& device_object)
 
 template <typename T,
           typename ContainerT>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 queue<T, ContainerT>::push(const T& element)
 {
     return _c.push_back(element);
@@ -54,7 +54,7 @@ queue<T, ContainerT>::push(const T& element)
 
 template <typename T,
           typename ContainerT>
-inline __device__ thrust::pair<T, bool>
+inline STDGPU_DEVICE_ONLY thrust::pair<T, bool>
 queue<T, ContainerT>::pop()
 {
     return _c.pop_front();

--- a/src/stdgpu/impl/stack_detail.cuh
+++ b/src/stdgpu/impl/stack_detail.cuh
@@ -45,7 +45,7 @@ stack<T, ContainerT>::destroyDeviceObject(stack<T, ContainerT>& device_object)
 
 template <typename T,
           typename ContainerT>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 stack<T, ContainerT>::push(const T& element)
 {
     return _c.push_back(element);
@@ -54,7 +54,7 @@ stack<T, ContainerT>::push(const T& element)
 
 template <typename T,
           typename ContainerT>
-inline __device__ thrust::pair<T, bool>
+inline STDGPU_DEVICE_ONLY thrust::pair<T, bool>
 stack<T, ContainerT>::pop()
 {
     return _c.pop_back();

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -110,42 +110,42 @@ class unordered_base
          * \brief An iterator to the begin of the internal value array
          * \return An iterator to the begin of the object
          */
-        __device__ iterator
+        STDGPU_DEVICE_ONLY iterator
         begin();
 
         /**
          * \brief An iterator to the begin of the internal value array
          * \return A const iterator to the begin of the object
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         begin() const;
 
         /**
          * \brief An iterator to the begin of the internal value array
          * \return A const iterator to the begin of the object
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         cbegin() const;
 
         /**
          * \brief An iterator to the end of the internal value array
          * \return An iterator to the end of the object
          */
-        __device__ iterator
+        STDGPU_DEVICE_ONLY iterator
         end();
 
         /**
          * \brief An iterator to the end of the internal value array
          * \return A const iterator to the end of the object
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         end() const;
 
         /**
          * \brief An iterator to the end of the internal value array
          * \return A const iterator to the end of the object
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         cend() const;
 
 
@@ -172,7 +172,7 @@ class unordered_base
          * \param[in] n The bucket index
          * \return The number of elements in the requested bucket
          */
-        __device__ index_type
+        STDGPU_DEVICE_ONLY index_type
         bucket_size(index_type n) const;
 
 
@@ -181,7 +181,7 @@ class unordered_base
          * \param[in] key The key
          * \return The number of elements with the given key, i.e. 1 or 0
          */
-        __device__ index_type
+        STDGPU_DEVICE_ONLY index_type
         count(const key_type& key) const;
 
 
@@ -190,7 +190,7 @@ class unordered_base
          * \param[in] key The key
          * \return An iterator to the position of the requested key if it was found, end() otherwise
          */
-        __device__ iterator
+        STDGPU_DEVICE_ONLY iterator
         find(const key_type& key);
 
         /**
@@ -198,7 +198,7 @@ class unordered_base
          * \param[in] key The key
          * \return An iterator to the position of the requested key if it was found, end() otherwise
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         find(const key_type& key) const;
 
 
@@ -207,7 +207,7 @@ class unordered_base
          * \param[in] key The key
          * \return True if the requested key was found, false otherwise
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         contains(const key_type& key) const;
 
 
@@ -216,7 +216,7 @@ class unordered_base
          * \param[in] value The new value
          * \return An iterator to the inserted pair and true if the insertion was successful, end() and false otherwise
          */
-        __device__ thrust::pair<iterator, bool>
+        STDGPU_DEVICE_ONLY thrust::pair<iterator, bool>
         try_insert(const value_type& value);
 
 
@@ -225,7 +225,7 @@ class unordered_base
          * \param[in] key The key
          * \return 1 if there was a value with key and it got erased, 0 otherwise
          */
-        __device__ index_type
+        STDGPU_DEVICE_ONLY index_type
         try_erase(const key_type& key);
 
 
@@ -235,7 +235,7 @@ class unordered_base
          * \return An iterator to the inserted pair and true if the insertion was successful, end() and false otherwise
          */
         template <class... Args>
-        __device__ thrust::pair<iterator, bool>
+        STDGPU_DEVICE_ONLY thrust::pair<iterator, bool>
         emplace(Args&&... args);
 
 
@@ -244,7 +244,7 @@ class unordered_base
          * \param[in] value The new value
          * \return An iterator to the inserted pair and true if the insertion was successful, end() and false otherwise
          */
-        __device__ thrust::pair<iterator, bool>
+        STDGPU_DEVICE_ONLY thrust::pair<iterator, bool>
         insert(const value_type& value);
 
 
@@ -273,7 +273,7 @@ class unordered_base
          * \param[in] key The key
          * \return 1 if there was a value with key and it got erased, 0 otherwise
          */
-        __device__ index_type
+        STDGPU_DEVICE_ONLY index_type
         erase(const key_type& key);
 
 
@@ -393,13 +393,13 @@ class unordered_base
         mutable vector<index_t> _range_indices = {};        /**< The buffer of range indices */
 
 
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         occupied(const index_t n) const;
 
-        __device__ index_t
+        STDGPU_DEVICE_ONLY index_t
         find_linked_list_end(const index_t linked_list_start);
 
-        __device__ index_t
+        STDGPU_DEVICE_ONLY index_t
         find_previous_entry_position(const index_t entry_position,
                                      const index_t linked_list_start);
 };

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -40,7 +40,7 @@ namespace detail
 {
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::begin()
 {
     return _values;
@@ -48,7 +48,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::begin()
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::begin() const
 {
     return _values;
@@ -56,7 +56,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::begin() const
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::cbegin() const
 {
     return begin();
@@ -64,7 +64,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::cbegin() const
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::end()
 {
     return _values + total_count();
@@ -72,7 +72,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::end()
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::end() const
 {
     return _values + total_count();
@@ -80,7 +80,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::end() const
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::cend() const
 {
     return end();
@@ -98,7 +98,7 @@ struct unordered_base_collect_positions
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const index_t i)
     {
         if (base.occupied(i))
@@ -170,7 +170,7 @@ struct count_visits
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const index_t i)
     {
         index_t linked_list = i;
@@ -230,7 +230,7 @@ struct value_reachable
 
     }
 
-    __device__ bool
+    STDGPU_DEVICE_ONLY bool
     operator()(const index_t i) const
     {
         if (base.occupied(i))
@@ -267,7 +267,7 @@ struct values_unique
 
     }
 
-    __device__ bool
+    STDGPU_DEVICE_ONLY bool
     operator()(const index_t i) const
     {
         if (base.occupied(i))
@@ -318,7 +318,7 @@ struct erase_from_key
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const Key& key)
     {
         base.erase(key);
@@ -337,7 +337,7 @@ struct erase_from_value
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const Value& value)
     {
         base.erase(base._key_from_value(value));
@@ -362,7 +362,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::bucket(const key_type&
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ index_t
+inline STDGPU_DEVICE_ONLY index_t
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::bucket_size(index_t n) const
 {
     STDGPU_EXPECTS(n < bucket_count());
@@ -392,7 +392,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::bucket_size(index_t n)
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ index_t
+inline STDGPU_DEVICE_ONLY index_t
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::count(const key_type& key) const
 {
     return contains(key) ? index_t(1) : index_t(0);
@@ -400,7 +400,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::count(const key_type& 
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find(const key_type& key)
 {
     index_t key_index = bucket(key);
@@ -433,7 +433,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find(const key_type& k
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find(const key_type& key) const
 {
     index_t key_index = bucket(key);
@@ -466,7 +466,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find(const key_type& k
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::contains(const key_type& key) const
 {
     return find(key) != end();
@@ -474,7 +474,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::contains(const key_typ
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ thrust::pair<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator, bool>
+inline STDGPU_DEVICE_ONLY thrust::pair<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator, bool>
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_insert(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::value_type& value)
 {
     iterator inserted_it = end();
@@ -571,7 +571,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_insert(const unord
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ index_t
+inline STDGPU_DEVICE_ONLY index_t
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_erase(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::key_type& key)
 {
     bool erased = false;
@@ -672,7 +672,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_erase(const unorde
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ index_t
+inline STDGPU_DEVICE_ONLY index_t
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find_linked_list_end(const index_t linked_list_start)
 {
     index_t linked_list_end = linked_list_start;
@@ -687,7 +687,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find_linked_list_end(c
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ index_t
+inline STDGPU_DEVICE_ONLY index_t
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find_previous_entry_position(const index_t entry_position,
                                                                                        const index_t linked_list_start)
 {
@@ -718,7 +718,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find_previous_entry_po
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
 template <class... Args>
-inline __device__ thrust::pair<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator, bool>
+inline STDGPU_DEVICE_ONLY thrust::pair<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator, bool>
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::emplace(Args&&... args)
 {
     return insert(value_type(forward<Args>(args)...));
@@ -726,7 +726,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::emplace(Args&&... args
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ thrust::pair<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator, bool>
+inline STDGPU_DEVICE_ONLY thrust::pair<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator, bool>
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::insert(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::value_type& value)
 {
     thrust::pair<iterator, bool> result = thrust::make_pair(end(), false);
@@ -770,7 +770,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::insert(device_ptr<cons
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ index_t
+inline STDGPU_DEVICE_ONLY index_t
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::erase(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::key_type& key)
 {
     index_t result = 0;
@@ -813,7 +813,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::erase(device_ptr<const
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::occupied(const index_t n) const
 {
     STDGPU_EXPECTS(0 <= n);

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -41,7 +41,7 @@ struct select1st
 } // namespace detail
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline __device__ unordered_map<Key, T, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::iterator
 unordered_map<Key, T, Hash, KeyEqual>::begin()
 {
     return _base.begin();
@@ -49,7 +49,7 @@ unordered_map<Key, T, Hash, KeyEqual>::begin()
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline __device__ unordered_map<Key, T, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::const_iterator
 unordered_map<Key, T, Hash, KeyEqual>::begin() const
 {
     return _base.begin();
@@ -57,7 +57,7 @@ unordered_map<Key, T, Hash, KeyEqual>::begin() const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline __device__ unordered_map<Key, T, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::const_iterator
 unordered_map<Key, T, Hash, KeyEqual>::cbegin() const
 {
     return _base.begin();
@@ -65,7 +65,7 @@ unordered_map<Key, T, Hash, KeyEqual>::cbegin() const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline __device__ unordered_map<Key, T, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::iterator
 unordered_map<Key, T, Hash, KeyEqual>::end()
 {
     return _base.end();
@@ -73,7 +73,7 @@ unordered_map<Key, T, Hash, KeyEqual>::end()
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline __device__ unordered_map<Key, T, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::const_iterator
 unordered_map<Key, T, Hash, KeyEqual>::end() const
 {
     return _base.end();
@@ -81,7 +81,7 @@ unordered_map<Key, T, Hash, KeyEqual>::end() const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline __device__ unordered_map<Key, T, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::const_iterator
 unordered_map<Key, T, Hash, KeyEqual>::cend() const
 {
     return _base.end();
@@ -105,7 +105,7 @@ unordered_map<Key, T, Hash, KeyEqual>::bucket(const key_type& key) const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline __device__ unordered_map<Key, T, Hash, KeyEqual>::index_type
+inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::index_type
 unordered_map<Key, T, Hash, KeyEqual>::bucket_size(index_type n) const
 {
     return _base.bucket_size(n);
@@ -113,7 +113,7 @@ unordered_map<Key, T, Hash, KeyEqual>::bucket_size(index_type n) const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline __device__ unordered_map<Key, T, Hash, KeyEqual>::index_type
+inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::index_type
 unordered_map<Key, T, Hash, KeyEqual>::count(const key_type& key) const
 {
     return _base.count(key);
@@ -121,7 +121,7 @@ unordered_map<Key, T, Hash, KeyEqual>::count(const key_type& key) const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline __device__ unordered_map<Key, T, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::iterator
 unordered_map<Key, T, Hash, KeyEqual>::find(const key_type& key)
 {
     return _base.find(key);
@@ -129,7 +129,7 @@ unordered_map<Key, T, Hash, KeyEqual>::find(const key_type& key)
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline __device__ unordered_map<Key, T, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::const_iterator
 unordered_map<Key, T, Hash, KeyEqual>::find(const key_type& key) const
 {
     return _base.find(key);
@@ -137,7 +137,7 @@ unordered_map<Key, T, Hash, KeyEqual>::find(const key_type& key) const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 unordered_map<Key, T, Hash, KeyEqual>::contains(const key_type& key) const
 {
     return _base.contains(key);
@@ -146,7 +146,7 @@ unordered_map<Key, T, Hash, KeyEqual>::contains(const key_type& key) const
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
 template <class... Args>
-inline __device__ thrust::pair<typename unordered_map<Key, T, Hash, KeyEqual>::iterator, bool>
+inline STDGPU_DEVICE_ONLY thrust::pair<typename unordered_map<Key, T, Hash, KeyEqual>::iterator, bool>
 unordered_map<Key, T, Hash, KeyEqual>::emplace(Args&&... args)
 {
     return _base.emplace(forward<Args>(args)...);
@@ -154,7 +154,7 @@ unordered_map<Key, T, Hash, KeyEqual>::emplace(Args&&... args)
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline __device__ thrust::pair<typename unordered_map<Key, T, Hash, KeyEqual>::iterator, bool>
+inline STDGPU_DEVICE_ONLY thrust::pair<typename unordered_map<Key, T, Hash, KeyEqual>::iterator, bool>
 unordered_map<Key, T, Hash, KeyEqual>::insert(const unordered_map<Key, T, Hash, KeyEqual>::value_type& value)
 {
     return _base.insert(value);
@@ -180,7 +180,7 @@ unordered_map<Key, T, Hash, KeyEqual>::insert(device_ptr<const unordered_map<Key
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline __device__ unordered_map<Key, T, Hash, KeyEqual>::index_type
+inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::index_type
 unordered_map<Key, T, Hash, KeyEqual>::erase(const unordered_map<Key, T, Hash, KeyEqual>::key_type& key)
 {
     return _base.erase(key);

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -26,7 +26,7 @@ namespace stdgpu
 {
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline __device__ unordered_set<Key, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::iterator
 unordered_set<Key, Hash, KeyEqual>::begin()
 {
     return _base.begin();
@@ -34,7 +34,7 @@ unordered_set<Key, Hash, KeyEqual>::begin()
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline __device__ unordered_set<Key, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::const_iterator
 unordered_set<Key, Hash, KeyEqual>::begin() const
 {
     return _base.begin();
@@ -42,7 +42,7 @@ unordered_set<Key, Hash, KeyEqual>::begin() const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline __device__ unordered_set<Key, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::const_iterator
 unordered_set<Key, Hash, KeyEqual>::cbegin() const
 {
     return _base.begin();
@@ -50,7 +50,7 @@ unordered_set<Key, Hash, KeyEqual>::cbegin() const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline __device__ unordered_set<Key, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::iterator
 unordered_set<Key, Hash, KeyEqual>::end()
 {
     return _base.end();
@@ -58,7 +58,7 @@ unordered_set<Key, Hash, KeyEqual>::end()
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline __device__ unordered_set<Key, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::const_iterator
 unordered_set<Key, Hash, KeyEqual>::end() const
 {
     return _base.end();
@@ -66,7 +66,7 @@ unordered_set<Key, Hash, KeyEqual>::end() const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline __device__ unordered_set<Key, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::const_iterator
 unordered_set<Key, Hash, KeyEqual>::cend() const
 {
     return _base.end();
@@ -90,7 +90,7 @@ unordered_set<Key, Hash, KeyEqual>::bucket(const key_type& key) const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline __device__ unordered_set<Key, Hash, KeyEqual>::index_type
+inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::index_type
 unordered_set<Key, Hash, KeyEqual>::bucket_size(index_type n) const
 {
     return _base.bucket_size(n);
@@ -98,7 +98,7 @@ unordered_set<Key, Hash, KeyEqual>::bucket_size(index_type n) const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline __device__ unordered_set<Key, Hash, KeyEqual>::index_type
+inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::index_type
 unordered_set<Key, Hash, KeyEqual>::count(const key_type& key) const
 {
     return _base.count(key);
@@ -106,7 +106,7 @@ unordered_set<Key, Hash, KeyEqual>::count(const key_type& key) const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline __device__ unordered_set<Key, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::iterator
 unordered_set<Key, Hash, KeyEqual>::find(const key_type& key)
 {
     return _base.find(key);
@@ -114,7 +114,7 @@ unordered_set<Key, Hash, KeyEqual>::find(const key_type& key)
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline __device__ unordered_set<Key, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::const_iterator
 unordered_set<Key, Hash, KeyEqual>::find(const key_type& key) const
 {
     return _base.find(key);
@@ -122,7 +122,7 @@ unordered_set<Key, Hash, KeyEqual>::find(const key_type& key) const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 unordered_set<Key, Hash, KeyEqual>::contains(const key_type& key) const
 {
     return _base.contains(key);
@@ -131,7 +131,7 @@ unordered_set<Key, Hash, KeyEqual>::contains(const key_type& key) const
 
 template <typename Key, typename Hash, typename KeyEqual>
 template <class... Args>
-inline __device__ thrust::pair<typename unordered_set<Key, Hash, KeyEqual>::iterator, bool>
+inline STDGPU_DEVICE_ONLY thrust::pair<typename unordered_set<Key, Hash, KeyEqual>::iterator, bool>
 unordered_set<Key, Hash, KeyEqual>::emplace(Args&&... args)
 {
     return _base.emplace(forward<Args>(args)...);
@@ -139,7 +139,7 @@ unordered_set<Key, Hash, KeyEqual>::emplace(Args&&... args)
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline __device__ thrust::pair<typename unordered_set<Key, Hash, KeyEqual>::iterator, bool>
+inline STDGPU_DEVICE_ONLY thrust::pair<typename unordered_set<Key, Hash, KeyEqual>::iterator, bool>
 unordered_set<Key, Hash, KeyEqual>::insert(const unordered_set<Key, Hash, KeyEqual>::value_type& value)
 {
     return _base.insert(value);
@@ -165,7 +165,7 @@ unordered_set<Key, Hash, KeyEqual>::insert(device_ptr<const unordered_set<Key, H
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline __device__ unordered_set<Key, Hash, KeyEqual>::index_type
+inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::index_type
 unordered_set<Key, Hash, KeyEqual>::erase(const unordered_set<Key, Hash, KeyEqual>::key_type& key)
 {
     return _base.erase(key);

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -57,7 +57,7 @@ vector<T>::destroyDeviceObject(vector<T>& device_object)
 
 
 template <typename T>
-inline __device__ vector<T>::reference
+inline STDGPU_DEVICE_ONLY vector<T>::reference
 vector<T>::operator[](const vector<T>::index_type n)
 {
     return const_cast<vector<T>::reference>(static_cast<const vector<T>*>(this)->operator[](n));
@@ -65,7 +65,7 @@ vector<T>::operator[](const vector<T>::index_type n)
 
 
 template <typename T>
-inline __device__ vector<T>::const_reference
+inline STDGPU_DEVICE_ONLY vector<T>::const_reference
 vector<T>::operator[](const vector<T>::index_type n) const
 {
     STDGPU_EXPECTS(0 <= n);
@@ -77,7 +77,7 @@ vector<T>::operator[](const vector<T>::index_type n) const
 
 
 template <typename T>
-inline __device__ vector<T>::reference
+inline STDGPU_DEVICE_ONLY vector<T>::reference
 vector<T>::front()
 {
     return const_cast<reference>(static_cast<const vector<T>*>(this)->front());
@@ -85,7 +85,7 @@ vector<T>::front()
 
 
 template <typename T>
-inline __device__ vector<T>::const_reference
+inline STDGPU_DEVICE_ONLY vector<T>::const_reference
 vector<T>::front() const
 {
     return operator[](0);
@@ -93,7 +93,7 @@ vector<T>::front() const
 
 
 template <typename T>
-inline __device__ vector<T>::reference
+inline STDGPU_DEVICE_ONLY vector<T>::reference
 vector<T>::back()
 {
     return const_cast<reference>(static_cast<const vector<T>*>(this)->back());
@@ -101,7 +101,7 @@ vector<T>::back()
 
 
 template <typename T>
-inline __device__ vector<T>::const_reference
+inline STDGPU_DEVICE_ONLY vector<T>::const_reference
 vector<T>::back() const
 {
     return operator[](size() - 1);
@@ -110,7 +110,7 @@ vector<T>::back() const
 
 template <typename T>
 template <class... Args>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 vector<T>::emplace_back(Args&&... args)
 {
     return push_back(T(forward<Args>(args)...));
@@ -118,7 +118,7 @@ vector<T>::emplace_back(Args&&... args)
 
 
 template <typename T>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 vector<T>::push_back(const T& element)
 {
     bool pushed = false;
@@ -169,7 +169,7 @@ vector<T>::push_back(const T& element)
 
 
 template <typename T>
-inline __device__ thrust::pair<T, bool>
+inline STDGPU_DEVICE_ONLY thrust::pair<T, bool>
 vector<T>::pop_back()
 {
     thrust::pair<T, bool> popped = thrust::make_pair(T(), false);
@@ -389,7 +389,7 @@ vector<T>::device_range() const
 
 
 template <typename T>
-inline __device__ bool
+inline STDGPU_DEVICE_ONLY bool
 vector<T>::occupied(const index_t n) const
 {
     STDGPU_EXPECTS(0 <= n);

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -60,20 +60,20 @@ class mutex_ref
          * \brief Tries to lock the mutex
          * \return True if the mutex has been locked, false otherwise
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         try_lock();
 
         /**
          * \brief Unlocks the mutex
          */
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         unlock();
 
         /**
          * \brief Checks whether the mutex is locked
          * \return True if the mutex is locked, false otherwise
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         locked() const;
 
     private:
@@ -126,7 +126,7 @@ class mutex_array
          * \return The n-th mutex
          * \pre 0 <= n < size()
          */
-        __device__ mutex_ref
+        STDGPU_DEVICE_ONLY mutex_ref
         operator[](const index_t n);
 
         /**
@@ -135,7 +135,7 @@ class mutex_array
          * \return The n-th mutex
          * \pre 0 <= n < size()
          */
-        __device__ const mutex_ref
+        STDGPU_DEVICE_ONLY const mutex_ref
         operator[](const index_t n) const;
 
 
@@ -175,7 +175,7 @@ class mutex_array
  * \return -1 if locking was successful, the first position at which locking failed otherwise
  */
 template <typename Lockable1, typename Lockable2, typename... LockableN>
-__device__ int
+STDGPU_DEVICE_ONLY int
 try_lock(Lockable1 lock1,
          Lockable2 lock2,
          LockableN... lockn);

--- a/src/stdgpu/platform.h
+++ b/src/stdgpu/platform.h
@@ -88,6 +88,18 @@ namespace stdgpu
 
 
 /**
+ * \def STDGPU_DEVICE_ONLY
+ * \brief Platform-independent __device__ function annotation
+ */
+#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC
+    #define STDGPU_DEVICE_ONLY __device__
+#else
+    // Should trigger a compact error message containing the error string
+    #define STDGPU_DEVICE_ONLY sizeof("STDGPU ERROR: Wrong compiler detected! Device-only functions must be compiled with the device compiler!")
+#endif
+
+
+/**
  * \def STDGPU_CONSTANT
  * \brief Platform-independent _constant__ variable annotation
  */

--- a/src/stdgpu/queue.cuh
+++ b/src/stdgpu/queue.cuh
@@ -93,14 +93,14 @@ class queue
          * \param[in] element An element
          * \return True if not full, false otherwise
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         push(const T& element);
 
         /**
          * \brief Removes and returns the first element from the queue
          * \return The currently popped element and true if not empty, an empty element T() and false otherwise
          */
-        __device__ thrust::pair<T, bool>
+        STDGPU_DEVICE_ONLY thrust::pair<T, bool>
         pop();
 
         /**

--- a/src/stdgpu/stack.cuh
+++ b/src/stdgpu/stack.cuh
@@ -93,14 +93,14 @@ class stack
          * \param[in] element An element
          * \return True if not full, false otherwise
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         push(const T& element);
 
         /**
          * \brief Removes and returns the current element from stack
          * \return The currently popped element and true if not empty, an empty element T() and false otherwise
          */
-        __device__ thrust::pair<T, bool>
+        STDGPU_DEVICE_ONLY thrust::pair<T, bool>
         pop();
 
         /**

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -133,42 +133,42 @@ class unordered_map
          * \brief An iterator to the begin of the internal value array
          * \return An iterator to the begin of the object
          */
-        __device__ iterator
+        STDGPU_DEVICE_ONLY iterator
         begin();
 
         /**
          * \brief An iterator to the begin of the internal value array
          * \return A const iterator to the begin of the object
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         begin() const;
 
         /**
          * \brief An iterator to the begin of the internal value array
          * \return A const iterator to the begin of the object
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         cbegin() const;
 
         /**
          * \brief An iterator to the end of the internal value array
          * \return An iterator to the end of the object
          */
-        __device__ iterator
+        STDGPU_DEVICE_ONLY iterator
         end();
 
         /**
          * \brief An iterator to the end of the internal value array
          * \return A const iterator to the end of the object
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         end() const;
 
         /**
          * \brief An iterator to the end of the internal value array
          * \return A const iterator to the end of the object
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         cend() const;
 
 
@@ -195,7 +195,7 @@ class unordered_map
          * \param[in] n The bucket index
          * \return The number of elements in the requested bucket
          */
-        __device__ index_type
+        STDGPU_DEVICE_ONLY index_type
         bucket_size(index_type n) const;
 
 
@@ -204,7 +204,7 @@ class unordered_map
          * \param[in] key The key
          * \return The number of elements with the given key, i.e. 1 or 0
          */
-        __device__ index_type
+        STDGPU_DEVICE_ONLY index_type
         count(const key_type& key) const;
 
 
@@ -213,7 +213,7 @@ class unordered_map
          * \param[in] key The key
          * \return An iterator to the position of the requested key if it was found, end() otherwise
          */
-        __device__ iterator
+        STDGPU_DEVICE_ONLY iterator
         find(const key_type& key);
 
         /**
@@ -221,7 +221,7 @@ class unordered_map
          * \param[in] key The key
          * \return An iterator to the position of the requested key if it was found, end() otherwise
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         find(const key_type& key) const;
 
 
@@ -230,7 +230,7 @@ class unordered_map
          * \param[in] key The key
          * \return True if the requested key was found, false otherwise
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         contains(const key_type& key) const;
 
 
@@ -240,7 +240,7 @@ class unordered_map
          * \return An iterator to the inserted pair and true if the insertion was successful, end() and false otherwise
          */
         template <class... Args>
-        __device__ thrust::pair<iterator, bool>
+        STDGPU_DEVICE_ONLY thrust::pair<iterator, bool>
         emplace(Args&&... args);
 
 
@@ -249,7 +249,7 @@ class unordered_map
          * \param[in] value The new value
          * \return An iterator to the inserted pair and true if the insertion was successful, end() and false otherwise
          */
-        __device__ thrust::pair<iterator, bool>
+        STDGPU_DEVICE_ONLY thrust::pair<iterator, bool>
         insert(const value_type& value);
 
 
@@ -278,7 +278,7 @@ class unordered_map
          * \param[in] key The key
          * \return 1 if there was a value with key and it got erased, 0 otherwise
          */
-        __device__ index_type
+        STDGPU_DEVICE_ONLY index_type
         erase(const key_type& key);
 
 

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -121,42 +121,42 @@ class unordered_set
          * \brief An iterator to the begin of the internal value array
          * \return An iterator to the begin of the object
          */
-        __device__ iterator
+        STDGPU_DEVICE_ONLY iterator
         begin();
 
         /**
          * \brief An iterator to the begin of the internal value array
          * \return A const iterator to the begin of the object
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         begin() const;
 
         /**
          * \brief An iterator to the begin of the internal value array
          * \return A const iterator to the begin of the object
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         cbegin() const;
 
         /**
          * \brief An iterator to the end of the internal value array
          * \return An iterator to the end of the object
          */
-        __device__ iterator
+        STDGPU_DEVICE_ONLY iterator
         end();
 
         /**
          * \brief An iterator to the end of the internal value array
          * \return A const iterator to the end of the object
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         end() const;
 
         /**
          * \brief An iterator to the end of the internal value array
          * \return A const iterator to the end of the object
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         cend() const;
 
 
@@ -183,7 +183,7 @@ class unordered_set
          * \param[in] n The bucket index
          * \return The number of elements in the requested bucket
          */
-        __device__ index_type
+        STDGPU_DEVICE_ONLY index_type
         bucket_size(index_type n) const;
 
 
@@ -192,7 +192,7 @@ class unordered_set
          * \param[in] key The key
          * \return The number of elements with the given key, i.e. 1 or 0
          */
-        __device__ index_type
+        STDGPU_DEVICE_ONLY index_type
         count(const key_type& key) const;
 
 
@@ -201,7 +201,7 @@ class unordered_set
          * \param[in] key The key
          * \return An iterator to the position of the requested key if it was found, end() otherwise
          */
-        __device__ iterator
+        STDGPU_DEVICE_ONLY iterator
         find(const key_type& key);
 
         /**
@@ -209,7 +209,7 @@ class unordered_set
          * \param[in] key The key
          * \return An iterator to the position of the requested key if it was found, end() otherwise
          */
-        __device__ const_iterator
+        STDGPU_DEVICE_ONLY const_iterator
         find(const key_type& key) const;
 
 
@@ -218,7 +218,7 @@ class unordered_set
          * \param[in] key The key
          * \return True if the requested key was found, false otherwise
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         contains(const key_type& key) const;
 
 
@@ -228,7 +228,7 @@ class unordered_set
          * \return An iterator to the inserted pair and true if the insertion was successful, end() and false otherwise
          */
         template <class... Args>
-        __device__ thrust::pair<iterator, bool>
+        STDGPU_DEVICE_ONLY thrust::pair<iterator, bool>
         emplace(Args&&... args);
 
 
@@ -237,7 +237,7 @@ class unordered_set
          * \param[in] value The new value
          * \return An iterator to the inserted pair and true if the insertion was successful, end() and false otherwise
          */
-        __device__ thrust::pair<iterator, bool>
+        STDGPU_DEVICE_ONLY thrust::pair<iterator, bool>
         insert(const value_type& value);
 
 
@@ -266,7 +266,7 @@ class unordered_set
          * \param[in] key The key
          * \return 1 if there was a value with key and it got erased, 0 otherwise
          */
-        __device__ index_type
+        STDGPU_DEVICE_ONLY index_type
         erase(const key_type& key);
 
 

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -100,7 +100,7 @@ class vector
          * \return The value at this position
          * \pre 0 <= n < size()
          */
-        __device__ reference
+        STDGPU_DEVICE_ONLY reference
         operator[](const index_type n);
 
         /**
@@ -109,35 +109,35 @@ class vector
          * \return The value at this position
          * \pre 0 <= n < size()
          */
-        __device__ const_reference
+        STDGPU_DEVICE_ONLY const_reference
         operator[](const index_type n) const;
 
         /**
          * \brief Reads the first value
          * \return The first value
          */
-        __device__ reference
+        STDGPU_DEVICE_ONLY reference
         front();
 
         /**
          * \brief Reads the first value
          * \return The first value
          */
-        __device__ const_reference
+        STDGPU_DEVICE_ONLY const_reference
         front() const;
 
         /**
          * \brief Reads the last value
          * \return The last value
          */
-        __device__ reference
+        STDGPU_DEVICE_ONLY reference
         back();
 
         /**
          * \brief Reads the last value
          * \return The last value
          */
-        __device__ const_reference
+        STDGPU_DEVICE_ONLY const_reference
         back() const;
 
         /**
@@ -146,7 +146,7 @@ class vector
          * \return True if not full, false otherwise
          */
         template <class... Args>
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         emplace_back(Args&&... args);
 
         /**
@@ -154,14 +154,14 @@ class vector
          * \param[in] element An element
          * \return True if not full, false otherwise
          */
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         push_back(const T& element);
 
         /**
          * \brief Removes and returns the current element from end of the object
          * \return The currently popped element and true if not empty, an empty element T() and false otherwise
          */
-        __device__ thrust::pair<T, bool>
+        STDGPU_DEVICE_ONLY thrust::pair<T, bool>
         pop_back();
 
         /**
@@ -284,7 +284,7 @@ class vector
 
     private:
 
-        __device__ bool
+        STDGPU_DEVICE_ONLY bool
         occupied(const index_t n) const;
 
         bool

--- a/test/stdgpu/atomic.cu
+++ b/test/stdgpu/atomic.cu
@@ -91,7 +91,7 @@ struct sum_seqeuence
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const T x)
     {
         value.fetch_add(x);
@@ -147,7 +147,7 @@ struct desum_sequence
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const T x)
     {
         value.fetch_sub(x);
@@ -216,7 +216,7 @@ struct or_sequence
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
         T pattern = 1 << i;
@@ -277,7 +277,7 @@ struct and_sequence
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
         T pattern = one_pattern - (1 << i);
@@ -346,7 +346,7 @@ struct xor_sequence
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
         T pattern = 1 << i;
@@ -404,7 +404,7 @@ struct min_sequence
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const T x)
     {
         value.fetch_min(x);
@@ -461,7 +461,7 @@ struct max_sequence
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const T x)
     {
         value.fetch_max(x);
@@ -518,7 +518,7 @@ struct inc_mod_sequence
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const T x)
     {
         value.fetch_inc_mod(x);
@@ -574,7 +574,7 @@ struct dec_mod_dequence
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const T x)
     {
         value.fetch_dec_mod(x);
@@ -630,7 +630,7 @@ struct pre_inc_sequence
 
     }
 
-    __device__ T
+    STDGPU_DEVICE_ONLY T
     operator()()
     {
         return ++value;
@@ -692,7 +692,7 @@ struct post_inc_sequence
 
     }
 
-    __device__ T
+    STDGPU_DEVICE_ONLY T
     operator()()
     {
         return value++;
@@ -754,7 +754,7 @@ struct pre_dec_sequence
 
     }
 
-    __device__ T
+    STDGPU_DEVICE_ONLY T
     operator()()
     {
         return --value;
@@ -823,7 +823,7 @@ struct post_dec_sequence
 
     }
 
-    __device__ T
+    STDGPU_DEVICE_ONLY T
     operator()()
     {
         return value--;

--- a/test/stdgpu/bitset.cu
+++ b/test/stdgpu/bitset.cu
@@ -67,7 +67,7 @@ struct set_all_bits
 
     }
 
-    __device__ bool
+    STDGPU_DEVICE_ONLY bool
     operator()(const stdgpu::index_t i)
     {
         bitset.set(i);
@@ -87,7 +87,7 @@ struct reset_all_bits
 
     }
 
-    __device__ bool
+    STDGPU_DEVICE_ONLY bool
     operator()(const stdgpu::index_t i)
     {
         bitset.reset(i);
@@ -107,7 +107,7 @@ struct set_and_reset_all_bits
 
     }
 
-    __device__ bool
+    STDGPU_DEVICE_ONLY bool
     operator()(const stdgpu::index_t i)
     {
         bitset.set(i);
@@ -132,7 +132,7 @@ struct flip_all_bits
 
     }
 
-    __device__ bool
+    STDGPU_DEVICE_ONLY bool
     operator()(const stdgpu::index_t i)
     {
         bitset.flip(i);
@@ -301,7 +301,7 @@ struct set_bits
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
         bitset.set(positions[i]);
@@ -327,7 +327,7 @@ struct reset_bits
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
         bitset.reset(positions[i]);
@@ -353,7 +353,7 @@ struct set_and_reset_bits
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
         bitset.set(positions[i]);
@@ -384,7 +384,7 @@ struct flip_bits
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
         bitset.flip(positions[i]);

--- a/test/stdgpu/cuda/atomic.cu
+++ b/test/stdgpu/cuda/atomic.cu
@@ -58,7 +58,7 @@ struct subtract
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const T x)
     {
         atomicSub(value, x);
@@ -202,7 +202,7 @@ struct find_min
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const float x)
     {
         atomicMin(value, x);
@@ -220,7 +220,7 @@ struct find_max
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const float x)
     {
         atomicMax(value, x);

--- a/test/stdgpu/deque.cu
+++ b/test/stdgpu/deque.cu
@@ -53,7 +53,7 @@ struct pop_back_deque
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(STDGPU_MAYBE_UNUSED const int x)
     {
         pool.pop_back();
@@ -71,7 +71,7 @@ struct push_back_deque
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         pool.push_back(x);
@@ -89,7 +89,7 @@ struct emplace_back_deque
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         pool.emplace_back(x);
@@ -430,7 +430,7 @@ struct pop_front_deque
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(STDGPU_MAYBE_UNUSED const int x)
     {
         pool.pop_front();
@@ -448,7 +448,7 @@ struct push_front_deque
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         pool.push_front(x);
@@ -466,7 +466,7 @@ struct emplace_front_deque
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         pool.emplace_front(x);
@@ -885,7 +885,7 @@ struct simultaneous_push_back_and_pop_back_deque
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         pool.push_back(x);
@@ -948,7 +948,7 @@ struct simultaneous_push_front_and_pop_front_deque
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         pool.push_front(x);
@@ -1011,7 +1011,7 @@ struct simultaneous_push_front_and_pop_back_deque
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         pool.push_front(x);
@@ -1074,7 +1074,7 @@ struct simultaneous_push_back_and_pop_front_deque
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         pool.push_back(x);
@@ -1134,7 +1134,7 @@ struct access_operator_non_const_deque
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         pool[x] = x * x;

--- a/test/stdgpu/iterator.cu
+++ b/test/stdgpu/iterator.cu
@@ -231,7 +231,7 @@ struct back_insert_interface
 
     }
 
-    inline __device__ void
+    inline STDGPU_DEVICE_ONLY void
     push_back(const int x)
     {
         vector.push_back(x);
@@ -251,7 +251,7 @@ struct front_insert_interface
 
     }
 
-    inline __device__ void
+    inline STDGPU_DEVICE_ONLY void
     push_front(const int x)
     {
         vector.push_back(x);
@@ -271,7 +271,7 @@ struct insert_interface
 
     }
 
-    inline __device__ void
+    inline STDGPU_DEVICE_ONLY void
     insert(const int x)
     {
         vector.push_back(x);

--- a/test/stdgpu/mutex.cu
+++ b/test/stdgpu/mutex.cu
@@ -65,7 +65,7 @@ struct lock_and_unlock
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
         // --- SEQUENTIAL PART ---
@@ -115,7 +115,7 @@ struct same_state
 
     }
 
-    __device__ bool
+    STDGPU_DEVICE_ONLY bool
     operator()(const stdgpu::index_t i)
     {
         return locks_1[i].locked() == locks_2[i].locked();
@@ -154,7 +154,7 @@ struct lock_single_functor
 
     }
 
-    __device__ bool
+    STDGPU_DEVICE_ONLY bool
     operator()(const stdgpu::index_t i)
     {
         return locks[i].try_lock();
@@ -213,7 +213,7 @@ struct lock_multiple_functor
 
     }
 
-    __device__ int
+    STDGPU_DEVICE_ONLY int
     operator()(const thrust::tuple<stdgpu::index_t, stdgpu::index_t> i)
     {
         return stdgpu::try_lock(locks[thrust::get<0>(i)], locks[thrust::get<1>(i)]);

--- a/test/stdgpu/unordered_datastructure_test.h
+++ b/test/stdgpu/unordered_datastructure_test.h
@@ -142,7 +142,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(const test_unordered_datastructure::key_type key)
         {
             stdgpu::index_t bucket = hash_datastructure.bucket(key);
@@ -227,7 +227,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
         {
             thrust::pair<test_unordered_datastructure::iterator, bool> success = hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(key));
@@ -271,7 +271,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
         {
             *erased = hash_datastructure.erase(key);
@@ -313,7 +313,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
         {
             *result = hash_datastructure.find(key);
@@ -355,7 +355,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
         {
             *result = hash_datastructure.cbegin() + hash_datastructure.bucket(key);
@@ -394,7 +394,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
         {
             *result = hash_datastructure.cend();
@@ -700,7 +700,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(const stdgpu::index_t i)
         {
             thrust::pair<test_unordered_datastructure::iterator, bool> success = hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(key));
@@ -726,7 +726,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(const stdgpu::index_t i)
         {
             bool success = static_cast<bool>(hash_datastructure.erase(key));
@@ -1001,7 +1001,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(const stdgpu::index_t i)
         {
             thrust::pair<test_unordered_datastructure::iterator, bool> success = hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(keys[i]));
@@ -1027,7 +1027,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(const stdgpu::index_t i)
         {
             thrust::pair<test_unordered_datastructure::iterator, bool> success = hash_datastructure.emplace(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(keys[i]));
@@ -1053,7 +1053,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(const stdgpu::index_t i)
         {
             bool success = static_cast<bool>(hash_datastructure.erase(keys[i]));
@@ -1416,7 +1416,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(const stdgpu::index_t i)
         {
             thrust::pair<test_unordered_datastructure::iterator, bool> success_insert = hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(keys[i]));
@@ -1480,7 +1480,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(const test_unordered_datastructure::value_type& value)
         {
             if (!hash_datastructure.contains(STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(value)))
@@ -1530,7 +1530,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(const test_unordered_datastructure::value_type& value)
         {
             keys.push_back(STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(value));
@@ -1583,7 +1583,7 @@ namespace
 
         }
 
-        __device__ void
+        STDGPU_DEVICE_ONLY void
         operator()(const test_unordered_datastructure::value_type& value)
         {
             hash_datastructure.erase(STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(value));

--- a/test/stdgpu/vector.cu
+++ b/test/stdgpu/vector.cu
@@ -53,7 +53,7 @@ struct pop_back_vector
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(STDGPU_MAYBE_UNUSED const int x)
     {
         pool.pop_back();
@@ -71,7 +71,7 @@ struct push_back_vector
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         pool.push_back(x);
@@ -89,7 +89,7 @@ struct emplace_back_vector
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         pool.emplace_back(x);
@@ -454,7 +454,7 @@ struct simultaneous_push_back_and_pop_back_vector
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         pool.push_back(x);
@@ -514,7 +514,7 @@ struct access_operator_non_const_vector
 
     }
 
-    __device__ void
+    STDGPU_DEVICE_ONLY void
     operator()(const int x)
     {
         pool[x] = x * x;


### PR DESCRIPTION
Device-only functions still use the CUDA-specific `__device__` annotation. Wrap this into a custom macro to reduce the coupling to the CUDA backend. This significantly helps us to generate better error messages and is a further small step towards supporting a wider range of platforms and backends.