### PR TITLE
vector: Add at(), shrink_to_fit() and remove CopyAssignable requirement from type T

### DIFF
--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -30,16 +30,16 @@ namespace stdgpu
 
 template <typename T>
 vector<T>
-vector<T>::createDeviceObject(const index_t& size)
+vector<T>::createDeviceObject(const index_t& capacity)
 {
-    STDGPU_EXPECTS(size > 0);
+    STDGPU_EXPECTS(capacity > 0);
 
     vector<T> result;
-    result._data     = createDeviceArray<T>(size, T());
-    result._locks    = mutex_array::createDeviceObject(size);
-    result._occupied = bitset::createDeviceObject(size);
+    result._data     = createDeviceArray<T>(capacity, T());
+    result._locks    = mutex_array::createDeviceObject(capacity);
+    result._occupied = bitset::createDeviceObject(capacity);
     result._size     = atomic<int>::createDeviceObject();
-    result._capacity = size;
+    result._capacity = capacity;
 
     return result;
 }
@@ -161,7 +161,6 @@ vector<T>::push_back(const T& element)
     else
     {
         printf("stdgpu::vector::push_back : Index out of bounds: %d not in [0, %d]\n", push_position, _capacity - 1);
-        pushed = false;
     }
 
     return pushed;
@@ -213,7 +212,6 @@ vector<T>::pop_back()
     else
     {
         printf("stdgpu::vector::pop_back : Index out of bounds: %d not in [0, %d]\n", pop_position, _capacity - 1);
-        popped = thrust::make_pair(T(), false);
     }
 
     return popped;

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -58,9 +58,29 @@ vector<T>::destroyDeviceObject(vector<T>& device_object)
 
 template <typename T>
 inline STDGPU_DEVICE_ONLY typename vector<T>::reference
+vector<T>::at(const vector<T>::index_type n)
+{
+    return const_cast<vector<T>::reference>(static_cast<const vector<T>*>(this)->at(n));
+}
+
+
+template <typename T>
+inline STDGPU_DEVICE_ONLY typename vector<T>::const_reference
+vector<T>::at(const vector<T>::index_type n) const
+{
+    STDGPU_EXPECTS(0 <= n);
+    STDGPU_EXPECTS(n < size());
+    STDGPU_EXPECTS(occupied(n));
+
+    return _data[n];
+}
+
+
+template <typename T>
+inline STDGPU_DEVICE_ONLY typename vector<T>::reference
 vector<T>::operator[](const vector<T>::index_type n)
 {
-    return const_cast<vector<T>::reference>(static_cast<const vector<T>*>(this)->operator[](n));
+    return at(n);
 }
 
 
@@ -68,11 +88,7 @@ template <typename T>
 inline STDGPU_DEVICE_ONLY typename vector<T>::const_reference
 vector<T>::operator[](const vector<T>::index_type n) const
 {
-    STDGPU_EXPECTS(0 <= n);
-    STDGPU_EXPECTS(n < size());
-    STDGPU_EXPECTS(occupied(n));
-
-    return _data[n];
+    return at(n);
 }
 
 
