### PR TITLE
unordered_base: Improve reliability

### DIFF
--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -545,12 +545,12 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_insert(const unord
                         default_allocator_traits::construct(&(_values[new_linked_list_end]), value); //_values[new_linked_list_end] = value;
                         _offsets[new_linked_list_end] = 0;
 
-                        // Connect new linked list end after its values have been fully initialized as try_erase is not resetting offsets
-                        _offsets[linked_list_end] = new_linked_list_end - linked_list_end;
-
                         // Set occupied status after entry has been fully constructed
                         ++_occupied_count;
                         bool was_occupied = _occupied.set(new_linked_list_end);
+
+                        // Connect new linked list end after its values have been fully initialized and the occupied status has been set as try_erase is not resetting offsets
+                        _offsets[linked_list_end] = new_linked_list_end - linked_list_end;
 
                         inserted_it = begin() + new_linked_list_end;
                         inserted = true;

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -733,8 +733,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::insert(const unordered
 {
     thrust::pair<iterator, bool> result = thrust::make_pair(end(), false);
 
-    // Use for loop with a high range over while loop to workaround kernel timeouts caused by GPU compilation/scheduling issues
-    for (index_t i = 0; i < 1000; ++i)
+    while (true)
     {
         if (!contains(_key_from_value(value))
             && !full() && !_excess_list_positions.empty())
@@ -777,8 +776,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::erase(const unordered_
 {
     index_t result = 0;
 
-    // Use for loop with a high range over while loop to workaround kernel timeouts caused by GPU compilation/scheduling issues
-    for (index_t i = 0; i < 1000; ++i)
+    while (true)
     {
         if (contains(key))
         {


### PR DESCRIPTION
In case of inserting the same value multiple times in parallel (see unit test), this operation may be performed more than once which leads to duplicates within the container. Although the actual insertion process is already properly guarded by a lock and double-check mechanism, speculation and cache issues due to operation reordering may occur and make a thread believe that the value is not yet inserted (value and link set, but occupancy status still unset). Workaround this by updating the link to the newly created values after its occupancy status has been set.

Furthermore, revert the loop timeout workaround (#3) and replace it back to a while loop. 