### PR TITLE
atomic: Fix missing template type names in the function definitions

### DIFF
--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -110,7 +110,7 @@ atomic<T>::compare_exchange_strong(T& expected,
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_add(const T arg)
 {
@@ -119,7 +119,7 @@ atomic<T>::fetch_add(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_sub(const T arg)
 {
@@ -128,7 +128,7 @@ atomic<T>::fetch_sub(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_and(const T arg)
 {
@@ -137,7 +137,7 @@ atomic<T>::fetch_and(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_or(const T arg)
 {
@@ -146,7 +146,7 @@ atomic<T>::fetch_or(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_xor(const T arg)
 {
@@ -155,7 +155,7 @@ atomic<T>::fetch_xor(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_min(const T arg)
 {
@@ -164,7 +164,7 @@ atomic<T>::fetch_min(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_max(const T arg)
 {
@@ -173,7 +173,7 @@ atomic<T>::fetch_max(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_inc_mod(const T arg)
 {
@@ -182,7 +182,7 @@ atomic<T>::fetch_inc_mod(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_dec_mod(const T arg)
 {
@@ -191,7 +191,7 @@ atomic<T>::fetch_dec_mod(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator++()
 {
@@ -200,7 +200,7 @@ atomic<T>::operator++()
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator++(int)
 {
@@ -209,7 +209,7 @@ atomic<T>::operator++(int)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator--()
 {
@@ -218,7 +218,7 @@ atomic<T>::operator--()
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator--(int)
 {
@@ -227,7 +227,7 @@ atomic<T>::operator--(int)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator+=(const T arg)
 {
@@ -236,7 +236,7 @@ atomic<T>::operator+=(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator-=(const T arg)
 {
@@ -245,7 +245,7 @@ atomic<T>::operator-=(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator&=(const T arg)
 {
@@ -254,7 +254,7 @@ atomic<T>::operator&=(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator|=(const T arg)
 {
@@ -263,7 +263,7 @@ atomic<T>::operator|=(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator^=(const T arg)
 {
@@ -347,7 +347,7 @@ atomic_ref<T>::compare_exchange_strong(T& expected,
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_add(const T arg)
 {
@@ -356,7 +356,7 @@ atomic_ref<T>::fetch_add(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_sub(const T arg)
 {
@@ -365,7 +365,7 @@ atomic_ref<T>::fetch_sub(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_and(const T arg)
 {
@@ -374,7 +374,7 @@ atomic_ref<T>::fetch_and(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_or(const T arg)
 {
@@ -383,7 +383,7 @@ atomic_ref<T>::fetch_or(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_xor(const T arg)
 {
@@ -392,7 +392,7 @@ atomic_ref<T>::fetch_xor(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_min(const T arg)
 {
@@ -401,7 +401,7 @@ atomic_ref<T>::fetch_min(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_max(const T arg)
 {
@@ -410,7 +410,7 @@ atomic_ref<T>::fetch_max(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_inc_mod(const T arg)
 {
@@ -419,7 +419,7 @@ atomic_ref<T>::fetch_inc_mod(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_dec_mod(const T arg)
 {
@@ -428,7 +428,7 @@ atomic_ref<T>::fetch_dec_mod(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator++()
 {
@@ -437,7 +437,7 @@ atomic_ref<T>::operator++()
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator++(int)
 {
@@ -446,7 +446,7 @@ atomic_ref<T>::operator++(int)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator--()
 {
@@ -455,7 +455,7 @@ atomic_ref<T>::operator--()
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator--(int)
 {
@@ -464,7 +464,7 @@ atomic_ref<T>::operator--(int)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator+=(const T arg)
 {
@@ -473,7 +473,7 @@ atomic_ref<T>::operator+=(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator-=(const T arg)
 {
@@ -482,7 +482,7 @@ atomic_ref<T>::operator-=(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator&=(const T arg)
 {
@@ -491,7 +491,7 @@ atomic_ref<T>::operator&=(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator|=(const T arg)
 {
@@ -500,7 +500,7 @@ atomic_ref<T>::operator|=(const T arg)
 
 
 template <typename T>
-template <typename, typename>
+template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator^=(const T arg)
 {


### PR DESCRIPTION
The arithmetic and bit operations of `atomic` and `atomic_ref` use SFINAE to properly disable these operations for non-arithmetic types. Since the helper template types of these member functions are only used for SFINAE, their names were ignored in the member function definitions. Although this seems to be valid C++ code, some compilers may have problems to deduce the types. Also mention the template type names in the member function definitions to fix this issue.