@@ -270,6 +286,14 @@ inline STDGPU_HOST_DEVICE index_t
 vector<T>::capacity() const
 {
     return _capacity;
+}
+
+
+template <typename T>
+inline void
+vector<T>::shrink_to_fit()
+{
+    // Reject request for performance reasons
 }
 
 

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -143,8 +143,8 @@ vector<T>::push_back(const T& element)
 
                 if (!occupied(push_position))
                 {
-                    _data[push_position]    = element;
-                    bool was_occupied       = _occupied.set(push_position);
+                    default_allocator_traits::construct(&(_data[push_position]), element); //_data[push_position] = element;
+                    bool was_occupied = _occupied.set(push_position);
                     pushed = true;
 
                     if (was_occupied)
@@ -193,10 +193,10 @@ vector<T>::pop_back()
 
                 if (occupied(pop_position))
                 {
-                    bool was_occupied       = _occupied.reset(pop_position);
-                    T element               = _data[pop_position];
-                    _data[pop_position]     = T();
-                    popped = thrust::make_pair(element, true);
+                    bool was_occupied = _occupied.reset(pop_position);
+                    T element = _data[pop_position];
+                    default_allocator_traits::construct(&(_data[pop_position]), T()); //_data[pop_position] = T();
+                    default_allocator_traits::construct(&popped, element, true); //popped = thrust::make_pair(element, true);
 
                     if (!was_occupied)
                     {

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -102,6 +102,24 @@ class vector
          * \pre 0 <= n < size()
          */
         STDGPU_DEVICE_ONLY reference
+        at(const index_type n);
+
+        /**
+         * \brief Reads the value at position n
+         * \param[in] n The position
+         * \return The value at this position
+         * \pre 0 <= n < size()
+         */
+        STDGPU_DEVICE_ONLY const_reference
+        at(const index_type n) const;
+
+        /**
+         * \brief Reads the value at position n
+         * \param[in] n The position
+         * \return The value at this position
+         * \pre 0 <= n < size()
+         */
+        STDGPU_DEVICE_ONLY reference
         operator[](const index_type n);
 
         /**
@@ -199,6 +217,13 @@ class vector
          */
         STDGPU_HOST_DEVICE index_t
         capacity() const;
+
+        /**
+         * \brief Requests to shrink the capacity to the current size
+         * \note This is non-binding and may not have any effect
+         */
+        void
+        shrink_to_fit();
 
         /**
          * \brief Returns a pointer to the underlying data

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -55,7 +55,7 @@ namespace stdgpu
  *  - Manual allocation and destruction of container required
  *  - max_size and capacity limited to initially allocated size
  *  - No guaranteed valid state when reaching capacity limit
- *  - Additional non-standard capacity functions full(), capacity(), and valid()
+ *  - Additional non-standard capacity functions full() and valid()
  *  - Some member functions missing
  */
 template <typename T>
@@ -75,11 +75,12 @@ class vector
 
         /**
          * \brief Creates an object of this class on the GPU (device)
-         * \param[in] size The size of managed array
+         * \param[in] capacity The capacity of the object
          * \return A newly created object of this class allocated on the GPU (device)
+         * \pre capacity > 0
          */
         static vector<T>
-        createDeviceObject(const index_t& size);
+        createDeviceObject(const index_t& capacity);
 
         /**
          * \brief Destroys the given object of this class on the GPU (device)
@@ -193,8 +194,8 @@ class vector
         max_size() const;
 
         /**
-         * \brief Returns the _capacity
-         * \return The _capacity
+         * \brief Returns the capacity
+         * \return The capacity
          */
         STDGPU_HOST_DEVICE index_t
         capacity() const;

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -636,6 +636,46 @@ TEST_F(stdgpu_vector, simultaneous_push_back_and_pop_back)
 }
 
 
+struct at_non_const_vector
+{
+    stdgpu::vector<int> pool;
+
+    at_non_const_vector(stdgpu::vector<int> pool)
+        : pool(pool)
+    {
+
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const int x)
+    {
+        pool.at(x) = x * x;
+    }
+};
+
+
+TEST_F(stdgpu_vector, at_non_const)
+{
+    const stdgpu::index_t N = 100000;
+
+    stdgpu::vector<int> pool = stdgpu::vector<int>::createDeviceObject(N);
+
+    fill_vector(pool);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     at_non_const_vector(pool));
+
+    int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(host_numbers[i], i * i);
+    }
+
+    stdgpu::vector<int>::destroyDeviceObject(pool);
+    destroyHostArray<int>(host_numbers);
+}
+
+
 struct access_operator_non_const_vector
 {
     stdgpu::vector<int> pool;
@@ -673,6 +713,75 @@ TEST_F(stdgpu_vector, access_operator_non_const)
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+}
+
+
+TEST_F(stdgpu_vector, shrink_to_fit_empty)
+{
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::vector<int> pool = stdgpu::vector<int>::createDeviceObject(N);
+
+    ASSERT_EQ(pool.size(), 0);
+    ASSERT_EQ(pool.capacity(), N);
+    ASSERT_TRUE(pool.valid());
+
+    pool.shrink_to_fit();
+
+    EXPECT_EQ(pool.size(), 0);
+    EXPECT_TRUE(pool.capacity() == 0 || pool.capacity() == N); // Capacity may have changed or not
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::vector<int>::destroyDeviceObject(pool);
+}
+
+
+TEST_F(stdgpu_vector, shrink_to_fit_full)
+{
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::vector<int> pool = stdgpu::vector<int>::createDeviceObject(N);
+
+    fill_vector(pool);
+
+    ASSERT_EQ(pool.size(), N);
+    ASSERT_EQ(pool.capacity(), N);
+    ASSERT_TRUE(pool.valid());
+
+    pool.shrink_to_fit();
+
+    EXPECT_EQ(pool.size(), N);
+    EXPECT_EQ(pool.capacity(), N);
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::vector<int>::destroyDeviceObject(pool);
+}
+
+
+TEST_F(stdgpu_vector, shrink_to_fit)
+{
+    const stdgpu::index_t N            = 10000;
+    const stdgpu::index_t N_pop        = 100;
+    const stdgpu::index_t N_remaining  = N - N_pop;
+
+    stdgpu::vector<int> pool = stdgpu::vector<int>::createDeviceObject(N);
+
+    fill_vector(pool);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
+                     pop_back_vector<int>(pool));
+
+    ASSERT_EQ(pool.size(), N_remaining);
+    ASSERT_EQ(pool.capacity(), N);
+    ASSERT_TRUE(pool.valid());
+
+    pool.shrink_to_fit();
+
+    EXPECT_EQ(pool.size(), N_remaining);
+    EXPECT_TRUE(pool.capacity() == N_remaining || pool.capacity() == N); // Capacity may have changed or not
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::vector<int>::destroyDeviceObject(pool);
 }
 
 

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -43,54 +43,57 @@ class stdgpu_vector : public ::testing::Test
 };
 
 
