### PR TITLE
unordered_{map,set}: Remove unnecessary anonymous namespace

### DIFF
--- a/test/stdgpu/unordered_map.cu
+++ b/test/stdgpu/unordered_map.cu
@@ -20,87 +20,85 @@
 #include <stdgpu/platform.h>
 
 
-namespace
+
+struct dummy
 {
-    struct dummy
+    // no data in dummy
+};
+
+
+struct vec3int16
+{
+    vec3int16() = default;
+
+    STDGPU_HOST_DEVICE
+    vec3int16(const std::int16_t x,
+              const std::int16_t y,
+              const std::int16_t z)
+        : x(x),
+          y(y),
+          z(z)
     {
-        // no data in dummy
-    };
 
-
-    struct vec3int16
-    {
-        vec3int16() = default;
-
-        STDGPU_HOST_DEVICE
-        vec3int16(const std::int16_t x,
-                  const std::int16_t y,
-                  const std::int16_t z)
-            : x(x),
-              y(y),
-              z(z)
-        {
-
-        }
-
-        std::int16_t x = 0;
-        std::int16_t y = 0;
-        std::int16_t z = 0;
-    };
-
-    STDGPU_HOST_DEVICE bool
-    operator==(const vec3int16& lhs,
-               const vec3int16& rhs)
-    {
-        return lhs.x == rhs.x
-            && lhs.y == rhs.y
-            && lhs.z == rhs.z;
     }
 
-    struct less
+    std::int16_t x = 0;
+    std::int16_t y = 0;
+    std::int16_t z = 0;
+};
+
+inline STDGPU_HOST_DEVICE bool
+operator==(const vec3int16& lhs,
+           const vec3int16& rhs)
+{
+    return lhs.x == rhs.x
+        && lhs.y == rhs.y
+        && lhs.z == rhs.z;
+}
+
+struct less
+{
+    inline STDGPU_HOST_DEVICE bool
+    operator()(const vec3int16& lhs,
+               const vec3int16& rhs) const
     {
-        inline STDGPU_HOST_DEVICE bool
-        operator()(const vec3int16& lhs,
-                   const vec3int16& rhs) const
-        {
-            if (lhs.x < rhs.x) return true;
-            if (lhs.x > rhs.x) return false;
+        if (lhs.x < rhs.x) return true;
+        if (lhs.x > rhs.x) return false;
 
-            if (lhs.y < rhs.y) return true;
-            if (lhs.y > rhs.y) return false;
+        if (lhs.y < rhs.y) return true;
+        if (lhs.y > rhs.y) return false;
 
-            if (lhs.z < rhs.z) return true;
-            if (lhs.z > rhs.z) return false;
+        if (lhs.z < rhs.z) return true;
+        if (lhs.z > rhs.z) return false;
 
-            return true;
-        }
-    };
-
-
-    struct hash
-    {
-        inline STDGPU_HOST_DEVICE std::size_t
-        operator()(const vec3int16& key) const
-        {
-            return (static_cast<std::size_t>(key.x) * static_cast<std::size_t>(73856093u))
-                 ^ (static_cast<std::size_t>(key.y) * static_cast<std::size_t>(19349669u))
-                 ^ (static_cast<std::size_t>(key.z) * static_cast<std::size_t>(83492791u));
-        }
-    };
-
-
-    inline STDGPU_HOST_DEVICE stdgpu::unordered_map<vec3int16, dummy, hash>::value_type
-    key_to_value(const vec3int16& key)
-    {
-        return stdgpu::unordered_map<vec3int16, dummy, hash>::value_type(key, dummy());
+        return true;
     }
+};
 
 
-    inline STDGPU_HOST_DEVICE vec3int16
-    value_to_key(const stdgpu::unordered_map<vec3int16, dummy, hash>::value_type& value)
+struct hash
+{
+    inline STDGPU_HOST_DEVICE std::size_t
+    operator()(const vec3int16& key) const
     {
-        return value.first;
+        return (static_cast<std::size_t>(key.x) * static_cast<std::size_t>(73856093u))
+             ^ (static_cast<std::size_t>(key.y) * static_cast<std::size_t>(19349669u))
+             ^ (static_cast<std::size_t>(key.z) * static_cast<std::size_t>(83492791u));
     }
+};
+
+
+inline STDGPU_HOST_DEVICE stdgpu::unordered_map<vec3int16, dummy, hash>::value_type
+key_to_value(const vec3int16& key)
+{
+    return stdgpu::unordered_map<vec3int16, dummy, hash>::value_type(key, dummy());
+}
+
+
+inline STDGPU_HOST_DEVICE vec3int16
+value_to_key(const stdgpu::unordered_map<vec3int16, dummy, hash>::value_type& value)
+{
+    return value.first;
 }
 
 

