### PR TITLE
scripts: Improve console output and internal structure

### DIFF
--- a/scripts/build_debug.sh
+++ b/scripts/build_debug.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
 
 # Build project
+cmake -E cmake_echo_color --blue ">>>>> Build stdgpu project"
 cmake --build build --config Debug --parallel 13

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
 
 # Build project
+cmake -E cmake_echo_color --blue ">>>>> Build stdgpu project"
 cmake --build build --config Release --parallel 13

--- a/scripts/create_documentation.sh
+++ b/scripts/create_documentation.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
 
 # Create and install documentation
+cmake -E cmake_echo_color --blue ">>>>> Create documentation"
 cmake --build build --target stdgpu_doc

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
 
 # Install project
+cmake -E cmake_echo_color --blue ">>>>> Install stdgpu project"
 cmake -DCOMPONENT="stdgpu" -P build/cmake_install.cmake

--- a/scripts/run_tests_debug.sh
+++ b/scripts/run_tests_debug.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
 
 # Run tests
+cmake -E cmake_echo_color --blue ">>>>> Run tests"
 cmake -E chdir build ctest -V -C Debug

--- a/scripts/run_tests_release.sh
+++ b/scripts/run_tests_release.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
 
 # Run tests
+cmake -E cmake_echo_color --blue ">>>>> Run tests"
 cmake -E chdir build ctest -V -C Release

--- a/scripts/setup_debug.sh
+++ b/scripts/setup_debug.sh
@@ -1,21 +1,14 @@
 #!/bin/sh
+set -e
 
-# Delete directories to allow a clean build
-cmake -E cmake_echo_color --red ">>>>> Delete directories from old build"
-cmake -E remove_directory build
+# Create build directory
+sh scripts/utils/create_empty_directory.sh build
 
-# Create directories
-cmake -E cmake_echo_color --green ">>>>> Create directories from current build"
-cmake -E make_directory build
-
-# Invoke CMake on project
-cmake -E cmake_echo_color --blue ">>>>> Build stdgpu project"
-cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=bin
-
+# Configure project
+sh scripts/utils/configure_debug.sh
 
 # Build project
 sh scripts/build_debug.sh
-
 
 # Run tests
 sh scripts/run_tests_debug.sh

--- a/scripts/setup_release.sh
+++ b/scripts/setup_release.sh
@@ -1,21 +1,14 @@
 #!/bin/sh
+set -e
 
-# Delete directories to allow a clean build
-cmake -E cmake_echo_color --red ">>>>> Delete directories from old build"
-cmake -E remove_directory build
+# Create build directory
+sh scripts/utils/create_empty_directory.sh build
 
-# Create directories
-cmake -E cmake_echo_color --green ">>>>> Create directories from current build"
-cmake -E make_directory build
-
-# Invoke CMake on project
-cmake -E cmake_echo_color --blue ">>>>> Build stdgpu project"
-cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=bin
-
+# Configure project
+sh scripts/utils/configure_release.sh
 
 # Build project
 sh scripts/build_release.sh
-
 
 # Run tests
 sh scripts/run_tests_release.sh

--- a/scripts/utils/configure_debug.sh
+++ b/scripts/utils/configure_debug.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+# Configure project
+cmake -E cmake_echo_color --blue ">>>>> Configure stdgpu project"
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=bin $*

--- a/scripts/utils/configure_release.sh
+++ b/scripts/utils/configure_release.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+# Configure project
+cmake -E cmake_echo_color --blue ">>>>> Configure stdgpu project"
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=bin $*

--- a/scripts/utils/create_empty_directory.sh
+++ b/scripts/utils/create_empty_directory.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Check number of input parameters
+if [ "$#" -ne 1 ]; then
+    cmake -E echo "create_empty_directory: Expected 1 parameter, but received $# parameters"
+    exit 1
+fi
+
+# Delete old directory
+cmake -E cmake_echo_color --red ">>>>> Delete directory \"$1\" from old build"
+cmake -E remove_directory $1
+
+# Create new directory
+cmake -E cmake_echo_color --green ">>>>> Create directory \"$1\" for new build"
+cmake -E make_directory $1


### PR DESCRIPTION
Previously, some scripts print an informative message on the console while others just execute the desired action. Add the missing prints and also tell all the scripts to exit early if a command fails. Furthermore, refactor common subscripts into a `utils` directory. This improves the overall structure and consistency.