### PR TITLE
unordered_{map,set}: Add single-parameter createDeviceObject function

### DIFF
--- a/examples/cuda/container_kernel.cu
+++ b/examples/cuda/container_kernel.cu
@@ -76,7 +76,7 @@ main()
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n);
-    stdgpu::unordered_set<int> set = stdgpu::unordered_set<int>::createDeviceObject(1024, n);
+    stdgpu::unordered_set<int> set = stdgpu::unordered_set<int>::createDeviceObject(n);
     stdgpu::vector<int> vec = stdgpu::vector<int>::createDeviceObject(n);
 
     thrust::sequence(stdgpu::device_begin(d_input), stdgpu::device_end(d_input),

--- a/examples/cuda/thrust_towards_ranges.cu
+++ b/examples/cuda/thrust_towards_ranges.cu
@@ -61,7 +61,7 @@ main()
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n);
-    stdgpu::unordered_set<int> set = stdgpu::unordered_set<int>::createDeviceObject(1024, n);
+    stdgpu::unordered_set<int> set = stdgpu::unordered_set<int>::createDeviceObject(n);
     stdgpu::atomic<int> sum = stdgpu::atomic<int>::createDeviceObject();
 
     thrust::sequence(stdgpu::device_begin(d_input), stdgpu::device_end(d_input),

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -74,16 +74,12 @@ class unordered_base
 
         /**
          * \brief Creates an object of this class on the GPU (device)
-         * \param[in] bucket_count The number of buckets
-         * \param[in] excess_count The number of excess entries
-         * \pre bucket_count > 0
-         * \pre excess_count > 0
-         * \pre ispow2(bucket_count)
+         * \param[in] capacity The capacity of the object
+         * \pre capacity > 0
          * \return A newly created object of this class allocated on the GPU (device)
          */
         static unordered_base
-        createDeviceObject(const index_t& bucket_count,
-                           const index_t& excess_count);
+        createDeviceObject(const index_t& capacity);
 
         /**
          * \brief Destroys the given object of this class on the GPU (device)
@@ -340,20 +336,6 @@ class unordered_base
         STDGPU_HOST_DEVICE index_t
         bucket_count() const;
 
-        /**
-         * \brief The excess count
-         * \return The number of excess entries for handling collisions
-         */
-        STDGPU_HOST_DEVICE index_t
-        excess_count() const;
-
-        /**
-         * \brief The total count
-         * \return The total number of entries
-         */
-        STDGPU_HOST_DEVICE index_t
-        total_count() const;
-
 
         /**
          * \brief The average number of elements per bucket
@@ -361,6 +343,13 @@ class unordered_base
          */
         STDGPU_HOST_DEVICE float
         load_factor() const;
+
+        /**
+         * \brief The maximum number of elements per bucket
+         * \return The maximum number of elements per bucket
+         */
+        STDGPU_HOST_DEVICE float
+        max_load_factor() const;
 
 
         /**
@@ -392,6 +381,16 @@ class unordered_base
 
         mutable vector<index_t> _range_indices = {};        /**< The buffer of range indices */
 
+        // Deprecated
+        static unordered_base
+        createDeviceObject(const index_t& bucket_count,
+                           const index_t& excess_count);
+
+        STDGPU_HOST_DEVICE index_t
+        excess_count() const;
+
+        STDGPU_HOST_DEVICE index_t
+        total_count() const;
 
         STDGPU_DEVICE_ONLY bool
         occupied(const index_t n) const;

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -270,6 +270,14 @@ unordered_map<Key, T, Hash, KeyEqual>::load_factor() const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
+inline STDGPU_HOST_DEVICE float
+unordered_map<Key, T, Hash, KeyEqual>::max_load_factor() const
+{
+    return _base.max_load_factor();
+}
+
+
+template <typename Key, typename T, typename Hash, typename KeyEqual>
 inline STDGPU_HOST_DEVICE typename unordered_map<Key, T, Hash, KeyEqual>::hasher
 unordered_map<Key, T, Hash, KeyEqual>::hash_function() const
 {
@@ -300,6 +308,19 @@ unordered_map<Key, T, Hash, KeyEqual>::clear()
     _base.clear();
 }
 
+
+
+template <typename Key, typename T, typename Hash, typename KeyEqual>
+unordered_map<Key, T, Hash, KeyEqual>
+unordered_map<Key, T, Hash, KeyEqual>::createDeviceObject(const index_t& capacity)
+{
+    STDGPU_EXPECTS(capacity > 0);
+
+    unordered_map<Key, T, Hash, KeyEqual> result;
+    result._base = detail::unordered_base<key_type, value_type, detail::select1st<value_type>, hasher, key_equal>::createDeviceObject(capacity);
+
+    return result;
+}
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -255,6 +255,14 @@ unordered_set<Key, Hash, KeyEqual>::load_factor() const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
+inline STDGPU_HOST_DEVICE float
+unordered_set<Key, Hash, KeyEqual>::max_load_factor() const
+{
+    return _base.max_load_factor();
+}
+
+
+template <typename Key, typename Hash, typename KeyEqual>
 inline STDGPU_HOST_DEVICE typename unordered_set<Key, Hash, KeyEqual>::hasher
 unordered_set<Key, Hash, KeyEqual>::hash_function() const
 {
@@ -285,6 +293,19 @@ unordered_set<Key, Hash, KeyEqual>::clear()
     _base.clear();
 }
 
+
+
+template <typename Key, typename Hash, typename KeyEqual>
+unordered_set<Key, Hash, KeyEqual>
+unordered_set<Key, Hash, KeyEqual>::createDeviceObject(const index_t& capacity)
+{
+    STDGPU_EXPECTS(capacity > 0);
+
+    unordered_set<Key, Hash, KeyEqual> result;
+    result._base = detail::unordered_base<key_type, value_type, thrust::identity<key_type>, hasher, key_equal>::createDeviceObject(capacity);
+
+    return result;
+}
 
 
 template <typename Key, typename Hash, typename KeyEqual>

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -96,6 +96,7 @@ class unordered_map
 
 
         /**
+         * \deprecated Replaced by createDeviceObject(const index_t& capacity)
          * \brief Creates an object of this class on the GPU (device)
          * \param[in] bucket_count The number of buckets
          * \param[in] excess_count The number of excess entries
@@ -104,9 +105,19 @@ class unordered_map
          * \pre ispow2(bucket_count)
          * \return A newly created object of this class allocated on the GPU (device)
          */
+        [[deprecated("Replaced by createDeviceObject(const index_t& capacity)")]]
         static unordered_map
         createDeviceObject(const index_t& bucket_count,
                            const index_t& excess_count);
+
+        /**
+         * \brief Creates an object of this class on the GPU (device)
+         * \param[in] capacity The capacity of the object
+         * \pre capacity > 0
+         * \return A newly created object of this class allocated on the GPU (device)
+         */
+        static unordered_map
+        createDeviceObject(const index_t& capacity);
 
         /**
          * \brief Destroys the given object of this class on the GPU (device)
@@ -333,7 +344,6 @@ class unordered_map
         /**
          * \brief The maximum size
          * \return The maximum size
-         * \note Equivalent to total_count()
          */
         STDGPU_HOST_DEVICE index_t
         max_size() const;
@@ -346,16 +356,20 @@ class unordered_map
         bucket_count() const;
 
         /**
+         * \deprecated Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function
          * \brief The excess count
          * \return The number of excess entries for handling collisions
          */
+        [[deprecated("Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function")]]
         STDGPU_HOST_DEVICE index_t
         excess_count() const;
 
         /**
+         * \deprecated Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function
          * \brief The total count
          * \return The total number of entries
          */
+        [[deprecated("Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function")]]
         STDGPU_HOST_DEVICE index_t
         total_count() const;
 
@@ -366,6 +380,13 @@ class unordered_map
          */
         STDGPU_HOST_DEVICE float
         load_factor() const;
+
+        /**
+         * \brief The maximum number of elements per bucket
+         * \return The maximum number of elements per bucket
+         */
+        STDGPU_HOST_DEVICE float
+        max_load_factor() const;
 
 
         /**

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -84,6 +84,7 @@ class unordered_set
 
 
         /**
+         * \deprecated Replaced by createDeviceObject(const index_t& capacity)
          * \brief Creates an object of this class on the GPU (device)
          * \param[in] bucket_count The number of buckets
          * \param[in] excess_count The number of excess entries
@@ -92,9 +93,19 @@ class unordered_set
          * \pre ispow2(bucket_count)
          * \return A newly created object of this class allocated on the GPU (device)
          */
+        [[deprecated("Replaced by createDeviceObject(const index_t& capacity)")]]
         static unordered_set
         createDeviceObject(const index_t& bucket_count,
                            const index_t& excess_count);
+
+        /**
+         * \brief Creates an object of this class on the GPU (device)
+         * \param[in] capacity The capacity of the object
+         * \pre capacity > 0
+         * \return A newly created object of this class allocated on the GPU (device)
+         */
+        static unordered_set
+        createDeviceObject(const index_t& capacity);
 
         /**
          * \brief Destroys the given object of this class on the GPU (device)
@@ -321,7 +332,6 @@ class unordered_set
         /**
          * \brief The maximum size
          * \return The maximum size
-         * \note Equivalent to total_count()
          */
         STDGPU_HOST_DEVICE index_t
         max_size() const;
@@ -334,16 +344,20 @@ class unordered_set
         bucket_count() const;
 
         /**
+         * \deprecated Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function
          * \brief The excess count
          * \return The number of excess entries for handling collisions
          */
+        [[deprecated("Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function")]]
         STDGPU_HOST_DEVICE index_t
         excess_count() const;
 
         /**
+         * \deprecated Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function
          * \brief The total count
          * \return The total number of entries
          */
+        [[deprecated("Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function")]]
         STDGPU_HOST_DEVICE index_t
         total_count() const;
 
@@ -354,6 +368,13 @@ class unordered_set
          */
         STDGPU_HOST_DEVICE float
         load_factor() const;
+
+        /**
+         * \brief The maximum number of elements per bucket
+         * \return The maximum number of elements per bucket
+         */
+        STDGPU_HOST_DEVICE float
+        max_load_factor() const;
 
 
         /**

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -58,7 +58,7 @@ class STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS : public ::testing::Test
         // Called before each test
         virtual void SetUp()
         {
-            hash_datastructure = test_unordered_datastructure::createDeviceObject(1048576, 1048576);
+            hash_datastructure = test_unordered_datastructure::createDeviceObject(1048576);
         }
 
         // Called after each test
@@ -893,7 +893,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_multiple_collision_tail_
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_while_full)
 {
-    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1, 1);
+    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1);
 
     // Fill tiny hash table
     test_unordered_datastructure::key_type position_1(1, 2, 3);
@@ -921,7 +921,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_while_full)
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_multiple_while_full)
 {
-    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1, 1);
+    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1);
 
     // Fill tiny hash table
     test_unordered_datastructure::key_type position_1(1, 2, 3);
@@ -960,7 +960,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_multiple_while_full)
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_while_excess_empty)
 {
-    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(2, 1);
+    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(2);
 
     // Fill tiny hash table
     test_unordered_datastructure::key_type position_1( 1,  2,  3);
@@ -1066,7 +1066,7 @@ namespace
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_one_free)
 {
-    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1, 1);
+    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1);
 
     // Fill tiny hash table and only keep one free
     test_unordered_datastructure::key_type position_1(1, 2, 3);
@@ -1122,7 +1122,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_one_free
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_excess_empty)
 {
-    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(2, 1);
+    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(2);
 
     // Fill tiny hash table
     test_unordered_datastructure::key_type position_1( 1,  2,  3);
@@ -1162,7 +1162,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_excess_e
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, emplace_parallel_while_one_free)
 {
-    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1, 1);
+    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1);
 
     // Fill tiny hash table and only keep one free
     test_unordered_datastructure::key_type position_1(1, 2, 3);
@@ -1218,7 +1218,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, emplace_parallel_while_one_fre
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, emplace_parallel_while_excess_empty)
 {
-    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(2, 1);
+    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(2);
 
     // Fill tiny hash table
     test_unordered_datastructure::key_type position_1( 1,  2,  3);


### PR DESCRIPTION
In contrast to all other containers, `unordered_map` and `unordered_set` have a 2-parameter version of `createDeviceObject` which is difficult to use since it requires the user to balance both "capacity" values and imposes a strict constraint to the first parameter. Add a 1-parameter version of this function (without such a constraint) that automatically estimates a suitable number of buckets and excess entries for the requested container capacity. Furthermore, add a `max_load_factor` function that returns the current/default maximum load factor that is taken into account for above estimation. Deprecate the old- 2-parameter function to encourage users to port/use the new version.