### PR TITLE
README,doc: Significantly improve description and readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,35 +71,15 @@ Older compiler versions may also work but are currently considered experimental 
 
 ### Building
 
-Use the setup script to perform a clean build (release mode in this case, with default installation path to `./bin`) and run the tests:
+For convenience, we provide several cross-platform scripts to build the project. Note that some scripts depend on the build type, so there are scripts for both `debug` and `release` builds.
 
-```sh
-sh scripts/setup_release.sh
-```
-
-Building the library - in the respective build mode - afterwards can be done using
-
-```sh
-sh scripts/build_release.sh
-```
-
-and the tests can be executed using
-
-```sh
-sh scripts/run_tests_release.sh
-```
-
-The documentation can be build (optional, requires Doxygen) using
-
-```sh
-sh scripts/create_documentation.sh
-```
-
-To install the library at the configured path, use
-
-```sh
-sh scripts/install.sh
-```
+Command | Effect
+--- | ---
+<code>sh&nbsp;scripts/setup_&lt;build_type&gt;.sh</code> | Performs a full clean build of the project. Removes old build, configures the project (build path: `./build`), builds the project, and runs the unit tests.
+<code>sh&nbsp;scripts/build_&lt;build_type&gt;.sh</code> | (Re-)Builds the project. Requires that project is configured (or set up).
+<code>sh&nbsp;scripts/run_tests_&lt;build_type&gt;.sh</code> | Runs the unit tests. Requires that project is built.
+<code>sh&nbsp;scripts/create_documentation.sh</code> | Builds the documentation locally. Requires doxygen and that project is configured (or set up).
+<code>sh&nbsp;scripts/install.sh</code> | Installs the project at the configured install path (default: `./bin`).
 
 
 ## Usage
@@ -138,24 +118,26 @@ target_link_libraries(foo PUBLIC stdgpu::stdgpu)
 
 ### CMake Options
 
-To configure the library, you can set the following options:
+To configure the library, two sets of options are provided. The following build options control the build process:
 
-Build:
+Build Option | Effect | Default
+--- | --- | ---
+`STDGPU_BACKEND` | Device system backend | `STDGPU_BACKEND_CUDA`
+`STDGPU_SETUP_COMPILER_FLAGS` | Constructs the compiler flags | `ON` if standalone, `OFF` if included via `add_subdirectory`
+`STDGPU_BUILD_SHARED_LIBS` | Builds the project as a shared library, if set to `ON`, or as a static library, if set to `OFF` | `BUILD_SHARED_LIBS`
+`STDGPU_BUILD_EXAMPLES` | Build the example | `ON`
+`STDGPU_BUILD_TESTS` | Build the unit tests | `ON`
 
-- `STDGPU_BACKEND`: Device system backend, default: `STDGPU_BACKEND_CUDA`
-- `STDGPU_SETUP_COMPILER_FLAGS`: Constructs the compiler flags, default: `ON` if standalone, `OFF` if included via `add_subdirectory`
-- `STDGPU_BUILD_SHARED_LIBS`: Builds the project as a shared library, if set to `ON`, or as a static library, if set to `OFF`, default: `BUILD_SHARED_LIBS`
-- `STDGPU_BUILD_EXAMPLES`: Build the example, default: `ON`
-- `STDGPU_BUILD_TESTS`: Build the unit tests, default: `ON`
+In addition, the implementation of some functionality can be controlled via configuration options:
 
