### PR TITLE
deque: Add at(), shrink_to_fit() and remove CopyAssignable requirement from type T

### DIFF
--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -77,11 +77,12 @@ class deque
 
         /**
          * \brief Creates an object of this class on the GPU (device)
-         * \param[in] size The size of managed array
+         * \param[in] capacity The capacity of the object
          * \return A newly created object of this class allocated on the GPU (device)
+         * \pre capacity > 0
          */
         static deque<T>
-        createDeviceObject(const index_t& size);
+        createDeviceObject(const index_t& capacity);
 
         /**
          * \brief Destroys the given object of this class on the GPU (device)

--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -104,6 +104,24 @@ class deque
          * \pre 0 <= n < size()
          */
         STDGPU_DEVICE_ONLY reference
+        at(const index_type n);
+
+        /**
+         * \brief Reads the value at position n
+         * \param[in] n The position
+         * \return The value at this position
+         * \pre 0 <= n < size()
+         */
+        STDGPU_DEVICE_ONLY const_reference
+        at(const index_type n) const;
+
+        /**
+         * \brief Reads the value at position n
+         * \param[in] n The position
+         * \return The value at this position
+         * \pre 0 <= n < size()
+         */
+        STDGPU_DEVICE_ONLY reference
         operator[](const index_type n);
 
         /**
@@ -225,6 +243,13 @@ class deque
          */
         STDGPU_HOST_DEVICE index_t
         capacity() const;
