### PR TITLE
General: Add Clang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To compile the library, please make sure to fulfill the build requirements and e
 The following components (or newer versions) are required to build the library:
 
 * C++14 compiler:
-    * Ubuntu 18.04: GCC 7: `sudo apt install build-essential`
+    * Ubuntu 18.04: GCC 7: `sudo apt install build-essential` or Clang: `sudo apt install clang`
     * Windows: Visual Studio 2019
 * CMake 3.13: `https://apt.kitware.com/`
 * Doxygen 1.8.13 (optional): `sudo apt install doxygen`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,9 +9,21 @@ jobs:
 
   strategy:
     matrix:
-      Debug:
+      GCC Debug:
+        CC: gcc-7
+        CXX: g++-7
         BuildType: debug
-      Release:
+      GCC Release:
+        CC: gcc-7
+        CXX: g++-7
+        BuildType: release
+      Clang Debug:
+        CC: clang-6.0
+        CXX: clang++-6.0
+        BuildType: debug
+      Clang Release:
+        CC: clang-6.0
+        CXX: clang++-6.0
         BuildType: release
 
   steps:
@@ -22,6 +34,14 @@ jobs:
         script: |
           set -e
           sh scripts/utils/install_cmake_ubuntu1804.sh
+
+    - task: Bash@3
+      displayName: Set C/C++ compiler
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/set_cxx_compiler_ubuntu.sh $(CC) $(CXX)
 
     - task: Bash@3
       displayName: Build stdgpu
@@ -46,9 +66,9 @@ jobs:
 
   strategy:
     matrix:
-      Debug:
+      MSVC Debug:
         BuildType: debug
-      Release:
+      MSVC Release:
         BuildType: release
 
   steps:

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -18,7 +18,7 @@ To compile the library, please make sure to fulfill the build requirements and e
 The following components (or newer versions) are required to build the library:
 
 - C++14 compiler:
-    - Ubuntu 18.04: GCC 7: `sudo apt install build-essential`
+    - Ubuntu 18.04: GCC 7: `sudo apt install build-essential` or Clang: `sudo apt install clang`
     - Windows: Visual Studio 2019
 - CUDA 10.0: `https://developer.nvidia.com/cuda-downloads`
 - CMake 3.13: `https://apt.kitware.com/`

--- a/scripts/utils/set_cxx_compiler_ubuntu.sh
+++ b/scripts/utils/set_cxx_compiler_ubuntu.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Check number of input parameters
+if [ "$#" -ne 2 ]; then
+    cmake -E echo "set_cxx_compiler_ubuntu: Expected 2 parameters, but received $# parameters"
+    exit 1
+fi
+
+# Set C compiler
+sudo update-alternatives --install /usr/bin/cc cc /usr/bin/$1 100
+sudo update-alternatives --set cc /usr/bin/$1
+
+# Set C++ compiler
+sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/$2 100
+sudo update-alternatives --set c++ /usr/bin/$2

--- a/src/stdgpu/attribute.h
+++ b/src/stdgpu/attribute.h
@@ -44,7 +44,7 @@ namespace stdgpu
  * \def STDGPU_MAYBE_UNUSED
  * \brief Suppresses compiler warnings caused by variables that are or might be unused
  */
-#if STDGPU_HAS_CPP_ATTRIBUTE(maybe_unused)
+#if STDGPU_HAS_CPP_ATTRIBUTE(maybe_unused) && (STDGPU_HAS_CXX_17 || STDGPU_HOST_COMPILER != STDGPU_HOST_COMPILER_CLANG) // Clang outputs a warning if C++17 is not present
     #define STDGPU_MAYBE_UNUSED [[maybe_unused]]
 #elif STDGPU_HAS_CPP_ATTRIBUTE(gnu::unused)
     #define STDGPU_MAYBE_UNUSED [[gnu::unused]]
@@ -59,7 +59,7 @@ namespace stdgpu
  * \def STDGPU_FALLTHROUGH
  * \brief Suppresses compiler warnings caused by implicit fallthrough
  */
-#if STDGPU_HAS_CPP_ATTRIBUTE(fallthrough)
+#if STDGPU_HAS_CPP_ATTRIBUTE(fallthrough) && (STDGPU_HAS_CXX_17 || STDGPU_HOST_COMPILER != STDGPU_HOST_COMPILER_CLANG)  // Clang outputs a warning if C++17 is not present
     #define STDGPU_FALLTHROUGH [[fallthrough]]
 #elif STDGPU_HAS_CPP_ATTRIBUTE(gnu::fallthrough)
     #define STDGPU_FALLTHROUGH [[gnu::fallthrough]]
@@ -74,7 +74,7 @@ namespace stdgpu
  * \def STDGPU_NODISCARD
  * \brief Encourages compiler warnings or errors if the function return value is unused
  */
-#if STDGPU_HAS_CPP_ATTRIBUTE(nodiscard)
+#if STDGPU_HAS_CPP_ATTRIBUTE(nodiscard) && (STDGPU_HAS_CXX_17 || STDGPU_HOST_COMPILER != STDGPU_HOST_COMPILER_CLANG)    // Clang outputs a warning if C++17 is not present
     #define STDGPU_NODISCARD [[nodiscard]]
 #elif STDGPU_HAS_CPP_ATTRIBUTE(gnu::warn_unused_result)
     #define STDGPU_NODISCARD [[gnu::warn_unused_result]]

--- a/src/stdgpu/cstddef.h
+++ b/src/stdgpu/cstddef.h
@@ -45,7 +45,7 @@ using index64_t = std::ptrdiff_t;       /**< std::ptrdiff_t */
  * \def STDGPU_FUNC
  * \brief A macro for getting the name of the function where this macro is expanded
  */
-#if STDGPU_HOST_COMPILER == STDGPU_HOST_COMPILER_GCC
+#if STDGPU_HOST_COMPILER == STDGPU_HOST_COMPILER_GCC || STDGPU_HOST_COMPILER == STDGPU_HOST_COMPILER_CLANG
     #define STDGPU_FUNC __PRETTY_FUNCTION__
 #elif STDGPU_HOST_COMPILER == STDGPU_HOST_COMPILER_MSVC
     #define STDGPU_FUNC __FUNCSIG__

--- a/src/stdgpu/platform.h
+++ b/src/stdgpu/platform.h
@@ -57,7 +57,7 @@ namespace stdgpu
  * \def STDGPU_HOST_COMPILER
  * \brief The host compiler
  */
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__)
     #define STDGPU_HOST_COMPILER STDGPU_HOST_COMPILER_GCC
 #elif defined(__clang__)
     #define STDGPU_HOST_COMPILER STDGPU_HOST_COMPILER_CLANG
@@ -75,6 +75,18 @@ namespace stdgpu
     #define STDGPU_DEVICE_COMPILER STDGPU_DEVICE_COMPILER_NVCC
 #else
     #define STDGPU_DEVICE_COMPILER STDGPU_DEVICE_COMPILER_UNKNOWN
+#endif
+
+
+
+/**
+ * \def STDGPU_HAS_CXX_17
+ * \brief Indicator of C++17 availability
+ */
+#if defined(__cplusplus) && __cplusplus >= 201703L
+    #define STDGPU_HAS_CXX_17 1
+#else
+    #define STDGPU_HAS_CXX_17 0
 #endif
 
 


### PR DESCRIPTION
Most of the platform-specific functions already had reasonable fallbacks for any non-tested compiler such as Clang. Thus, the project already compiles fine with Clang although some warnings related to C++17 are still present. Fix the platform detection and warnings to provide full Clang support. Furthermore, add it to the CI tests.