-Configuration:
-
-- `STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING`: Enable warnings when auxiliary arrays are allocated in memory API, default: `OFF`
-- `STDGPU_ENABLE_CONTRACT_CHECKS`: Enable contract checks, default: `OFF` if `CMAKE_BUILD_TYPE` equals `Release` or `MinSizeRel`, `ON` otherwise
-- `STDGPU_ENABLE_MANAGED_ARRAY_WARNING`: Enable warnings when managed memory is initialized on the host side but should be on device in memory API, default: `OFF`
-- `STDGPU_USE_32_BIT_INDEX`: Use 32-bit instead of 64-bit signed integer for `index_t`, default: `ON`
-- `STDGPU_USE_FAST_DESTROY`: Use fast destruction of allocated arrays (filled with a default value) by omitting destructor calls in memory API, default: `OFF`
-- `STDGPU_USE_FIBONACCI_HASHING`: Use Fibonacci Hashing instead of Modulo to compute hash bucket indices, default: `ON`
+Configuration Option | Effect | Default
+--- | --- | ---
+`STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING` | Enable warnings when auxiliary arrays are allocated in memory API | `OFF`
+`STDGPU_ENABLE_CONTRACT_CHECKS` | Enable contract checks | `OFF` if `CMAKE_BUILD_TYPE` equals `Release` or `MinSizeRel`, `ON` otherwise
+`STDGPU_ENABLE_MANAGED_ARRAY_WARNING` | Enable warnings when managed memory is initialized on the host side but should be on device in memory API | `OFF`
+`STDGPU_USE_32_BIT_INDEX` | Use 32-bit instead of 64-bit signed integer for `index_t` | `ON`
+`STDGPU_USE_FAST_DESTROY` | Use fast destruction of allocated arrays (filled with a default value) by omitting destructor calls in memory API | `OFF`
+`STDGPU_USE_FIBONACCI_HASHING` | Use Fibonacci Hashing instead of Modulo to compute hash bucket indices | `ON`
 
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -37,7 +37,15 @@
 
 ## About the Project
 
-stdgpu is an open-source library which provides several generic GPU data structures for fast and reliable data management. Our library aims to extend previous established frameworks, therefore bridging the gap between CPU and GPU computing. This way, it provides clean and familiar interfaces and integrates seamlessly into new as well as existing projects. stdgpu has been developed as part of the SLAMCast live telepresence system which performs real-time, large-scale 3D scene reconstruction from RGB-D camera images as well as real-time data streaming between a server and an arbitrary number of remote clients. We hope to foster further developments towards unified CPU and GPU computing and welcome contributions from the community.
+stdgpu is an open-source library which provides several generic GPU data structures for fast and reliable data management. stdgpu lets you write more complex algorithms rapidly that look like sequential CPU code but are executed in parallel on the GPU.
+
+- **Productivity**. Previous libraries such as thrust, VexCL, ArrayFire or Boost.Compute focus on the fast and efficient implementation of various algorithms for contiguously stored data to enhance productivity. stdgpu follows an *orthogonal approach* and focuses on *fast and reliable data management* to enable the rapid development of more general and flexible GPU algorithms just like their CPU counterparts.
+
+- **Interoperability**. Instead of providing yet another ecosystem, stdgpu is designed to be a *lightweight container library*. Therefore, a core feature of stdgpu is its interoperability with previous established frameworks, i.e. the thrust library, to enable a *seamless integration* into new as well as existing projects.
+
+- **Maintainability**. Following the trend in recent C++ standards of providing functionality for safer and more reliable programming, the philosophy of stdgpu   is to provide *clean and familiar functions* with strong guarantees that encourage users to write *more robust code* while giving them full control to achieve a high performance.
+
+stdgpu has been developed as part of the SLAMCast live telepresence system which performs real-time, large-scale 3D scene reconstruction from RGB-D camera images as well as real-time data streaming between a server and an arbitrary number of remote clients. We hope to foster further developments towards unified CPU and GPU computing and welcome contributions from the community.
 
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -237,17 +237,17 @@ private:
 };
 ```
 
-For more examples, please refer to the `examples` directory.
+More examples can be found in the <a href="https://github.com/stotko/stdgpu/tree/master/examples">`examples`</a> directory.
 
 
 ## Contributing
 
-If you encounter a bug or want to propose a new feature, please open an issue or pull request.
+For detailed information on how to contribute, see <a href="https://github.com/stotko/stdgpu/blob/master/CONTRIBUTING.md">`CONTRIBUTING`</a>.
 
 
 ## License
 
-Distributed under the Apache 2.0 License. See `LICENSE` for more information.
+Distributed under the Apache 2.0 License. See <a href="https://github.com/stotko/stdgpu/blob/master/LICENSE">`LICENSE`</a> for more information.
 
 If you use this library in one of your projects, please also cite the following publications:
 
@@ -277,4 +277,4 @@ If you use this library in one of your projects, please also cite the following 
 
 ## Contact
 
-Patrick Stotko - stotko@cs.uni-bonn.de
+Patrick Stotko - <a href="mailto:stotko@cs.uni-bonn.de">stotko@cs.uni-bonn.de</a>

--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ To compile the library, please make sure to fulfill the build requirements and e
 
 The following components (or newer versions) are required to build the library:
 
-- C++14 compiler:
-    - Ubuntu 18.04: GCC 7: `sudo apt install build-essential` or Clang: `sudo apt install clang`
-    - Windows: Visual Studio 2019
+- C++14 compiler (one of the following):
+    - Ubuntu 18.04:
+        - GCC 7: `sudo apt install build-essential`
+        - Clang 6: `sudo apt install clang`
+    - Windows:
+        - MSVC 19.2x (Visual Studio 2019)
 - CMake 3.13: `https://apt.kitware.com/`
 - Doxygen 1.8.13 (optional): `sudo apt install doxygen`
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="./doc/stdgpu_logo.png" width="400" />
+<img src="./doc/stdgpu_logo.png" width="500" />
 </p>
 
 <h1 align="center">stdgpu: Efficient STL-like Data Structures on the GPU</h1>
