### PR TITLE
General: Add Azure Pipelines CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,60 @@
+trigger:
+- master
+
+jobs:
+- job:
+  displayName: Linux
+  pool:
+    vmImage: 'ubuntu-18.04'
+
+  strategy:
+    matrix:
+      OpenMP Debug:
+        BuildType: debug
+      OpenMP Release:
+        BuildType: release
+
+  steps:
+    - task: Bash@3
+      displayName: Install CMake 3.13+
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          # Install CMake 3.13+ from official Kitware repository (see https://apt.kitware.com/)
+          sudo apt update
+          sudo rm /usr/local/bin/ccmake* /usr/local/bin/cmake* /usr/local/bin/cpack* /usr/local/bin/ctest*
+          sudo apt install apt-transport-https ca-certificates gnupg software-properties-common wget
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
+          sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+          sudo apt update
+          sudo apt install cmake
+
+    - task: Bash@3
+      displayName: Build stdgpu
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/ci/openmp_$(BuildType).sh
+
+- job:
+  displayName: Windows
+  pool:
+    vmImage: 'windows-2019'
+
+  strategy:
+    matrix:
+      OpenMP Debug:
+        BuildType: debug
+      OpenMP Release:
+        BuildType: release
+
+  steps:
+    - task: Bash@3
+      displayName: Build stdgpu
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/ci/openmp_$(BuildType).sh

--- a/scripts/ci/openmp_debug.sh
+++ b/scripts/ci/openmp_debug.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Create build directory
+sh scripts/utils/create_empty_directory.sh build
+
+# Download external dependencies
+sh scripts/utils/download_dependencies.sh
+
+# Configure project
+sh scripts/utils/configure_debug.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -Dthrust_ROOT=external/thrust
+
+# Build project
+sh scripts/build_debug.sh
+
+# Run tests
+sh scripts/run_tests_debug.sh

--- a/scripts/ci/openmp_release.sh
+++ b/scripts/ci/openmp_release.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Create build directory
+sh scripts/utils/create_empty_directory.sh build
+
+# Download external dependencies
+sh scripts/utils/download_dependencies.sh
+
+# Configure project
+sh scripts/utils/configure_release.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -Dthrust_ROOT=external/thrust
+
+# Build project
+sh scripts/build_release.sh
+
+# Run tests
+sh scripts/run_tests_release.sh

--- a/scripts/utils/download_dependencies.sh
+++ b/scripts/utils/download_dependencies.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Create external directory
+cmake -E cmake_echo_color --blue ">>>>> Download external dependencies"
+sh scripts/utils/create_empty_directory.sh external
+
+# Download thrust
+sh scripts/utils/download_thrust.sh

--- a/scripts/utils/download_thrust.sh
+++ b/scripts/utils/download_thrust.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+cmake -E cmake_echo_color --blue ">>>>> Download thrust"
+cmake -E chdir external git clone https://github.com/thrust/thrust


### PR DESCRIPTION
Due to the recent enhancements and especially the recently added OpenMP backend (#32), we can integrate and run CI to verify code changes. Setup Azure Pipelines CI for this purpose.