### PR TITLE
deque,unordered_{map,set},vector: Fix missing typename

### DIFF
--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -67,7 +67,7 @@ deque<T>::destroyDeviceObject(deque<T>& device_object)
 
 
 template <typename T>
-inline STDGPU_DEVICE_ONLY deque<T>::reference
+inline STDGPU_DEVICE_ONLY typename deque<T>::reference
 deque<T>::operator[](const deque<T>::index_type n)
 {
     return const_cast<reference>(static_cast<const deque<T>*>(this)->operator[](n));
@@ -75,7 +75,7 @@ deque<T>::operator[](const deque<T>::index_type n)
 
 
 template <typename T>
-inline STDGPU_DEVICE_ONLY deque<T>::const_reference
+inline STDGPU_DEVICE_ONLY typename deque<T>::const_reference
 deque<T>::operator[](const deque<T>::index_type n) const
 {
     STDGPU_EXPECTS(0 <= n);
@@ -91,7 +91,7 @@ deque<T>::operator[](const deque<T>::index_type n) const
 
 
 template <typename T>
-inline STDGPU_DEVICE_ONLY deque<T>::reference
+inline STDGPU_DEVICE_ONLY typename deque<T>::reference
 deque<T>::front()
 {
     return const_cast<reference>(static_cast<const deque<T>*>(this)->front());
@@ -99,7 +99,7 @@ deque<T>::front()
 
 
 template <typename T>
-inline STDGPU_DEVICE_ONLY deque<T>::const_reference
+inline STDGPU_DEVICE_ONLY typename deque<T>::const_reference
 deque<T>::front() const
 {
     return operator[](0);
@@ -107,7 +107,7 @@ deque<T>::front() const
 
 
 template <typename T>
-inline STDGPU_DEVICE_ONLY deque<T>::reference
+inline STDGPU_DEVICE_ONLY typename deque<T>::reference
 deque<T>::back()
 {
     return const_cast<reference>(static_cast<const deque<T>*>(this)->back());
@@ -115,7 +115,7 @@ deque<T>::back()
 
 
 template <typename T>
-inline STDGPU_DEVICE_ONLY deque<T>::const_reference
+inline STDGPU_DEVICE_ONLY typename deque<T>::const_reference
 deque<T>::back() const
 {
     return operator[](size() - 1);

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -18,6 +18,7 @@
 
 #include <thrust/copy.h>
 #include <thrust/distance.h>
+#include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/logical.h>
@@ -40,7 +41,7 @@ namespace detail
 {
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::begin()
 {
     return _values;
@@ -48,7 +49,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::begin()
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::begin() const
 {
     return _values;
@@ -56,7 +57,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::begin() const
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::cbegin() const
 {
     return begin();
@@ -64,7 +65,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::cbegin() const
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::end()
 {
     return _values + total_count();
@@ -72,7 +73,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::end()
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::end() const
 {
     return _values + total_count();
@@ -80,7 +81,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::end() const
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::cend() const
 {
     return end();
@@ -400,7 +401,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::count(const key_type& 
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find(const key_type& key)
 {
     index_t key_index = bucket(key);
@@ -433,7 +434,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find(const key_type& k
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::const_iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find(const key_type& key) const
 {
     index_t key_index = bucket(key);
@@ -892,7 +893,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::load_factor() const
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline STDGPU_HOST_DEVICE unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::hasher
+inline STDGPU_HOST_DEVICE typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::hasher
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::hash_function() const
 {
     return _hash;
@@ -900,7 +901,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::hash_function() const
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline STDGPU_HOST_DEVICE unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::key_equal
+inline STDGPU_HOST_DEVICE typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::key_equal
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::key_eq() const
 {
     return _key_equal;

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -41,7 +41,7 @@ struct select1st
 } // namespace detail
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::iterator
 unordered_map<Key, T, Hash, KeyEqual>::begin()
 {
     return _base.begin();
@@ -49,7 +49,7 @@ unordered_map<Key, T, Hash, KeyEqual>::begin()
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::const_iterator
 unordered_map<Key, T, Hash, KeyEqual>::begin() const
 {
     return _base.begin();
@@ -57,7 +57,7 @@ unordered_map<Key, T, Hash, KeyEqual>::begin() const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::const_iterator
 unordered_map<Key, T, Hash, KeyEqual>::cbegin() const
 {
     return _base.begin();
@@ -65,7 +65,7 @@ unordered_map<Key, T, Hash, KeyEqual>::cbegin() const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::iterator
 unordered_map<Key, T, Hash, KeyEqual>::end()
 {
     return _base.end();
@@ -73,7 +73,7 @@ unordered_map<Key, T, Hash, KeyEqual>::end()
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::const_iterator
 unordered_map<Key, T, Hash, KeyEqual>::end() const
 {
     return _base.end();
@@ -81,7 +81,7 @@ unordered_map<Key, T, Hash, KeyEqual>::end() const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::const_iterator
 unordered_map<Key, T, Hash, KeyEqual>::cend() const
 {
     return _base.end();
@@ -97,7 +97,7 @@ unordered_map<Key, T, Hash, KeyEqual>::device_range() const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_HOST_DEVICE unordered_map<Key, T, Hash, KeyEqual>::index_type
+inline STDGPU_HOST_DEVICE typename unordered_map<Key, T, Hash, KeyEqual>::index_type
 unordered_map<Key, T, Hash, KeyEqual>::bucket(const key_type& key) const
 {
     return _base.bucket(key);
@@ -105,7 +105,7 @@ unordered_map<Key, T, Hash, KeyEqual>::bucket(const key_type& key) const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::index_type
+inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::index_type
 unordered_map<Key, T, Hash, KeyEqual>::bucket_size(index_type n) const
 {
     return _base.bucket_size(n);
@@ -113,7 +113,7 @@ unordered_map<Key, T, Hash, KeyEqual>::bucket_size(index_type n) const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::index_type
+inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::index_type
 unordered_map<Key, T, Hash, KeyEqual>::count(const key_type& key) const
 {
     return _base.count(key);
@@ -121,7 +121,7 @@ unordered_map<Key, T, Hash, KeyEqual>::count(const key_type& key) const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::iterator
 unordered_map<Key, T, Hash, KeyEqual>::find(const key_type& key)
 {
     return _base.find(key);
@@ -129,7 +129,7 @@ unordered_map<Key, T, Hash, KeyEqual>::find(const key_type& key)
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::const_iterator
 unordered_map<Key, T, Hash, KeyEqual>::find(const key_type& key) const
 {
     return _base.find(key);
@@ -180,7 +180,7 @@ unordered_map<Key, T, Hash, KeyEqual>::insert(device_ptr<const unordered_map<Key
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_map<Key, T, Hash, KeyEqual>::index_type
+inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::index_type
 unordered_map<Key, T, Hash, KeyEqual>::erase(const unordered_map<Key, T, Hash, KeyEqual>::key_type& key)
 {
     return _base.erase(key);
@@ -270,7 +270,7 @@ unordered_map<Key, T, Hash, KeyEqual>::load_factor() const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_HOST_DEVICE unordered_map<Key, T, Hash, KeyEqual>::hasher
+inline STDGPU_HOST_DEVICE typename unordered_map<Key, T, Hash, KeyEqual>::hasher
 unordered_map<Key, T, Hash, KeyEqual>::hash_function() const
 {
     return _base.hash_function();
@@ -278,7 +278,7 @@ unordered_map<Key, T, Hash, KeyEqual>::hash_function() const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_HOST_DEVICE unordered_map<Key, T, Hash, KeyEqual>::key_equal
+inline STDGPU_HOST_DEVICE typename unordered_map<Key, T, Hash, KeyEqual>::key_equal
 unordered_map<Key, T, Hash, KeyEqual>::key_eq() const
 {
     return _base.key_eq();

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -26,7 +26,7 @@ namespace stdgpu
 {
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::iterator
 unordered_set<Key, Hash, KeyEqual>::begin()
 {
     return _base.begin();
@@ -34,7 +34,7 @@ unordered_set<Key, Hash, KeyEqual>::begin()
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::const_iterator
 unordered_set<Key, Hash, KeyEqual>::begin() const
 {
     return _base.begin();
@@ -42,7 +42,7 @@ unordered_set<Key, Hash, KeyEqual>::begin() const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::const_iterator
 unordered_set<Key, Hash, KeyEqual>::cbegin() const
 {
     return _base.begin();
@@ -50,7 +50,7 @@ unordered_set<Key, Hash, KeyEqual>::cbegin() const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::iterator
 unordered_set<Key, Hash, KeyEqual>::end()
 {
     return _base.end();
@@ -58,7 +58,7 @@ unordered_set<Key, Hash, KeyEqual>::end()
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::const_iterator
 unordered_set<Key, Hash, KeyEqual>::end() const
 {
     return _base.end();
@@ -66,7 +66,7 @@ unordered_set<Key, Hash, KeyEqual>::end() const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::const_iterator
 unordered_set<Key, Hash, KeyEqual>::cend() const
 {
     return _base.end();
@@ -82,7 +82,7 @@ unordered_set<Key, Hash, KeyEqual>::device_range() const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_HOST_DEVICE unordered_set<Key, Hash, KeyEqual>::index_type
+inline STDGPU_HOST_DEVICE typename unordered_set<Key, Hash, KeyEqual>::index_type
 unordered_set<Key, Hash, KeyEqual>::bucket(const key_type& key) const
 {
     return _base.bucket(key);
@@ -90,7 +90,7 @@ unordered_set<Key, Hash, KeyEqual>::bucket(const key_type& key) const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::index_type
+inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::index_type
 unordered_set<Key, Hash, KeyEqual>::bucket_size(index_type n) const
 {
     return _base.bucket_size(n);
@@ -98,7 +98,7 @@ unordered_set<Key, Hash, KeyEqual>::bucket_size(index_type n) const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::index_type
+inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::index_type
 unordered_set<Key, Hash, KeyEqual>::count(const key_type& key) const
 {
     return _base.count(key);
@@ -106,7 +106,7 @@ unordered_set<Key, Hash, KeyEqual>::count(const key_type& key) const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::iterator
+inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::iterator
 unordered_set<Key, Hash, KeyEqual>::find(const key_type& key)
 {
     return _base.find(key);
@@ -114,7 +114,7 @@ unordered_set<Key, Hash, KeyEqual>::find(const key_type& key)
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::const_iterator
+inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::const_iterator
 unordered_set<Key, Hash, KeyEqual>::find(const key_type& key) const
 {
     return _base.find(key);
@@ -165,7 +165,7 @@ unordered_set<Key, Hash, KeyEqual>::insert(device_ptr<const unordered_set<Key, H
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY unordered_set<Key, Hash, KeyEqual>::index_type
+inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::index_type
 unordered_set<Key, Hash, KeyEqual>::erase(const unordered_set<Key, Hash, KeyEqual>::key_type& key)
 {
     return _base.erase(key);
@@ -255,7 +255,7 @@ unordered_set<Key, Hash, KeyEqual>::load_factor() const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_HOST_DEVICE unordered_set<Key, Hash, KeyEqual>::hasher
+inline STDGPU_HOST_DEVICE typename unordered_set<Key, Hash, KeyEqual>::hasher
 unordered_set<Key, Hash, KeyEqual>::hash_function() const
 {
     return _base.hash_function();
@@ -263,7 +263,7 @@ unordered_set<Key, Hash, KeyEqual>::hash_function() const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_HOST_DEVICE unordered_set<Key, Hash, KeyEqual>::key_equal
+inline STDGPU_HOST_DEVICE typename unordered_set<Key, Hash, KeyEqual>::key_equal
 unordered_set<Key, Hash, KeyEqual>::key_eq() const
 {
     return _base.key_eq();

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -57,7 +57,7 @@ vector<T>::destroyDeviceObject(vector<T>& device_object)
 
 
 template <typename T>
-inline STDGPU_DEVICE_ONLY vector<T>::reference
+inline STDGPU_DEVICE_ONLY typename vector<T>::reference
 vector<T>::operator[](const vector<T>::index_type n)
 {
     return const_cast<vector<T>::reference>(static_cast<const vector<T>*>(this)->operator[](n));
@@ -65,7 +65,7 @@ vector<T>::operator[](const vector<T>::index_type n)
 
 
 template <typename T>
-inline STDGPU_DEVICE_ONLY vector<T>::const_reference
+inline STDGPU_DEVICE_ONLY typename vector<T>::const_reference
 vector<T>::operator[](const vector<T>::index_type n) const
 {
     STDGPU_EXPECTS(0 <= n);
@@ -77,7 +77,7 @@ vector<T>::operator[](const vector<T>::index_type n) const
 
 
 template <typename T>
-inline STDGPU_DEVICE_ONLY vector<T>::reference
+inline STDGPU_DEVICE_ONLY typename vector<T>::reference
 vector<T>::front()
 {
     return const_cast<reference>(static_cast<const vector<T>*>(this)->front());
@@ -85,7 +85,7 @@ vector<T>::front()
 
 
 template <typename T>
-inline STDGPU_DEVICE_ONLY vector<T>::const_reference
+inline STDGPU_DEVICE_ONLY typename vector<T>::const_reference
 vector<T>::front() const
 {
     return operator[](0);
@@ -93,7 +93,7 @@ vector<T>::front() const
 
 
 template <typename T>
-inline STDGPU_DEVICE_ONLY vector<T>::reference
+inline STDGPU_DEVICE_ONLY typename vector<T>::reference
 vector<T>::back()
 {
     return const_cast<reference>(static_cast<const vector<T>*>(this)->back());
@@ -101,7 +101,7 @@ vector<T>::back()
 
 
 template <typename T>
-inline STDGPU_DEVICE_ONLY vector<T>::const_reference
+inline STDGPU_DEVICE_ONLY typename vector<T>::const_reference
 vector<T>::back() const
 {
     return operator[](size() - 1);


### PR DESCRIPTION
Several member functions of `deque`, `unordered_map`, `unordered_set`, and `vector` use the public typedefs in the function signatures. As they are dependent names, the `typename` keyword is required for disambiguation. Add it where it was previously missing to avoid compilation errors.