@@ -11,11 +11,17 @@
 <a href="https://stotko.github.io/stdgpu" alt="Documentation">
     <img src="https://img.shields.io/badge/docs-doxygen-blue.svg"/>
 </a>
+<a href="https://github.com/stotko/stdgpu/blob/master/CONTRIBUTING.md" alt="Contributing">
+    <img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat"/>
+</a>
 <a href="https://github.com/stotko/stdgpu/blob/master/LICENSE" alt="License">
     <img src="https://img.shields.io/github/license/stotko/stdgpu"/>
 </a>
-<a href="https://github.com/stotko/stdgpu/releases" alt="Release">
+<a href="https://github.com/stotko/stdgpu/releases" alt="Latest Release">
     <img src="https://img.shields.io/github/v/release/stotko/stdgpu"/>
+</a>
+<a href="https://github.com/stotko/stdgpu/compare/release...master" alt="Commits Since Latest Release">
+    <img src="https://img.shields.io/github/commits-since/stotko/stdgpu/latest"/>
 </a>
 </p>
 

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -17,10 +17,12 @@ To compile the library, please make sure to fulfill the build requirements and e
 
 The following components (or newer versions) are required to build the library:
 
-- C++14 compiler:
-    - Ubuntu 18.04: GCC 7: `sudo apt install build-essential` or Clang: `sudo apt install clang`
-    - Windows: Visual Studio 2019
-- CUDA 10.0: `https://developer.nvidia.com/cuda-downloads`
+- C++14 compiler (one of the following):
+    - Ubuntu 18.04:
+        - GCC 7: `sudo apt install build-essential`
+        - Clang 6: `sudo apt install clang`
+    - Windows:
+        - MSVC 19.2x (Visual Studio 2019)
 - CMake 3.13: `https://apt.kitware.com/`
 - Doxygen 1.8.13 (optional): `sudo apt install doxygen`
 

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -39,35 +39,15 @@ Older compiler versions may also work but are currently considered experimental 
 
 \subsection building Building
 
-Use the setup script to perform a clean build (release mode in this case, with default installation path to `./bin`) and run the tests:
+For convenience, we provide several cross-platform scripts to build the project. Note that some scripts depend on the build type, so there are scripts for both `debug` and `release` builds.
 
