### PR TITLE
deque,vector: Remove unreliable validity check in unit test

### DIFF
--- a/test/stdgpu/deque.cu
+++ b/test/stdgpu/deque.cu
@@ -189,7 +189,7 @@ TEST_F(stdgpu_deque, pop_back_too_many)
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
     ASSERT_FALSE(pool.full());
-    ASSERT_FALSE(pool.valid());
+    // pool may be valid or invalid depending on the thread scheduling
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -296,7 +296,7 @@ TEST_F(stdgpu_deque, push_back_too_many)
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
-    ASSERT_FALSE(pool.valid());
+    // pool may be valid or invalid depending on the thread scheduling
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -405,7 +405,7 @@ TEST_F(stdgpu_deque, emplace_back_too_many)
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
-    ASSERT_FALSE(pool.valid());
+    // pool may be valid or invalid depending on the thread scheduling
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -550,7 +550,7 @@ TEST_F(stdgpu_deque, pop_front_too_many)
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
     ASSERT_FALSE(pool.full());
-    ASSERT_FALSE(pool.valid());
+    // pool may be valid or invalid depending on the thread scheduling
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -654,7 +654,7 @@ TEST_F(stdgpu_deque, push_front_too_many)
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
-    ASSERT_FALSE(pool.valid());
+    // pool may be valid or invalid depending on the thread scheduling
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -760,7 +760,7 @@ TEST_F(stdgpu_deque, emplace_front_too_many)
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
-    ASSERT_FALSE(pool.valid());
+    // pool may be valid or invalid depending on the thread scheduling
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)

--- a/test/stdgpu/vector.cu
+++ b/test/stdgpu/vector.cu
@@ -189,7 +189,7 @@ TEST_F(stdgpu_vector, pop_back_too_many)
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
     ASSERT_FALSE(pool.full());
-    ASSERT_FALSE(pool.valid());
+    // pool may be valid or invalid depending on the thread scheduling
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -296,7 +296,7 @@ TEST_F(stdgpu_vector, push_back_too_many)
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
-    ASSERT_FALSE(pool.valid());
+    // pool may be valid or invalid depending on the thread scheduling
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -405,7 +405,7 @@ TEST_F(stdgpu_vector, emplace_back_too_many)
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
-    ASSERT_FALSE(pool.valid());
+    // pool may be valid or invalid depending on the thread scheduling
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)


### PR DESCRIPTION
The unit tests of `deque` and vector` assume that the object state becomes invalid when pushing or popping too many elements. However, there is preemptive check that tries to avoid getting into this invalid state. Remove the check in the test as the object may remain in a valid state.