### PR TITLE
memory: Workaround possible compilation failures

### DIFF
--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -330,6 +330,20 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyDeviceArray)
 }
 
 
+TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyDeviceArray_const_type)
+{
+    using T = thrust::pair<const int,float>;
+    T default_value = {10, 2.0f};
+    stdgpu::index64_t size = 42;
+
+    T* array_device = createDeviceArray<T>(size, default_value);
+
+    destroyDeviceArray<T>(array_device);
+
+    EXPECT_EQ(array_device, nullptr);
+}
+
+
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyDeviceArray_parallel)
 {
     stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
@@ -345,6 +359,20 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyHostArray)
 }
 
 
+TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyHostArray_const_type)
+{
+    using T = thrust::pair<const int,float>;
+    T default_value = {10, 2.0f};
+    stdgpu::index64_t size = 42;
+
+    T* array_host = createHostArray<T>(size, default_value);
+
+    destroyHostArray<T>(array_host);
+
+    EXPECT_EQ(array_host, nullptr);
+}
+
+
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyHostArray_parallel)
 {
     stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
@@ -357,6 +385,20 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyHostArray_parallel)
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyManagedArray)
 {
     createAndDestroyManagedFunction(1);
+}
+
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyManagedArray_const_type)
+{
+    using T = thrust::pair<const int,float>;
+    T default_value = {10, 2.0f};
+    stdgpu::index64_t size = 42;
+
+    T* array_managed = createManagedArray<T>(size, default_value);
+
+    destroyManagedArray<T>(array_managed);
+
+    EXPECT_EQ(array_managed, nullptr);
 }
 
 


### PR DESCRIPTION
thrust uses an optimization within the `uninitialized_fill` function in case the type `T` has a trivial copy constructor. However, as they actually perform copy assignment rather than copy construction, this may cause compilation failures for types `T` that have a copy constructor but no copy assignment operator. Since the detection code for this mechanism also differs for different compilers, the behavior is rather unpredictable. Define an own internal version of `uninitialized_fill` to workaround this issue.