-\code{.sh}
-sh scripts/setup_release.sh
-\endcode
-
-Building the library - in the respective build mode - afterwards can be done using
-
-\code{.sh}
-sh scripts/build_release.sh
-\endcode
-
-and the tests can be executed using
-
-\code{.sh}
-sh scripts/run_tests_release.sh
-\endcode
-
-The documentation can be build (optional, requires Doxygen) using
-
-\code{.sh}
-sh scripts/create_documentation.sh
-\endcode
-
-To install the library at the configured path, use
-
-\code{.sh}
-sh scripts/install.sh
-\endcode
+Command | Effect
+--- | ---
+<code>sh&nbsp;scripts/setup_&lt;build_type&gt;.sh</code> | Performs a full clean build of the project. Removes old build, configures the project (build path: `./build`), builds the project, and runs the unit tests.
+<code>sh&nbsp;scripts/build_&lt;build_type&gt;.sh</code> | (Re-)Builds the project. Requires that project is configured (or set up).
+<code>sh&nbsp;scripts/run_tests_&lt;build_type&gt;.sh</code> | Runs the unit tests. Requires that project is built.
+<code>sh&nbsp;scripts/create_documentation.sh</code> | Builds the documentation locally. Requires doxygen and that project is configured (or set up).
+<code>sh&nbsp;scripts/install.sh</code> | Installs the project at the configured install path (default: `./bin`).
 
 
 \section usage Usage
@@ -106,24 +86,26 @@ target_link_libraries(foo PUBLIC stdgpu::stdgpu)
 
 \subsection cmake-options CMake Options
 
-To configure the library, you can set the following options:
+To configure the library, two sets of options are provided. The following build options control the build process:
 
-Build:
+Build Option | Effect | Default
+--- | --- | ---
+`STDGPU_BACKEND` | Device system backend | `STDGPU_BACKEND_CUDA`
+`STDGPU_SETUP_COMPILER_FLAGS` | Constructs the compiler flags | `ON` if standalone, `OFF` if included via `add_subdirectory`
+`STDGPU_BUILD_SHARED_LIBS` | Builds the project as a shared library, if set to `ON`, or as a static library, if set to `OFF` | `BUILD_SHARED_LIBS`
+`STDGPU_BUILD_EXAMPLES` | Build the example | `ON`
+`STDGPU_BUILD_TESTS` | Build the unit tests | `ON`
 
-- `STDGPU_BACKEND`: Device system backend, default: `STDGPU_BACKEND_CUDA`
-- `STDGPU_SETUP_COMPILER_FLAGS`: Constructs the compiler flags, default: `ON` if standalone, `OFF` if included via `add_subdirectory`
-- `STDGPU_BUILD_SHARED_LIBS`: Builds the project as a shared library, if set to `ON`, or as a static library, if set to `OFF`, default: `BUILD_SHARED_LIBS`
-- `STDGPU_BUILD_EXAMPLES`: Build the example, default: `ON`
-- `STDGPU_BUILD_TESTS`: Build the unit tests, default: `ON`
+In addition, the implementation of some functionality can be controlled via configuration options:
 
-Configuration:
-
-- `STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING`: Enable warnings when auxiliary arrays are allocated in memory API, default: `OFF`
-- `STDGPU_ENABLE_CONTRACT_CHECKS`: Enable contract checks, default: `OFF` if `CMAKE_BUILD_TYPE` equals `Release` or `MinSizeRel`, `ON` otherwise
-- `STDGPU_ENABLE_MANAGED_ARRAY_WARNING`: Enable warnings when managed memory is initialized on the host side but should be on device in memory API, default: `OFF`
-- `STDGPU_USE_32_BIT_INDEX`: Use 32-bit instead of 64-bit signed integer for `index_t`, default: `ON`
-- `STDGPU_USE_FAST_DESTROY`: Use fast destruction of allocated arrays (filled with a default value) by omitting destructor calls in memory API, default: `OFF`
-- `STDGPU_USE_FIBONACCI_HASHING`: Use Fibonacci Hashing instead of Modulo to compute hash bucket indices, default: `ON`
+Configuration Option | Effect | Default
+--- | --- | ---
+`STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING` | Enable warnings when auxiliary arrays are allocated in memory API | `OFF`
+`STDGPU_ENABLE_CONTRACT_CHECKS` | Enable contract checks | `OFF` if `CMAKE_BUILD_TYPE` equals `Release` or `MinSizeRel`, `ON` otherwise
+`STDGPU_ENABLE_MANAGED_ARRAY_WARNING` | Enable warnings when managed memory is initialized on the host side but should be on device in memory API | `OFF`
+`STDGPU_USE_32_BIT_INDEX` | Use 32-bit instead of 64-bit signed integer for `index_t` | `ON`
+`STDGPU_USE_FAST_DESTROY` | Use fast destruction of allocated arrays (filled with a default value) by omitting destructor calls in memory API | `OFF`
+`STDGPU_USE_FIBONACCI_HASHING` | Use Fibonacci Hashing instead of Modulo to compute hash bucket indices | `ON`
 
 
 \subsection examples Examples

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -5,7 +5,15 @@
 
 \section about-the-project About the Project
 
