### PR TITLE
examples: Fix missing port to non-deprecated functions

### DIFF
--- a/examples/openmp/thrust_towards_ranges.cpp
+++ b/examples/openmp/thrust_towards_ranges.cpp
@@ -61,7 +61,7 @@ main()
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n);
-    stdgpu::unordered_set<int> set = stdgpu::unordered_set<int>::createDeviceObject(1024, n);
+    stdgpu::unordered_set<int> set = stdgpu::unordered_set<int>::createDeviceObject(n);
     stdgpu::atomic<int> sum = stdgpu::atomic<int>::createDeviceObject();
 
     thrust::sequence(stdgpu::device_begin(d_input), stdgpu::device_end(d_input),


### PR DESCRIPTION
A simpler factory function for `unordered_map` and `unordered_set` has been introduced in #46. However, the port to this new function is incomplete causing warnings. Port the overlooked OpenMP example to fix the warning.