--- a/test/stdgpu/unordered_set.cu
+++ b/test/stdgpu/unordered_set.cu
@@ -20,83 +20,81 @@
 #include <stdgpu/platform.h>
 
 
-namespace
+
+struct vec3int16
 {
-    struct vec3int16
+    vec3int16() = default;
+
+    STDGPU_HOST_DEVICE
+    vec3int16(const std::int16_t x,
+              const std::int16_t y,
+              const std::int16_t z)
+        : x(x),
+          y(y),
+          z(z)
     {
-        vec3int16() = default;
 
-        STDGPU_HOST_DEVICE
-        vec3int16(const std::int16_t x,
-                  const std::int16_t y,
-                  const std::int16_t z)
-            : x(x),
-              y(y),
-              z(z)
-        {
-
-        }
-
-        std::int16_t x = 0;
-        std::int16_t y = 0;
-        std::int16_t z = 0;
-    };
-
-
-    STDGPU_HOST_DEVICE bool
-    operator==(const vec3int16& lhs,
-               const vec3int16& rhs)
-    {
-        return lhs.x == rhs.x
-            && lhs.y == rhs.y
-            && lhs.z == rhs.z;
     }
 
+    std::int16_t x = 0;
+    std::int16_t y = 0;
+    std::int16_t z = 0;
+};
 
-    struct less
+
+inline STDGPU_HOST_DEVICE bool
+operator==(const vec3int16& lhs,
+           const vec3int16& rhs)
+{
+    return lhs.x == rhs.x
+        && lhs.y == rhs.y
+        && lhs.z == rhs.z;
+}
+
+
+struct less
+{
+    inline STDGPU_HOST_DEVICE bool
+    operator()(const vec3int16& lhs,
+               const vec3int16& rhs) const
     {
-        inline STDGPU_HOST_DEVICE bool
-        operator()(const vec3int16& lhs,
-                   const vec3int16& rhs) const
-        {
-            if (lhs.x < rhs.x) return true;
-            if (lhs.x > rhs.x) return false;
+        if (lhs.x < rhs.x) return true;
+        if (lhs.x > rhs.x) return false;
 
-            if (lhs.y < rhs.y) return true;
-            if (lhs.y > rhs.y) return false;
+        if (lhs.y < rhs.y) return true;
+        if (lhs.y > rhs.y) return false;
 
-            if (lhs.z < rhs.z) return true;
-            if (lhs.z > rhs.z) return false;
+        if (lhs.z < rhs.z) return true;
+        if (lhs.z > rhs.z) return false;
 
-            return true;
-        }
-    };
-
-
-    struct hash
-    {
-        inline STDGPU_HOST_DEVICE std::size_t
-        operator()(const vec3int16& key) const
-        {
-            return (static_cast<std::size_t>(key.x) * static_cast<std::size_t>(73856093u))
-                 ^ (static_cast<std::size_t>(key.y) * static_cast<std::size_t>(19349669u))
-                 ^ (static_cast<std::size_t>(key.z) * static_cast<std::size_t>(83492791u));
-        }
-    };
-
-
-    inline STDGPU_HOST_DEVICE vec3int16
-    key_to_value(const vec3int16& key)
-    {
-        return key;
+        return true;
     }
+};
 
 
-    inline STDGPU_HOST_DEVICE vec3int16
-    value_to_key(const vec3int16& key)
+struct hash
+{
+    inline STDGPU_HOST_DEVICE std::size_t
+    operator()(const vec3int16& key) const
     {
-        return key;
+        return (static_cast<std::size_t>(key.x) * static_cast<std::size_t>(73856093u))
+             ^ (static_cast<std::size_t>(key.y) * static_cast<std::size_t>(19349669u))
+             ^ (static_cast<std::size_t>(key.z) * static_cast<std::size_t>(83492791u));
     }
+};
+
+
+inline STDGPU_HOST_DEVICE vec3int16
+key_to_value(const vec3int16& key)
+{
+    return key;
+}
+
+
+inline STDGPU_HOST_DEVICE vec3int16
+value_to_key(const vec3int16& key)
+{
+    return key;
 }
 
 


### PR DESCRIPTION
The test data structures used for `unordered_map` and `unordered_set` were defined in an anonymous namespace. Remove it and mark `operator==` as inline.