### PR TITLE
memory: Reduce requirements to backend

### DIFF
--- a/src/stdgpu/cuda/impl/memory.cpp
+++ b/src/stdgpu/cuda/impl/memory.cpp
@@ -190,47 +190,6 @@ workaround_synchronize_managed_memory()
 }
 
 
-dynamic_memory_type
-get_dynamic_memory_type(void* array)
-{
-    cudaPointerAttributes attributes;
-    cudaError_t state = cudaPointerGetAttributes(&attributes, array);
-
-    if (state != cudaSuccess)
-    {
-        // Flush error flag
-        cudaGetLastError();
-        return dynamic_memory_type::invalid;
-    }
-
-    switch (attributes.type)
-    {
-        case cudaMemoryTypeManaged :
-        {
-            return dynamic_memory_type::managed;
-        }
-        break;
-
-        case cudaMemoryTypeDevice :
-        {
-            return dynamic_memory_type::device;
-        }
-        break;
-
-        case cudaMemoryTypeHost :
-        {
-            return dynamic_memory_type::host;
-        }
-        break;
-
-        default :
-        {
-            return dynamic_memory_type::invalid;
-        }
-    }
-}
-
-
 } // namespace cuda
 
 } // namespace stdgpu

--- a/src/stdgpu/cuda/memory.h
+++ b/src/stdgpu/cuda/memory.h
@@ -79,15 +79,6 @@ void
 workaround_synchronize_managed_memory();
 
 
-/**
- * \brief Determines the dynamic memory type of the given array
- * \param[in] array An array
- * \return The memory type of the array
- */
-dynamic_memory_type
-get_dynamic_memory_type(void* array);
-
-
 } // namespace cuda
 
 } // namespace stdgpu

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -461,7 +461,20 @@ template <>
 dynamic_memory_type
 get_dynamic_memory_type(void* array)
 {
-    return stdgpu::cuda::get_dynamic_memory_type(array);
+    if (detail::manager_device.contains_memory(array))
+    {
+        return dynamic_memory_type::device;
+    }
+    if (detail::manager_host.contains_memory(array))
+    {
+        return dynamic_memory_type::host;
+    }
+    if (detail::manager_managed.contains_memory(array))
+    {
+        return dynamic_memory_type::managed;
+    }
+
+    return dynamic_memory_type::invalid;
 }
 
 


### PR DESCRIPTION
The function `get_dynamic_memory_type` is considered backend-specific as it contains plain CUDA function calls. Use our internal memory management system to implement a generic version. This reduces the requirements and will ease the implementation future backends.