### PR TITLE
bitset: Add further missing member functions

### DIFF
--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -215,6 +215,15 @@ class bitset
         STDGPU_DEVICE_ONLY reference
         operator[](const index_t n);
 
+        /**
+         * \brief Returns the bit at the given position
+         * \param[in] n The position
+         * \return The bit at this position
+         * \pre 0 <= n < size()
+         */
+        STDGPU_DEVICE_ONLY bool
+        test(const index_t n) const;
+
 
         /**
          * \brief Checks if this object is empty
@@ -236,6 +245,27 @@ class bitset
          */
         index_t
         count() const;
+
+        /**
+         * \brief Checks if all bits are set
+         * \return True if all bits are set, false otherwise
+         */
+        bool
+        all() const;
+
+        /**
+         * \brief Checks if any bits are set
+         * \return True if any bits are set, false otherwise
+         */
+        bool
+        any() const;
+
+        /**
+         * \brief Checks if none of the bits are set
+         * \return True if none of the bits are set, false otherwise
+         */
+        bool
+        none() const;
 
     private:
         using block_type = unsigned int;        /**< The type of the stored bit blocks */

--- a/src/stdgpu/impl/bitset.inc
+++ b/src/stdgpu/impl/bitset.inc
@@ -160,6 +160,42 @@ bitset::count() const
                                     thrust::plus<block_type>());
 }
 
+
+bool
+bitset::all() const
+{
+    if (size() == 0)
+    {
+        return false;
+    }
+
+    return count() == size();
+}
+
+
+bool
+bitset::any() const
+{
+    if (size() == 0)
+    {
+        return false;
+    }
+
+    return count() > 0;
+}
+
+
+bool
+bitset::none() const
+{
+    if (size() == 0)
+    {
+        return false;
+    }
+
+    return count() == 0;
+}
+
 } // namespace stdgpu
 
 

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -156,6 +156,13 @@ bitset::operator[](const index_t n)
 }
 
 
+inline STDGPU_DEVICE_ONLY bool
+bitset::test(const index_t n) const
+{
+    return operator[](n);
+}
+
+
 inline STDGPU_HOST_DEVICE bool
 bitset::empty() const
 {


### PR DESCRIPTION
Up to now, the `bitset` class defines the most important functions for atomic bitwise manipulation and access. Extend its capabilities by implementing more functions to get closer to `std::bitset` and `boost::dynamic_bitset`.