### PR TITLE
documentation: Include config.h and cleanup macro definitions

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -282,6 +282,7 @@ OPTIMIZE_OUTPUT_VHDL   = NO
 # the files are not read by doxygen.
 
 EXTENSION_MAPPING      = cuh=C++ \
+                         in=C++ \
                          no_extension=C++
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
@@ -811,7 +812,8 @@ FILE_PATTERNS          = *.doxy \
                          *.cuh \
                          *.h \
                          *.hpp \
-                         *_fwd
+                         *_fwd \
+                         *.h.in
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -2054,7 +2056,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = STDGPU_RUN_DOXYGEN=1
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/src/stdgpu/attribute.h
+++ b/src/stdgpu/attribute.h
@@ -29,6 +29,7 @@ namespace stdgpu
 
 /**
  * \def STDGPU_HAS_CPP_ATTRIBUTE
+ * \hideinitializer
  * \brief Checks whether the requested attribute is defined
  * \param[in] name The name of the requested C++ attribute
  * \return True if the attribute is defined, false otherwise or if the compiler does not support this check
@@ -42,6 +43,7 @@ namespace stdgpu
 
 /**
  * \def STDGPU_MAYBE_UNUSED
+ * \hideinitializer
  * \brief Suppresses compiler warnings caused by variables that are or might be unused
  */
 #if STDGPU_HAS_CPP_ATTRIBUTE(maybe_unused) && (STDGPU_HAS_CXX_17 || STDGPU_HOST_COMPILER != STDGPU_HOST_COMPILER_CLANG) // Clang outputs a warning if C++17 is not present
@@ -57,6 +59,7 @@ namespace stdgpu
 
 /**
  * \def STDGPU_FALLTHROUGH
+ * \hideinitializer
  * \brief Suppresses compiler warnings caused by implicit fallthrough
  */
 #if STDGPU_HAS_CPP_ATTRIBUTE(fallthrough) && (STDGPU_HAS_CXX_17 || STDGPU_HOST_COMPILER != STDGPU_HOST_COMPILER_CLANG)  // Clang outputs a warning if C++17 is not present
@@ -72,6 +75,7 @@ namespace stdgpu
 
 /**
  * \def STDGPU_NODISCARD
+ * \hideinitializer
  * \brief Encourages compiler warnings or errors if the function return value is unused
  */
 #if STDGPU_HAS_CPP_ATTRIBUTE(nodiscard) && (STDGPU_HAS_CXX_17 || STDGPU_HOST_COMPILER != STDGPU_HOST_COMPILER_CLANG)    // Clang outputs a warning if C++17 is not present

--- a/src/stdgpu/config.h.in
+++ b/src/stdgpu/config.h.in
@@ -18,6 +18,7 @@
 
 /**
  * \file stdgpu/config.h.in
+ * \brief This file serves as a template for CMake which configures the corresponding config.h file.
  */
 
 