+template <typename T>
 struct pop_back_vector
 {
-    stdgpu::vector<int> pool;
+    stdgpu::vector<T> pool;
 
-    pop_back_vector(stdgpu::vector<int> pool)
+    pop_back_vector(stdgpu::vector<T> pool)
         : pool(pool)
     {
 
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(STDGPU_MAYBE_UNUSED const int x)
+    operator()(STDGPU_MAYBE_UNUSED const T x)
     {
         pool.pop_back();
     }
 };
 
 
+template <typename T>
 struct push_back_vector
 {
-    stdgpu::vector<int> pool;
+    stdgpu::vector<T> pool;
 
-    push_back_vector(stdgpu::vector<int> pool)
+    push_back_vector(stdgpu::vector<T> pool)
         : pool(pool)
     {
 
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const T x)
     {
         pool.push_back(x);
     }
 };
 
 
+template <typename T>
 struct emplace_back_vector
 {
-    stdgpu::vector<int> pool;
+    stdgpu::vector<T> pool;
 
-    emplace_back_vector(stdgpu::vector<int> pool)
+    emplace_back_vector(stdgpu::vector<T> pool)
         : pool(pool)
     {
 
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const T x)
     {
         pool.emplace_back(x);
     }
@@ -102,7 +105,7 @@ fill_vector(stdgpu::vector<int> pool)
 {
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(pool.capacity() + init),
-                     push_back_vector(pool));
+                     push_back_vector<int>(pool));
 
     thrust::sort(stdgpu::device_begin(pool), stdgpu::device_end(pool));
 
@@ -124,7 +127,7 @@ TEST_F(stdgpu_vector, pop_back_some)
     fill_vector(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector(pool));
+                     pop_back_vector<int>(pool));
 
     ASSERT_EQ(pool.size(), N_remaining);
     ASSERT_FALSE(pool.empty());
