### PR TITLE
CI: Improve structure of scripts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,15 +3,15 @@ trigger:
 
 jobs:
 - job:
-  displayName: Linux
+  displayName: Linux OpenMP
   pool:
     vmImage: 'ubuntu-18.04'
 
   strategy:
     matrix:
-      OpenMP Debug:
+      Debug:
         BuildType: debug
-      OpenMP Release:
+      Release:
         BuildType: release
 
   steps:
@@ -21,14 +21,7 @@ jobs:
         targetType: 'inline'
         script: |
           set -e
-          # Install CMake 3.13+ from official Kitware repository (see https://apt.kitware.com/)
-          sudo apt update
-          sudo rm /usr/local/bin/ccmake* /usr/local/bin/cmake* /usr/local/bin/cpack* /usr/local/bin/ctest*
-          sudo apt install apt-transport-https ca-certificates gnupg software-properties-common wget
-          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
-          sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
-          sudo apt update
-          sudo apt install cmake
+          sh scripts/utils/install_cmake_ubuntu1804.sh
 
     - task: Bash@3
       displayName: Build stdgpu
@@ -38,16 +31,24 @@ jobs:
             set -e
             sh scripts/ci/openmp_$(BuildType).sh
 
+    - task: Bash@3
+      displayName: Run tests
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/run_tests_$(BuildType).sh
+
 - job:
-  displayName: Windows
+  displayName: Windows OpenMP
   pool:
     vmImage: 'windows-2019'
 
   strategy:
     matrix:
-      OpenMP Debug:
+      Debug:
         BuildType: debug
-      OpenMP Release:
+      Release:
         BuildType: release
 
   steps:
@@ -58,3 +59,11 @@ jobs:
         script: |
             set -e
             sh scripts/ci/openmp_$(BuildType).sh
+
+    - task: Bash@3
+      displayName: Run tests
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/run_tests_$(BuildType).sh

--- a/scripts/ci/openmp_debug.sh
+++ b/scripts/ci/openmp_debug.sh
@@ -12,6 +12,3 @@ sh scripts/utils/configure_debug.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -Dthr
 
 # Build project
 sh scripts/build_debug.sh
-
-# Run tests
-sh scripts/run_tests_debug.sh

--- a/scripts/ci/openmp_release.sh
+++ b/scripts/ci/openmp_release.sh
@@ -12,6 +12,3 @@ sh scripts/utils/configure_release.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -Dt
 
 # Build project
 sh scripts/build_release.sh
-
-# Run tests
-sh scripts/run_tests_release.sh

--- a/scripts/utils/install_cmake_ubuntu1804.sh
+++ b/scripts/utils/install_cmake_ubuntu1804.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Install CMake 3.13+ from official Kitware repository (see https://apt.kitware.com/)
+sudo apt-get update
+sudo rm /usr/local/bin/ccmake* /usr/local/bin/cmake* /usr/local/bin/cpack* /usr/local/bin/ctest*
+sudo apt-get install apt-transport-https ca-certificates gnupg software-properties-common wget
+wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
+sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+sudo apt-get update
+sudo apt-get install cmake


### PR DESCRIPTION
The steps to install a recent CMake version are backed into the CI configuration file. Furthermore, the execution of the unit tests is included into the build step. Split out both into a dedicated file/step to improve the structure. Furthermore, use `apt-get` instead of `apt` to improve stability and fix a warning.