@@ -25,23 +26,109 @@
 namespace stdgpu
 {
 
-// Version
+/**
+ * \hideinitializer
+ * \brief Major version component of stdgpu library
+ */
 #define STDGPU_VERSION_MAJOR @stdgpu_VERSION_MAJOR@
+/**
+ * \hideinitializer
+ * \brief Minor version component of stdgpu library
+ */
 #define STDGPU_VERSION_MINOR @stdgpu_VERSION_MINOR@
+/**
+ * \hideinitializer
+ * \brief Patch version component of stdgpu library
+ */
 #define STDGPU_VERSION_PATCH @stdgpu_VERSION_PATCH@
+/**
+ * \hideinitializer
+ * \brief Version string of stdgpu library
+ */
 #define STDGPU_VERSION_STRING "@stdgpu_VERSION@"
 
-// Backend
+
+/**
+ * \hideinitializer
+ * \brief Selected backend
+ */
 #define STDGPU_BACKEND @STDGPU_BACKEND@
+/**
+ * \hideinitializer
+ * \brief Directory of selected backend
+ */
 #define STDGPU_BACKEND_DIRECTORY @STDGPU_BACKEND_DIRECTORY@
+/**
+ * \hideinitializer
+ * \brief Namespace of selected backend
+ */
 #define STDGPU_BACKEND_NAMESPACE @STDGPU_BACKEND_DIRECTORY@
 
-// Library options
+
+/**
+ * \def STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING
+ * \hideinitializer
+ * \brief Library option to enable warnings when falling back to use auxiliary arrays
+ */
+// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
+#ifdef STDGPU_RUN_DOXYGEN
+    #define STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING
+#endif
 #cmakedefine01 STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING
+
+/**
+ * \def STDGPU_ENABLE_CONTRACT_CHECKS
+ * \hideinitializer
+ * \brief Library option to enable contract checks
+ */
+// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
+#ifdef STDGPU_RUN_DOXYGEN
+    #define STDGPU_ENABLE_CONTRACT_CHECKS
+#endif
 #cmakedefine01 STDGPU_ENABLE_CONTRACT_CHECKS
+
+/**
+ * \def STDGPU_ENABLE_MANAGED_ARRAY_WARNING
+ * \hideinitializer
+ * \brief Library option to enable warnings when device initialization of managed memory can only be performed on the host
+ */
+// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
+#ifdef STDGPU_RUN_DOXYGEN
+    #define STDGPU_ENABLE_MANAGED_ARRAY_WARNING
+#endif
 #cmakedefine01 STDGPU_ENABLE_MANAGED_ARRAY_WARNING
+
+/**
+ * \def STDGPU_USE_32_BIT_INDEX
+ * \hideinitializer
+ * \brief Library option to use 32-bit integers rather than 64-bit to define index_t
+ */
+// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
+#ifdef STDGPU_RUN_DOXYGEN
+    #define STDGPU_USE_32_BIT_INDEX
+#endif
 #cmakedefine01 STDGPU_USE_32_BIT_INDEX
+
+/**
+ * \def STDGPU_USE_FAST_DESTROY
+ * \hideinitializer
+ * \brief Library option to use fast destruction of arrays
+ */
+// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
+#ifdef STDGPU_RUN_DOXYGEN
+    #define STDGPU_USE_FAST_DESTROY
+#endif
 #cmakedefine01 STDGPU_USE_FAST_DESTROY
+
+/**
+ * \def STDGPU_USE_FIBONACCI_HASHING
+ * \hideinitializer
+ * \brief Library option to use Fibonacci Hashing to compute the bucket from the hash value
+ */
+// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
+#ifdef STDGPU_RUN_DOXYGEN
+    #define STDGPU_USE_FIBONACCI_HASHING
+#endif
 #cmakedefine01 STDGPU_USE_FIBONACCI_HASHING
 
 } // namespace stdgpu

--- a/src/stdgpu/contract.h
+++ b/src/stdgpu/contract.h
@@ -35,14 +35,17 @@ namespace stdgpu
 
 /**
  * \def STDGPU_EXPECTS(condition)
+ * \hideinitializer
  * \brief A macro to define pre-conditions for both host and device
  */
 /**
  * \def STDGPU_ENSURES(condition)
+ * \hideinitializer
  * \brief A macro to define post-conditions for both host and device
  */
 /**
  * \def STDGPU_ASSERT(condition)
+ * \hideinitializer
  * \brief A macro to define in-body conditions for both host and device
  */
 #if STDGPU_ENABLE_CONTRACT_CHECKS

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -431,11 +431,10 @@ size_bytes(T* array);
 
 // Deprecated classes and functions
 /**
- * \def safe_pinned_host_allocator
  * \deprecated Replaced by stdgpu::safe_host_allocator<T>
- * \brief An allocator for pinned host memory
- * \tparam T A type
  */
+template <typename T>
+struct safe_pinned_host_allocator;
 
 } // namespace stdgpu
 

