### PR TITLE
cmake,src: Handle format warnings

### DIFF
--- a/cmake/set_host_flags.cmake
+++ b/cmake/set_host_flags.cmake
@@ -4,6 +4,7 @@ if(NOT MSVC)
     string(APPEND STDGPU_HOST_FLAGS " -pedantic")
     string(APPEND STDGPU_HOST_FLAGS " -Wextra")
     string(APPEND STDGPU_HOST_FLAGS " -O3")
+    string(APPEND STDGPU_HOST_FLAGS " -Wno-format")
 else()
     #string(APPEND STDGPU_HOST_FLAGS " /W3") # or /W4 depending on how useful this is
     #string(APPEND STDGPU_HOST_FLAGS " /O2")

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -141,7 +141,7 @@ struct offset_inside_range
 
         if (linked_entry < 0 || linked_entry >= base.total_count())
         {
-            printf("stdgpu::detail::unordered_base : Linked entry out of range : %d -> %ld\n", i, linked_entry);
+            printf("stdgpu::detail::unordered_base : Linked entry out of range : %d -> %d\n", i, linked_entry);
             return false;
         }
 


### PR DESCRIPTION
In device code, we use `printf` to display warnings and errors to the user. However, as indices might be 32-bit or 64-bit depending on the configuration, this may lead to warnings at compile time. Since CUDA only supports `printf` in device code, suppress the warnings for now.

In the future, the new `std::format` (C++20) will solve the issue. However, we need to wait until the support is sufficient.