@@ -156,7 +159,7 @@ TEST_F(stdgpu_vector, pop_back_all)
     fill_vector(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector(pool));
+                     pop_back_vector<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -184,7 +187,7 @@ TEST_F(stdgpu_vector, pop_back_too_many)
     fill_vector(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector(pool));
+                     pop_back_vector<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -214,11 +217,11 @@ TEST_F(stdgpu_vector, push_back_some)
     fill_vector(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector(pool));
+                     pop_back_vector<int>(pool));
 
     const stdgpu::index_t init = 1 + N_remaining;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     push_back_vector(pool));
+                     push_back_vector<int>(pool));
 
 
     thrust::sort(stdgpu::device_begin(pool), stdgpu::device_end(pool));
@@ -250,11 +253,11 @@ TEST_F(stdgpu_vector, push_back_all)
     fill_vector(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector(pool));
+                     pop_back_vector<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     push_back_vector(pool));
+                     push_back_vector<int>(pool));
 
 
     thrust::sort(stdgpu::device_begin(pool), stdgpu::device_end(pool));
@@ -286,11 +289,11 @@ TEST_F(stdgpu_vector, push_back_too_many)
     fill_vector(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector(pool));
+                     pop_back_vector<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     push_back_vector(pool));
+                     push_back_vector<int>(pool));
 
 
     ASSERT_EQ(pool.size(), N);
@@ -323,11 +326,11 @@ TEST_F(stdgpu_vector, emplace_back_some)
     fill_vector(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector(pool));
+                     pop_back_vector<int>(pool));
 
     const stdgpu::index_t init = 1 + N_remaining;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     push_back_vector(pool));
+                     push_back_vector<int>(pool));
 
 
     thrust::sort(stdgpu::device_begin(pool), stdgpu::device_end(pool));
@@ -359,11 +362,11 @@ TEST_F(stdgpu_vector, emplace_back_all)
     fill_vector(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector(pool));
+                     pop_back_vector<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     emplace_back_vector(pool));
+                     emplace_back_vector<int>(pool));
 
 
     thrust::sort(stdgpu::device_begin(pool), stdgpu::device_end(pool));
@@ -395,11 +398,11 @@ TEST_F(stdgpu_vector, emplace_back_too_many)
     fill_vector(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector(pool));
+                     pop_back_vector<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     emplace_back_vector(pool));
+                     emplace_back_vector<int>(pool));
 
 
     ASSERT_EQ(pool.size(), N);
@@ -441,13 +444,14 @@ TEST_F(stdgpu_vector, clear)
 }
 
 
+template <typename T>
 struct simultaneous_push_back_and_pop_back_vector
 {
-    stdgpu::vector<int> pool;
-    stdgpu::vector<int> pool_validation;
+    stdgpu::vector<T> pool;
+    stdgpu::vector<T> pool_validation;
 
-    simultaneous_push_back_and_pop_back_vector(stdgpu::vector<int> pool,
-                                               stdgpu::vector<int> pool_validation)
+    simultaneous_push_back_and_pop_back_vector(stdgpu::vector<T> pool,
+                                               stdgpu::vector<T> pool_validation)
         : pool(pool),
           pool_validation(pool_validation)
     {
@@ -455,11 +459,11 @@ struct simultaneous_push_back_and_pop_back_vector
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const T x)
     {
         pool.push_back(x);
 
-        thrust::pair<int, bool> popped = pool.pop_back();
+        thrust::pair<T, bool> popped = pool.pop_back();
 
         if (popped.second)
         {
@@ -477,7 +481,7 @@ TEST_F(stdgpu_vector, simultaneous_push_back_and_pop_back)
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N + init),
-                     simultaneous_push_back_and_pop_back_vector(pool, pool_validation));
+                     simultaneous_push_back_and_pop_back_vector<int>(pool, pool_validation));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -61,6 +61,24 @@ struct pop_back_vector
     }
 };
 