--- a/src/stdgpu/platform.h
+++ b/src/stdgpu/platform.h
@@ -28,34 +28,41 @@ namespace stdgpu
 {
 
 /**
+ * \hideinitializer
  * \brief Host compiler: Unknown
  */
 #define STDGPU_HOST_COMPILER_UNKNOWN -1
 /**
+ * \hideinitializer
  * \brief Host compiler: GCC
  */
 #define STDGPU_HOST_COMPILER_GCC      0
 /**
+ * \hideinitializer
  * \brief Host compiler: Clang
  */
 #define STDGPU_HOST_COMPILER_CLANG    1
 /**
+ * \hideinitializer
  * \brief Host compiler: Microsoft Visual C++
  */
 #define STDGPU_HOST_COMPILER_MSVC     2
 
 /**
+ * \hideinitializer
  * \brief Device compiler: Unknown
  */
 #define STDGPU_DEVICE_COMPILER_UNKNOWN -1
 /**
+ * \hideinitializer
  * \brief Device compiler: NVCC
  */
 #define STDGPU_DEVICE_COMPILER_NVCC     0
 
 /**
  * \def STDGPU_HOST_COMPILER
- * \brief The host compiler
+ * \hideinitializer
+ * \brief The detected host compiler
  */
 #if defined(__GNUC__) && !defined(__clang__)
     #define STDGPU_HOST_COMPILER STDGPU_HOST_COMPILER_GCC
@@ -69,7 +76,8 @@ namespace stdgpu
 
 /**
  * \def STDGPU_DEVICE_COMPILER
- * \brief The device compiler
+ * \hideinitializer
+ * \brief The detected device compiler
  */
 #if defined(__CUDACC__)
     #define STDGPU_DEVICE_COMPILER STDGPU_DEVICE_COMPILER_NVCC
@@ -81,6 +89,7 @@ namespace stdgpu
 
 /**
  * \def STDGPU_HAS_CXX_17
+ * \hideinitializer
  * \brief Indicator of C++17 availability
  */
 #if defined(__cplusplus) && __cplusplus >= 201703L
@@ -92,25 +101,25 @@ namespace stdgpu
 
 
 /**
+ * \hideinitializer
  * \brief Backend: CUDA
  */
 #define STDGPU_BACKEND_CUDA   0
 /**
+ * \hideinitializer
  * \brief Backend: OpenMP
  */
 #define STDGPU_BACKEND_OPENMP 1
 
-/**
- * \def STDGPU_BACKEND
- * \brief The backend
- */
-// defined in stdgpu/config.h
+
+// STDGPU_BACKEND is defined in stdgpu/config.h
 
 
 
 /**
  * \def STDGPU_HOST_DEVICE
- * \brief Platform-independent __host__ __device__ function annotation
+ * \hideinitializer
+ * \brief Platform-independent host device function annotation
  */
 #if STDGPU_BACKEND == STDGPU_BACKEND_CUDA
     #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC
@@ -125,7 +134,8 @@ namespace stdgpu
 
 /**
  * \def STDGPU_DEVICE_ONLY
- * \brief Platform-independent __device__ function annotation
+ * \hideinitializer
+ * \brief Platform-independent device function annotation
  */
 #if STDGPU_BACKEND == STDGPU_BACKEND_CUDA
     #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC
@@ -141,7 +151,8 @@ namespace stdgpu
 
 /**
  * \def STDGPU_CONSTANT
- * \brief Platform-independent _constant__ variable annotation
+ * \hideinitializer
+ * \brief Platform-independent constant variable annotation
  */
 #if STDGPU_BACKEND == STDGPU_BACKEND_CUDA
     #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC
@@ -155,16 +166,19 @@ namespace stdgpu
 
 
 /**
+ * \hideinitializer
  * \brief Code path: Host
  */
 #define STDGPU_CODE_HOST   0
 /**
+ * \hideinitializer
  * \brief Code path: Device
  */
 #define STDGPU_CODE_DEVICE 1
 
 /**
  * \def STDGPU_CODE
+ * \hideinitializer
  * \brief The code path
  */
 #if STDGPU_BACKEND == STDGPU_BACKEND_CUDA


### PR DESCRIPTION
Doxygen also includes macro definitions in the generated documentation. Since this step incorporates the macro definition by default, users might wonder about the actual values that are exposed to them. However, since most of these values are not meaningful at all without proper platform and backend context, hide them and just explain the formal meaning instead.

Furthermore, doxygen recognizes `#cmakedefine` but not `#cmakedefine01`unfortunately. Workaround this by manually defining the macros if doxygen has been detected.