### PR TITLE
cmake: Workaround unspecified CUDA directories on Windows

### DIFF
--- a/cmake/cuda/check_compute_capability.cmake
+++ b/cmake/cuda/check_compute_capability.cmake
@@ -4,6 +4,13 @@
 set(STDGPU_CUDA_COMPUTE_CAPABILITIES_SOURCE "${CMAKE_CURRENT_LIST_DIR}/compute_capability.cpp")
 message(STATUS "Detecting CCs of GPUs : ${STDGPU_CUDA_COMPUTE_CAPABILITIES_SOURCE}")
 
+# Workaround for unset variables when compiling with Visual Studio (Windows)
+if(MSVC)
+    get_filename_component(STDGPU_CUDA_COMPILER_DIR "${CMAKE_CUDA_COMPILER}" DIRECTORY)
+    set(CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES "${STDGPU_CUDA_COMPILER_DIR}/../include")
+    set(CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES "${STDGPU_CUDA_COMPILER_DIR}/../lib/x64")
+endif()
+
 # Detect CUDA runtime library to build the .cpp file (implicitly used if .cu file was used)
 find_library(STDGPU_CUDART_LIBRARY cudart
              HINTS ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})


### PR DESCRIPTION
The compute capability logic has been improved in #8. However, as the variables `CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES` and `CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES` are now involved, this resulted in a regression when compiling with Visual Studio (Windows). Here, the variables are not defined [1] [2] which caused build failures. Workaround this issue by manually computing the paths in this scenario.

Once the respective CMake bug is fixed, we can remove the workaround. If this workaround is not sufficient, we need to revert to the older and slower version.

[1] https://gitlab.kitware.com/cmake/cmake/issues/18733
[2] https://gitlab.kitware.com/cmake/cmake/issues/19229