### PR TITLE
CI: Split project building into separate step

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,12 +44,20 @@ jobs:
           sh scripts/utils/set_cxx_compiler_ubuntu.sh $(CC) $(CXX)
 
     - task: Bash@3
-      displayName: Build stdgpu
+      displayName: Configure project
       inputs:
         targetType: 'inline'
         script: |
             set -e
-            sh scripts/ci/openmp_$(BuildType).sh
+            sh scripts/ci/configure_openmp_$(BuildType).sh
+
+    - task: Bash@3
+      displayName: Build project
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/build_$(BuildType).sh
 
     - task: Bash@3
       displayName: Run tests
@@ -73,12 +81,20 @@ jobs:
 
   steps:
     - task: Bash@3
-      displayName: Build stdgpu
+      displayName: Configure project
       inputs:
         targetType: 'inline'
         script: |
             set -e
-            sh scripts/ci/openmp_$(BuildType).sh
+            sh scripts/ci/configure_openmp_$(BuildType).sh
+
+    - task: Bash@3
+      displayName: Build project
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/build_$(BuildType).sh
 
     - task: Bash@3
       displayName: Run tests

--- a/scripts/ci/configure_openmp_debug.sh
+++ b/scripts/ci/configure_openmp_debug.sh
@@ -8,7 +8,4 @@ sh scripts/utils/create_empty_directory.sh build
 sh scripts/utils/download_dependencies.sh
 
 # Configure project
-sh scripts/utils/configure_release.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -Dthrust_ROOT=external/thrust
-
-# Build project
-sh scripts/build_release.sh
+sh scripts/utils/configure_debug.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -Dthrust_ROOT=external/thrust

--- a/scripts/ci/configure_openmp_release.sh
+++ b/scripts/ci/configure_openmp_release.sh
@@ -8,7 +8,4 @@ sh scripts/utils/create_empty_directory.sh build
 sh scripts/utils/download_dependencies.sh
 
 # Configure project
-sh scripts/utils/configure_debug.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -Dthrust_ROOT=external/thrust
-
-# Build project
-sh scripts/build_debug.sh
+sh scripts/utils/configure_release.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -Dthrust_ROOT=external/thrust


### PR DESCRIPTION
The CI scripts were refactored in #37. Further refine them by separating the configuration from the build step.