+template <typename Pair>
+struct pop_back_vector_const_type
+{
+    stdgpu::vector<Pair> pool;
+
+    pop_back_vector_const_type(stdgpu::vector<Pair> pool)
+        : pool(pool)
+    {
+
+    }
+
+    inline STDGPU_HOST_DEVICE void
+    operator()(STDGPU_MAYBE_UNUSED const typename Pair::first_type& first)
+    {
+        pool.pop_back();
+    }
+};
+
 
 template <typename T>
 struct push_back_vector
@@ -80,6 +98,27 @@ struct push_back_vector
     }
 };
 
+template <typename Pair>
+struct push_back_vector_const_type
+{
+    stdgpu::vector<Pair> pool;
+    typename Pair::second_type second;
+
+    push_back_vector_const_type(stdgpu::vector<Pair> pool,
+                                const typename Pair::second_type& second)
+        : pool(pool),
+          second(second)
+    {
+
+    }
+
+    inline STDGPU_HOST_DEVICE void
+    operator()(const typename Pair::first_type& first)
+    {
+        pool.push_back(thrust::make_pair(first, second));
+    }
+};
+
 
 template <typename T>
 struct emplace_back_vector
@@ -96,6 +135,27 @@ struct emplace_back_vector
     operator()(const T x)
     {
         pool.emplace_back(x);
+    }
+};
+
+template <typename Pair>
+struct emplace_back_vector_const_type
+{
+    stdgpu::vector<Pair> pool;
+    typename Pair::second_type second;
+
+    emplace_back_vector_const_type(stdgpu::vector<Pair> pool,
+                                   const typename Pair::second_type& second)
+        : pool(pool),
+          second(second)
+    {
+
+    }
+
+    inline STDGPU_HOST_DEVICE void
+    operator()(const typename Pair::first_type& first)
+    {
+        pool.emplace_back(first, second);
     }
 };
 
@@ -202,6 +262,34 @@ TEST_F(stdgpu_vector, pop_back_too_many)
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+}
+
+
+TEST_F(stdgpu_vector, pop_back_const_type)
+{
+    using T = thrust::pair<int, const float>;
+
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     push_back_vector_const_type<T>(pool, 2.0f));
+
+    ASSERT_EQ(pool.size(), N);
+    ASSERT_FALSE(pool.empty());
+    ASSERT_TRUE(pool.full());
+    ASSERT_TRUE(pool.valid());
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     pop_back_vector_const_type<T>(pool));
+
+    EXPECT_EQ(pool.size(), 0);
+    EXPECT_TRUE(pool.empty());
+    EXPECT_FALSE(pool.full());
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::vector<T>::destroyDeviceObject(pool);
 }
 
 
@@ -314,6 +402,26 @@ TEST_F(stdgpu_vector, push_back_too_many)
 }
 
 
+TEST_F(stdgpu_vector, push_back_const_type)
+{
+    using T = thrust::pair<int, const float>;
+
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     push_back_vector_const_type<T>(pool, 2.0f));
+
+    EXPECT_EQ(pool.size(), N);
+    EXPECT_FALSE(pool.empty());
+    EXPECT_TRUE(pool.full());
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::vector<T>::destroyDeviceObject(pool);
+}
+
+
 TEST_F(stdgpu_vector, emplace_back_some)
 {
     const stdgpu::index_t N            = 10000;
@@ -420,6 +528,26 @@ TEST_F(stdgpu_vector, emplace_back_too_many)
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+}
+
+
+TEST_F(stdgpu_vector, emplace_back_const_type)
+{
+    using T = thrust::pair<int, const float>;
+
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     emplace_back_vector_const_type<T>(pool, 2.0f));
+
+    EXPECT_EQ(pool.size(), N);
+    EXPECT_FALSE(pool.empty());
+    EXPECT_TRUE(pool.full());
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::vector<T>::destroyDeviceObject(pool);
 }
 
 


### PR DESCRIPTION
Although the `vector` class implements a significant part of the C++ container API, it still has some limitations. Partially address them by implementing some missing functions and relaxing the requirements of the template type T. Furthermore, perform some cleanups.