+
+        /**
+         * \brief Requests to shrink the capacity to the current size
+         * \note This is non-binding and may not have any effect
+         */
+        void
+        shrink_to_fit();
 
         /**
          * \brief Returns a pointer to the underlying data

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -32,20 +32,20 @@ namespace stdgpu
 
 template <typename T>
 deque<T>
-deque<T>::createDeviceObject(const index_t& size)
+deque<T>::createDeviceObject(const index_t& capacity)
 {
-    STDGPU_EXPECTS(size > 0);
+    STDGPU_EXPECTS(capacity > 0);
 
     deque<T> result;
-    result._data     = createDeviceArray<T>(size, T());
-    result._locks    = mutex_array::createDeviceObject(size);
-    result._occupied = bitset::createDeviceObject(size);
+    result._data     = createDeviceArray<T>(capacity, T());
+    result._locks    = mutex_array::createDeviceObject(capacity);
+    result._occupied = bitset::createDeviceObject(capacity);
     result._size     = atomic<int>::createDeviceObject();
     result._begin    = atomic<unsigned int>::createDeviceObject();
     result._end      = atomic<unsigned int>::createDeviceObject();
-    result._capacity = size;
+    result._capacity = capacity;
 
-    result._range_indices = vector<index_t>::createDeviceObject(size);
+    result._range_indices = vector<index_t>::createDeviceObject(capacity);
 
     return result;
 }
@@ -177,7 +177,6 @@ deque<T>::push_back(const T& element)
     else
     {
         printf("stdgpu::deque::push_back : Unable to push element to full queue\n");
-        pushed = false;
     }
 
     return pushed;
@@ -232,7 +231,6 @@ deque<T>::pop_back()
     else
     {
         printf("stdgpu::deque::pop_back : Unable to pop element from empty queue\n");
-        popped = thrust::make_pair(T(), false);
     }
 
     return popped;
@@ -295,7 +293,6 @@ deque<T>::push_front(const T& element)
     else
     {
         printf("stdgpu::deque::push_front : Unable to push element to full queue\n");
-        pushed = false;
     }
 
     return pushed;
@@ -349,7 +346,6 @@ deque<T>::pop_front()
     else
     {
         printf("stdgpu::deque::pop_front : Unable to pop element from empty queue\n");
-        popped = thrust::make_pair(T(), false);
     }
 
     return popped;

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -159,8 +159,8 @@ deque<T>::push_back(const T& element)
 
                 if (!occupied(push_position))
                 {
-                    _data[push_position]    = element;
-                    bool was_occupied       = _occupied.set(push_position);
+                    default_allocator_traits::construct(&(_data[push_position]), element); //_data[push_position] = element;
+                    bool was_occupied = _occupied.set(push_position);
                     pushed = true;
 
                     if (was_occupied)
@@ -212,10 +212,10 @@ deque<T>::pop_back()
 
                 if (occupied(pop_position))
                 {
-                    bool was_occupied       = _occupied.reset(pop_position);
-                    T element               = _data[pop_position];
-                    _data[pop_position]     = T();
-                    popped = thrust::make_pair(element, true);
+                    bool was_occupied = _occupied.reset(pop_position);
+                    T element = _data[pop_position];
+                    default_allocator_traits::construct(&(_data[pop_position]), T()); //_data[pop_position] = T();
+                    default_allocator_traits::construct(&popped, element, true); //popped = thrust::make_pair(element, true);
 
                     if (!was_occupied)
                     {
@@ -275,8 +275,8 @@ deque<T>::push_front(const T& element)
 
                 if (!occupied(push_position))
                 {
-                    _data[push_position]    = element;
-                    bool was_occupied       = _occupied.set(push_position);
+                    default_allocator_traits::construct(&(_data[push_position]), element); //_data[push_position] = element;
+                    bool was_occupied = _occupied.set(push_position);
                     pushed = true;
 
                     if (was_occupied)
@@ -327,10 +327,10 @@ deque<T>::pop_front()
 
                 if (occupied(pop_position))
                 {
-                    bool was_occupied       = _occupied.reset(pop_position);
-                    T element               = _data[pop_position];
-                    _data[pop_position]     = T();
-                    popped = thrust::make_pair(element, true);
+                    bool was_occupied = _occupied.reset(pop_position);
+                    T element = _data[pop_position];
+                    default_allocator_traits::construct(&(_data[pop_position]), T()); //_data[pop_position] = T();
+                    default_allocator_traits::construct(&popped, element, true); //popped = thrust::make_pair(element, true);
 
                     if (!was_occupied)
                     {

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -68,15 +68,15 @@ deque<T>::destroyDeviceObject(deque<T>& device_object)
 
 template <typename T>
 inline STDGPU_DEVICE_ONLY typename deque<T>::reference
-deque<T>::operator[](const deque<T>::index_type n)
+deque<T>::at(const deque<T>::index_type n)
 {
-    return const_cast<reference>(static_cast<const deque<T>*>(this)->operator[](n));
+    return const_cast<reference>(static_cast<const deque<T>*>(this)->at(n));
 }
 
 
 template <typename T>
 inline STDGPU_DEVICE_ONLY typename deque<T>::const_reference
-deque<T>::operator[](const deque<T>::index_type n) const
+deque<T>::at(const deque<T>::index_type n) const
 {
     STDGPU_EXPECTS(0 <= n);
     STDGPU_EXPECTS(n < size());
@@ -87,6 +87,22 @@ deque<T>::operator[](const deque<T>::index_type n) const
     STDGPU_ASSERT(0 <= index_to_wrap);
 
     return _data[index_to_wrap % _capacity];
+}
+
+
+template <typename T>
+inline STDGPU_DEVICE_ONLY typename deque<T>::reference
+deque<T>::operator[](const deque<T>::index_type n)
+{
+    return at(n);
+}
+
+
+template <typename T>
+inline STDGPU_DEVICE_ONLY typename deque<T>::const_reference
+deque<T>::operator[](const deque<T>::index_type n) const
+{
+    return at(n);
 }
 
 
@@ -404,6 +420,14 @@ inline STDGPU_HOST_DEVICE index_t
 deque<T>::capacity() const
 {
     return _capacity;
+}
+
+
+template <typename T>
+inline void
+deque<T>::shrink_to_fit()
+{
+    // Reject request for performance reasons
 }
 
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -43,54 +43,57 @@ class stdgpu_deque : public ::testing::Test
 };
 
 
+template <typename T>
 struct pop_back_deque
 {
-    stdgpu::deque<int> pool;
+    stdgpu::deque<T> pool;
 
-    pop_back_deque(stdgpu::deque<int> pool)
+    pop_back_deque(stdgpu::deque<T> pool)
         : pool(pool)
     {
 
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(STDGPU_MAYBE_UNUSED const int x)
+    operator()(STDGPU_MAYBE_UNUSED const T x)
     {
         pool.pop_back();
     }
 };
 
 
+template <typename T>
 struct push_back_deque
 {
-    stdgpu::deque<int> pool;
+    stdgpu::deque<T> pool;
 
-    push_back_deque(stdgpu::deque<int> pool)
+    push_back_deque(stdgpu::deque<T> pool)
         : pool(pool)
     {
 
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const T x)
     {
         pool.push_back(x);
     }
 };
 
 
+template <typename T>
 struct emplace_back_deque
 {
-    stdgpu::deque<int> pool;
+    stdgpu::deque<T> pool;
 
-    emplace_back_deque(stdgpu::deque<int> pool)
+    emplace_back_deque(stdgpu::deque<T> pool)
         : pool(pool)
     {
 
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const T x)
     {
         pool.emplace_back(x);
     }
@@ -102,7 +105,7 @@ fill_deque(stdgpu::deque<int> pool)
 {
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(pool.capacity() + init),
-                     push_back_deque(pool));
+                     push_back_deque<int>(pool));
 
     thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
 
@@ -124,7 +127,7 @@ TEST_F(stdgpu_deque, pop_back_some)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque(pool));
+                     pop_back_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), N_remaining);
     ASSERT_FALSE(pool.empty());
@@ -156,7 +159,7 @@ TEST_F(stdgpu_deque, pop_back_all)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque(pool));
+                     pop_back_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -184,7 +187,7 @@ TEST_F(stdgpu_deque, pop_back_too_many)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque(pool));
+                     pop_back_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -214,11 +217,11 @@ TEST_F(stdgpu_deque, push_back_some)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque(pool));
+                     pop_back_deque<int>(pool));
 
     const stdgpu::index_t init = 1 + N_remaining;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     push_back_deque(pool));
+                     push_back_deque<int>(pool));
 
 
     thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
@@ -250,11 +253,11 @@ TEST_F(stdgpu_deque, push_back_all)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque(pool));
+                     pop_back_deque<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     push_back_deque(pool));
+                     push_back_deque<int>(pool));
 
 
     thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
@@ -286,11 +289,11 @@ TEST_F(stdgpu_deque, push_back_too_many)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque(pool));
+                     pop_back_deque<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     push_back_deque(pool));
+                     push_back_deque<int>(pool));
 
 
     ASSERT_EQ(pool.size(), N);
@@ -323,11 +326,11 @@ TEST_F(stdgpu_deque, emplace_back_some)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque(pool));
+                     pop_back_deque<int>(pool));
 
     const stdgpu::index_t init = 1 + N_remaining;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     emplace_back_deque(pool));
+                     emplace_back_deque<int>(pool));
 
 
     thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
@@ -359,11 +362,11 @@ TEST_F(stdgpu_deque, emplace_back_all)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque(pool));
+                     pop_back_deque<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     emplace_back_deque(pool));
+                     emplace_back_deque<int>(pool));
 
 
     thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
@@ -395,11 +398,11 @@ TEST_F(stdgpu_deque, emplace_back_too_many)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque(pool));
+                     pop_back_deque<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     emplace_back_deque(pool));
+                     emplace_back_deque<int>(pool));
 
 
     ASSERT_EQ(pool.size(), N);
@@ -420,54 +423,57 @@ TEST_F(stdgpu_deque, emplace_back_too_many)
 }
 
 
+template <typename T>
 struct pop_front_deque
 {
-    stdgpu::deque<int> pool;
+    stdgpu::deque<T> pool;
 
-    pop_front_deque(stdgpu::deque<int> pool)
+    pop_front_deque(stdgpu::deque<T> pool)
         : pool(pool)
     {
 
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(STDGPU_MAYBE_UNUSED const int x)
+    operator()(STDGPU_MAYBE_UNUSED const T x)
     {
         pool.pop_front();
     }
 };
 
 
+template <typename T>
 struct push_front_deque
 {
-    stdgpu::deque<int> pool;
+    stdgpu::deque<T> pool;
 
-    push_front_deque(stdgpu::deque<int> pool)
+    push_front_deque(stdgpu::deque<T> pool)
         : pool(pool)
     {
 
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const T x)
     {
         pool.push_front(x);
     }
 };
 
 
+template <typename T>
 struct emplace_front_deque
 {
-    stdgpu::deque<int> pool;
+    stdgpu::deque<T> pool;
 
-    emplace_front_deque(stdgpu::deque<int> pool)
+    emplace_front_deque(stdgpu::deque<T> pool)
         : pool(pool)
     {
 
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const T x)
     {
         pool.emplace_front(x);
     }
@@ -485,7 +491,7 @@ TEST_F(stdgpu_deque, pop_front_some)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque(pool));
+                     pop_front_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), N_remaining);
     ASSERT_FALSE(pool.empty());
@@ -517,7 +523,7 @@ TEST_F(stdgpu_deque, pop_front_all)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque(pool));
+                     pop_front_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -545,7 +551,7 @@ TEST_F(stdgpu_deque, pop_front_too_many)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque(pool));
+                     pop_front_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -574,11 +580,11 @@ TEST_F(stdgpu_deque, push_front_some)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque(pool));
+                     pop_front_deque<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     push_front_deque(pool));
+                     push_front_deque<int>(pool));
 
     thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
 
@@ -609,11 +615,11 @@ TEST_F(stdgpu_deque, push_front_all)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque(pool));
+                     pop_front_deque<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     push_front_deque(pool));
+                     push_front_deque<int>(pool));
 
     thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
 
@@ -644,11 +650,11 @@ TEST_F(stdgpu_deque, push_front_too_many)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque(pool));
+                     pop_front_deque<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     push_front_deque(pool));
+                     push_front_deque<int>(pool));
 
 
     ASSERT_EQ(pool.size(), N);
@@ -680,11 +686,11 @@ TEST_F(stdgpu_deque, emplace_front_some)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque(pool));
+                     pop_front_deque<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     emplace_front_deque(pool));
+                     emplace_front_deque<int>(pool));
 
     thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
 
@@ -715,11 +721,11 @@ TEST_F(stdgpu_deque, emplace_front_all)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque(pool));
+                     pop_front_deque<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     emplace_front_deque(pool));
+                     emplace_front_deque<int>(pool));
 
     thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
 
@@ -750,11 +756,11 @@ TEST_F(stdgpu_deque, emplace_front_too_many)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque(pool));
+                     pop_front_deque<int>(pool));
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     emplace_front_deque(pool));
+                     emplace_front_deque<int>(pool));
 
 
     ASSERT_EQ(pool.size(), N);
@@ -786,14 +792,14 @@ TEST_F(stdgpu_deque, push_back_circular)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque(pool));
+                     pop_back_deque<int>(pool));
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque(pool));
+                     pop_front_deque<int>(pool));
 
     const stdgpu::index_t init = N - N_pop + 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     push_back_deque(pool));
+                     push_back_deque<int>(pool));
 
     thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
 
@@ -824,14 +830,14 @@ TEST_F(stdgpu_deque, push_front_circular)
     fill_deque(pool);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque(pool));
+                     pop_back_deque<int>(pool));
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque(pool));
+                     pop_front_deque<int>(pool));
 
     const stdgpu::index_t init = N - N_pop + 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N_push + init),
-                     push_front_deque(pool));
+                     push_front_deque<int>(pool));
 
     thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
 
@@ -872,13 +878,14 @@ TEST_F(stdgpu_deque, clear)
 }
 
 
+template <typename T>
 struct simultaneous_push_back_and_pop_back_deque
 {
-    stdgpu::deque<int> pool;
-    stdgpu::deque<int> pool_validation;
+    stdgpu::deque<T> pool;
+    stdgpu::deque<T> pool_validation;
 
-    simultaneous_push_back_and_pop_back_deque(stdgpu::deque<int> pool,
-                                              stdgpu::deque<int> pool_validation)
+    simultaneous_push_back_and_pop_back_deque(stdgpu::deque<T> pool,
+                                              stdgpu::deque<T> pool_validation)
         : pool(pool),
           pool_validation(pool_validation)
     {
@@ -886,11 +893,11 @@ struct simultaneous_push_back_and_pop_back_deque
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const T x)
     {
         pool.push_back(x);
 
-        thrust::pair<int, bool> popped = pool.pop_back();
+        thrust::pair<T, bool> popped = pool.pop_back();
 
         if (popped.second)
         {
@@ -909,7 +916,7 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_back)
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N + init),
-                     simultaneous_push_back_and_pop_back_deque(pool, pool_validation));
+                     simultaneous_push_back_and_pop_back_deque<int>(pool, pool_validation));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -935,13 +942,14 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_back)
 }
 
 
+template <typename T>
 struct simultaneous_push_front_and_pop_front_deque
 {
-    stdgpu::deque<int> pool;
-    stdgpu::deque<int> pool_validation;
+    stdgpu::deque<T> pool;
+    stdgpu::deque<T> pool_validation;
 
-    simultaneous_push_front_and_pop_front_deque(stdgpu::deque<int> pool,
-                                                stdgpu::deque<int> pool_validation)
+    simultaneous_push_front_and_pop_front_deque(stdgpu::deque<T> pool,
+                                                stdgpu::deque<T> pool_validation)
         : pool(pool),
           pool_validation(pool_validation)
     {
@@ -949,11 +957,11 @@ struct simultaneous_push_front_and_pop_front_deque
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const T x)
     {
         pool.push_front(x);
 
-        thrust::pair<int, bool> popped = pool.pop_front();
+        thrust::pair<T, bool> popped = pool.pop_front();
 
         if (popped.second)
         {
@@ -972,7 +980,7 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_front)
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N + init),
-                     simultaneous_push_front_and_pop_front_deque(pool, pool_validation));
+                     simultaneous_push_front_and_pop_front_deque<int>(pool, pool_validation));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -998,13 +1006,14 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_front)
 }
 
 
+template <typename T>
 struct simultaneous_push_front_and_pop_back_deque
 {
-    stdgpu::deque<int> pool;
-    stdgpu::deque<int> pool_validation;
+    stdgpu::deque<T> pool;
+    stdgpu::deque<T> pool_validation;
 
-    simultaneous_push_front_and_pop_back_deque(stdgpu::deque<int> pool,
-                                               stdgpu::deque<int> pool_validation)
+    simultaneous_push_front_and_pop_back_deque(stdgpu::deque<T> pool,
+                                               stdgpu::deque<T> pool_validation)
         : pool(pool),
           pool_validation(pool_validation)
     {
@@ -1012,11 +1021,11 @@ struct simultaneous_push_front_and_pop_back_deque
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const T x)
     {
         pool.push_front(x);
 
-        thrust::pair<int, bool> popped = pool.pop_back();
+        thrust::pair<T, bool> popped = pool.pop_back();
 
         if (popped.second)
         {
@@ -1035,7 +1044,7 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_back)
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N + init),
-                     simultaneous_push_front_and_pop_back_deque(pool, pool_validation));
+                     simultaneous_push_front_and_pop_back_deque<int>(pool, pool_validation));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -1061,13 +1070,14 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_back)
 }
 
 
+template <typename T>
 struct simultaneous_push_back_and_pop_front_deque
 {
-    stdgpu::deque<int> pool;
-    stdgpu::deque<int> pool_validation;
+    stdgpu::deque<T> pool;
+    stdgpu::deque<T> pool_validation;
 
-    simultaneous_push_back_and_pop_front_deque(stdgpu::deque<int> pool,
-                                               stdgpu::deque<int> pool_validation)
+    simultaneous_push_back_and_pop_front_deque(stdgpu::deque<T> pool,
+                                               stdgpu::deque<T> pool_validation)
         : pool(pool),
           pool_validation(pool_validation)
     {
@@ -1075,11 +1085,11 @@ struct simultaneous_push_back_and_pop_front_deque
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const T x)
     {
         pool.push_back(x);
 
-        thrust::pair<int, bool> popped = pool.pop_back();
+        thrust::pair<T, bool> popped = pool.pop_back();
 
         if (popped.second)
         {
@@ -1098,7 +1108,7 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_front)
 
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(N + init),
-                     simultaneous_push_back_and_pop_front_deque(pool, pool_validation));
+                     simultaneous_push_back_and_pop_front_deque<int>(pool, pool_validation));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -1390,6 +1390,46 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_front)
 }
 
 
+struct at_non_const_deque
+{
+    stdgpu::deque<int> pool;
+
+    at_non_const_deque(stdgpu::deque<int> pool)
+        : pool(pool)
+    {
+
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const int x)
+    {
+        pool.at(x) = x * x;
+    }
+};
+
+
+TEST_F(stdgpu_deque, at_non_const)
+{
+    const stdgpu::index_t N = 100000;
+
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
+
+    fill_deque(pool);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     at_non_const_deque(pool));
+
+    int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(host_numbers[i], i * i);
+    }
+
+    stdgpu::deque<int>::destroyDeviceObject(pool);
+    destroyHostArray<int>(host_numbers);
+}
+
+
 struct access_operator_non_const_deque
 {
     stdgpu::deque<int> pool;
@@ -1427,6 +1467,75 @@ TEST_F(stdgpu_deque, access_operator_non_const)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+}
+
+
+TEST_F(stdgpu_deque, shrink_to_fit_empty)
+{
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
+
+    ASSERT_EQ(pool.size(), 0);
+    ASSERT_EQ(pool.capacity(), N);
+    ASSERT_TRUE(pool.valid());
+
+    pool.shrink_to_fit();
+
+    EXPECT_EQ(pool.size(), 0);
+    EXPECT_TRUE(pool.capacity() == 0 || pool.capacity() == N); // Capacity may have changed or not
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::deque<int>::destroyDeviceObject(pool);
+}
+
+
+TEST_F(stdgpu_deque, shrink_to_fit_full)
+{
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
+
+    fill_deque(pool);
+
+    ASSERT_EQ(pool.size(), N);
+    ASSERT_EQ(pool.capacity(), N);
+    ASSERT_TRUE(pool.valid());
+
+    pool.shrink_to_fit();
+
+    EXPECT_EQ(pool.size(), N);
+    EXPECT_EQ(pool.capacity(), N);
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::deque<int>::destroyDeviceObject(pool);
+}
+
+
+TEST_F(stdgpu_deque, shrink_to_fit)
+{
+    const stdgpu::index_t N            = 10000;
+    const stdgpu::index_t N_pop        = 100;
+    const stdgpu::index_t N_remaining  = N - N_pop;
+
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
+
+    fill_deque(pool);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N_pop),
+                     pop_back_deque<int>(pool));
+
+    ASSERT_EQ(pool.size(), N_remaining);
+    ASSERT_EQ(pool.capacity(), N);
+    ASSERT_TRUE(pool.valid());
+
+    pool.shrink_to_fit();
+
+    EXPECT_EQ(pool.size(), N_remaining);
+    EXPECT_TRUE(pool.capacity() == N_remaining || pool.capacity() == N); // Capacity may have changed or not
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::deque<int>::destroyDeviceObject(pool);
 }
 
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -61,6 +61,24 @@ struct pop_back_deque
     }
 };
 
+template <typename Pair>
+struct pop_back_deque_const_type
+{
+    stdgpu::deque<Pair> pool;
+
+    pop_back_deque_const_type(stdgpu::deque<Pair> pool)
+        : pool(pool)
+    {
+
+    }
+
+    inline STDGPU_HOST_DEVICE void
+    operator()(STDGPU_MAYBE_UNUSED const typename Pair::first_type& first)
+    {
+        pool.pop_back();
+    }
+};
+
 
 template <typename T>
 struct push_back_deque
@@ -80,6 +98,27 @@ struct push_back_deque
     }
 };
 
+template <typename Pair>
+struct push_back_deque_const_type
+{
+    stdgpu::deque<Pair> pool;
+    typename Pair::second_type second;
+
+    push_back_deque_const_type(stdgpu::deque<Pair> pool,
+                               const typename Pair::second_type& second)
+        : pool(pool),
+          second(second)
+    {
+
+    }
+
+    inline STDGPU_HOST_DEVICE void
+    operator()(const typename Pair::first_type& first)
+    {
+        pool.push_back(thrust::make_pair(first, second));
+    }
+};
+
 
 template <typename T>
 struct emplace_back_deque
@@ -96,6 +135,27 @@ struct emplace_back_deque
     operator()(const T x)
     {
         pool.emplace_back(x);
+    }
+};
+
+template <typename Pair>
+struct emplace_back_deque_const_type
+{
+    stdgpu::deque<Pair> pool;
+    typename Pair::second_type second;
+
+    emplace_back_deque_const_type(stdgpu::deque<Pair> pool,
+                                  const typename Pair::second_type& second)
+        : pool(pool),
+          second(second)
+    {
+
+    }
+
+    inline STDGPU_HOST_DEVICE void
+    operator()(const typename Pair::first_type& first)
+    {
+        pool.emplace_back(first, second);
     }
 };
 
@@ -202,6 +262,34 @@ TEST_F(stdgpu_deque, pop_back_too_many)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+}
+
+
+TEST_F(stdgpu_deque, pop_back_const_type)
+{
+    using T = thrust::pair<int, const float>;
+
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     push_back_deque_const_type<T>(pool, 2.0f));
+
+    ASSERT_EQ(pool.size(), N);
+    ASSERT_FALSE(pool.empty());
+    ASSERT_TRUE(pool.full());
+    ASSERT_TRUE(pool.valid());
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     pop_back_deque_const_type<T>(pool));
+
+    EXPECT_EQ(pool.size(), 0);
+    EXPECT_TRUE(pool.empty());
+    EXPECT_FALSE(pool.full());
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::deque<T>::destroyDeviceObject(pool);
 }
 
 
@@ -314,6 +402,26 @@ TEST_F(stdgpu_deque, push_back_too_many)
 }
 
 
+TEST_F(stdgpu_deque, push_back_const_type)
+{
+    using T = thrust::pair<int, const float>;
+
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     push_back_deque_const_type<T>(pool, 2.0f));
+
+    EXPECT_EQ(pool.size(), N);
+    EXPECT_FALSE(pool.empty());
+    EXPECT_TRUE(pool.full());
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::deque<T>::destroyDeviceObject(pool);
+}
+
+
 TEST_F(stdgpu_deque, emplace_back_some)
 {
     const stdgpu::index_t N            = 10000;
@@ -423,6 +531,26 @@ TEST_F(stdgpu_deque, emplace_back_too_many)
 }
 
 
+TEST_F(stdgpu_deque, emplace_back_const_type)
+{
+    using T = thrust::pair<int, const float>;
+
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     emplace_back_deque_const_type<T>(pool, 2.0f));
+
+    EXPECT_EQ(pool.size(), N);
+    EXPECT_FALSE(pool.empty());
+    EXPECT_TRUE(pool.full());
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::deque<T>::destroyDeviceObject(pool);
+}
+
+
 template <typename T>
 struct pop_front_deque
 {
@@ -436,6 +564,24 @@ struct pop_front_deque
 
     STDGPU_DEVICE_ONLY void
     operator()(STDGPU_MAYBE_UNUSED const T x)
+    {
+        pool.pop_front();
+    }
+};
+
+template <typename Pair>
+struct pop_front_deque_const_type
+{
+    stdgpu::deque<Pair> pool;
+
+    pop_front_deque_const_type(stdgpu::deque<Pair> pool)
+        : pool(pool)
+    {
+
+    }
+
+    inline STDGPU_HOST_DEVICE void
+    operator()(STDGPU_MAYBE_UNUSED const typename Pair::first_type& first)
     {
         pool.pop_front();
     }
@@ -460,6 +606,27 @@ struct push_front_deque
     }
 };
 
+template <typename Pair>
+struct push_front_deque_const_type
+{
+    stdgpu::deque<Pair> pool;
+    typename Pair::second_type second;
+
+    push_front_deque_const_type(stdgpu::deque<Pair> pool,
+                                const typename Pair::second_type& second)
+        : pool(pool),
+          second(second)
+    {
+
+    }
+
+    inline STDGPU_HOST_DEVICE void
+    operator()(const typename Pair::first_type& first)
+    {
+        pool.push_front(thrust::make_pair(first, second));
+    }
+};
+
 
 template <typename T>
 struct emplace_front_deque
@@ -476,6 +643,27 @@ struct emplace_front_deque
     operator()(const T x)
     {
         pool.emplace_front(x);
+    }
+};
+
+template <typename Pair>
+struct emplace_front_deque_const_type
+{
+    stdgpu::deque<Pair> pool;
+    typename Pair::second_type second;
+
+    emplace_front_deque_const_type(stdgpu::deque<Pair> pool,
+                                   const typename Pair::second_type& second)
+        : pool(pool),
+          second(second)
+    {
+
+    }
+
+    inline STDGPU_HOST_DEVICE void
+    operator()(const typename Pair::first_type& first)
+    {
+        pool.emplace_front(first, second);
     }
 };
 
@@ -566,6 +754,34 @@ TEST_F(stdgpu_deque, pop_front_too_many)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+}
+
+
+TEST_F(stdgpu_deque, pop_front_const_type)
+{
+    using T = thrust::pair<int, const float>;
+
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     push_back_deque_const_type<T>(pool, 2.0f));
+
+    ASSERT_EQ(pool.size(), N);
+    ASSERT_FALSE(pool.empty());
+    ASSERT_TRUE(pool.full());
+    ASSERT_TRUE(pool.valid());
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     pop_front_deque_const_type<T>(pool));
+
+    EXPECT_EQ(pool.size(), 0);
+    EXPECT_TRUE(pool.empty());
+    EXPECT_FALSE(pool.full());
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::deque<T>::destroyDeviceObject(pool);
 }
 
 
@@ -675,6 +891,26 @@ TEST_F(stdgpu_deque, push_front_too_many)
 }
 
 
+TEST_F(stdgpu_deque, push_front_const_type)
+{
+    using T = thrust::pair<int, const float>;
+
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     push_front_deque_const_type<T>(pool, 2.0f));
+
+    EXPECT_EQ(pool.size(), N);
+    EXPECT_FALSE(pool.empty());
+    EXPECT_TRUE(pool.full());
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::deque<T>::destroyDeviceObject(pool);
+}
+
+
 TEST_F(stdgpu_deque, emplace_front_some)
 {
     const stdgpu::index_t N            = 10000;
@@ -778,6 +1014,26 @@ TEST_F(stdgpu_deque, emplace_front_too_many)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+}
+
+
+TEST_F(stdgpu_deque, emplace_front_const_type)
+{
+    using T = thrust::pair<int, const float>;
+
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     emplace_front_deque_const_type<T>(pool, 2.0f));
+
+    EXPECT_EQ(pool.size(), N);
+    EXPECT_FALSE(pool.empty());
+    EXPECT_TRUE(pool.full());
+    EXPECT_TRUE(pool.valid());
+
+    stdgpu::deque<T>::destroyDeviceObject(pool);
 }
 
 


### PR DESCRIPTION
Since `deque` and `vector` have very similar implementations, the recent improvements to `vector` in #44 can also be applied to `deque`. Incorporate them to partially address the limitations of the current implementation.