-stdgpu is an open-source library which provides several generic GPU data structures for fast and reliable data management. Our library aims to extend previous established frameworks, therefore bridging the gap between CPU and GPU computing. This way, it provides clean and familiar interfaces and integrates seamlessly into new as well as existing projects. stdgpu has been developed as part of the SLAMCast live telepresence system which performs real-time, large-scale 3D scene reconstruction from RGB-D camera images as well as real-time data streaming between a server and an arbitrary number of remote clients. We hope to foster further developments towards unified CPU and GPU computing and welcome contributions from the community.
+stdgpu is an open-source library which provides several generic GPU data structures for fast and reliable data management. stdgpu lets you write more complex algorithms rapidly that look like sequential CPU code but are executed in parallel on the GPU.
+
+- **Productivity**. Previous libraries such as thrust, VexCL, ArrayFire or Boost.Compute focus on the fast and efficient implementation of various algorithms for contiguously stored data to enhance productivity. stdgpu follows an *orthogonal approach* and focuses on *fast and reliable data management* to enable the rapid development of more general and flexible GPU algorithms just like their CPU counterparts.
+
+- **Interoperability**. Instead of providing yet another ecosystem, stdgpu is designed to be a *lightweight container library*. Therefore, a core feature of stdgpu is its interoperability with previous established frameworks, i.e. the thrust library, to enable a *seamless integration* into new as well as existing projects.
+
+- **Maintainability**. Following the trend in recent C++ standards of providing functionality for safer and more reliable programming, the philosophy of stdgpu   is to provide *clean and familiar functions* with strong guarantees that encourage users to write *more robust code* while giving them full control to achieve a high performance.
+
+stdgpu has been developed as part of the SLAMCast live telepresence system which performs real-time, large-scale 3D scene reconstruction from RGB-D camera images as well as real-time data streaming between a server and an arbitrary number of remote clients. We hope to foster further developments towards unified CPU and GPU computing and welcome contributions from the community.
 
 
 \section getting-started Getting Started

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -206,17 +206,17 @@ private:
 };
 \endcode
 
-For more examples, please refer to the `examples` directory.
+More examples can be found in the <a href="https://github.com/stotko/stdgpu/tree/master/examples">`examples`</a> directory.
 
 
 \section contributing Contributing
 
-If you encounter a bug or want to propose a new feature, please open an issue or pull request.
+For detailed information on how to contribute, see <a href="https://github.com/stotko/stdgpu/blob/master/CONTRIBUTING.md">`CONTRIBUTING`</a>.
 
 
 \section license License
 
-Distributed under the Apache 2.0 License. See `LICENSE` for more information.
+Distributed under the Apache 2.0 License. See <a href="https://github.com/stotko/stdgpu/blob/master/LICENSE">`LICENSE`</a> for more information.
 
 If you use this library in one of your research projects, please also cite the related literature:
 
@@ -246,6 +246,6 @@ If you use this library in one of your research projects, please also cite the r
 
 \section Contact
 
-Patrick Stotko - stotko@cs.uni-bonn.de
+Patrick Stotko - <a href="mailto:stotko@cs.uni-bonn.de">stotko@cs.uni-bonn.de</a>
 
 */

--- a/doc/style.css
+++ b/doc/style.css
@@ -73,3 +73,16 @@ div.headertitle
 }
 
 
+table.doxtable th
+{
+    background-color: white;
+    color: black;
+    text-align: center;
+    border: 1px solid #B3C1F6;
+}
+
+
+table.doxtable td
+{
+    border: 1px solid #B3C1F6;
+}


### PR DESCRIPTION
The `README` file as well as the main page of the built documentation provide an overview of the project and describe various aspects of the library. However, some aspects may be difficult to grasp from their visual presentation. Improve the readability and extend the project description to let readers immediately catch what the project does and how certain aspects work.