### PR TITLE
Container: Add get_allocator() function

### DIFF
--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -27,6 +27,7 @@
 #include <stdgpu/bitset.cuh>
 #include <stdgpu/cstddef.h>
 #include <stdgpu/iterator.h>
+#include <stdgpu/memory.h>
 #include <stdgpu/mutex.cuh>
 #include <stdgpu/platform.h>
 #include <stdgpu/ranges.h>
@@ -66,6 +67,8 @@ class deque
     public:
         using value_type        = T;                                        /**< T */
 
+        using allocator_type    = safe_device_allocator<T>;                 /**< safe_device_allocator<T> */
+
         using index_type        = index_t;                                  /**< index_t */
         using difference_type   = std::ptrdiff_t;                           /**< std::ptrdiff_t */
 
@@ -96,6 +99,13 @@ class deque
          * \brief Empty constructor
          */
         deque() = default;
+
+        /**
+         * \brief Returns the container allocator
+         * \return The container allocator
+         */
+        allocator_type
+        get_allocator() const;
 
         /**
          * \brief Reads the value at position n

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -67,6 +67,14 @@ deque<T>::destroyDeviceObject(deque<T>& device_object)
 
 
 template <typename T>
+inline STDGPU_DEVICE_ONLY typename deque<T>::allocator_type
+deque<T>::get_allocator() const
+{
+    return allocator_type();
+}
+
+
+template <typename T>
 inline STDGPU_DEVICE_ONLY typename deque<T>::reference
 deque<T>::at(const deque<T>::index_type n)
 {

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -25,6 +25,7 @@
 #include <stdgpu/cstddef.h>
 #include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
+#include <stdgpu/memory.h>
 #include <stdgpu/mutex.cuh>
 #include <stdgpu/platform.h>
 #include <stdgpu/ranges.h>
@@ -64,6 +65,8 @@ class unordered_base
         using key_equal         = KeyEqual;                                 /**< KeyEqual */
         using hasher            = Hash;                                     /**< Hash */
 
+        using allocator_type    = safe_device_allocator<Value>;             /**< safe_device_allocator<Value> */
+
         using reference         = value_type&;                              /**< value_type& */
         using const_reference   = const value_type&;                        /**< const value_type& */
         using pointer           = value_type*;                              /**< value_type* */
@@ -93,6 +96,13 @@ class unordered_base
          * \brief Empty constructor
          */
         unordered_base() = default;
+
+        /**
+         * \brief Returns the container allocator
+         * \return The container allocator
+         */
+        allocator_type
+        get_allocator() const;
 
         /**
          * \brief Checks if the object is valid

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -82,6 +82,14 @@ default_max_load_factor()
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
+inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::allocator_type
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::get_allocator() const
+{
+    return allocator_type();
+}
+
+
+template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
 inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::begin()
 {

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -41,6 +41,14 @@ struct select1st
 } // namespace detail
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
+inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::allocator_type
+unordered_map<Key, T, Hash, KeyEqual>::get_allocator() const
+{
+    return _base.get_allocator();
+}
+
+
+template <typename Key, typename T, typename Hash, typename KeyEqual>
 inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::iterator
 unordered_map<Key, T, Hash, KeyEqual>::begin()
 {

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -26,6 +26,14 @@ namespace stdgpu
 {
 
 template <typename Key, typename Hash, typename KeyEqual>
+inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::allocator_type
+unordered_set<Key, Hash, KeyEqual>::get_allocator() const
+{
+    return _base.get_allocator();
+}
+
+
+template <typename Key, typename Hash, typename KeyEqual>
 inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::iterator
 unordered_set<Key, Hash, KeyEqual>::begin()
 {

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -57,6 +57,14 @@ vector<T>::destroyDeviceObject(vector<T>& device_object)
 
 
 template <typename T>
+inline STDGPU_DEVICE_ONLY typename vector<T>::allocator_type
+vector<T>::get_allocator() const
+{
+    return allocator_type();
+}
+
+
+template <typename T>
 inline STDGPU_DEVICE_ONLY typename vector<T>::reference
 vector<T>::at(const vector<T>::index_type n)
 {

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -24,6 +24,7 @@
 
 #include <stdgpu/attribute.h>
 #include <stdgpu/functional.h>
+#include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
 #include <stdgpu/impl/unordered_base.cuh>
 
@@ -87,6 +88,8 @@ class unordered_map
         using key_equal         = KeyEqual;                                 /**< KeyEqual */
         using hasher            = Hash;                                     /**< Hash */
 
+        using allocator_type    = safe_device_allocator<thrust::pair<const Key, T>>;    /**< safe_device_allocator<thrust::pair<cont Key, T>> */
+
         using reference         = value_type&;                              /**< value_type& */
         using const_reference   = const value_type&;                        /**< const value_type& */
         using pointer           = value_type*;                              /**< value_type* */
@@ -131,6 +134,13 @@ class unordered_map
          * \brief Empty constructor
          */
         unordered_map() = default;
+
+        /**
+         * \brief Returns the container allocator
+         * \return The container allocator
+         */
+        allocator_type
+        get_allocator() const;
 
         /**
          * \brief Checks if the object is valid

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -24,6 +24,7 @@
 
 #include <stdgpu/attribute.h>
 #include <stdgpu/functional.h>
+#include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
 #include <stdgpu/impl/unordered_base.cuh>
 
@@ -75,6 +76,8 @@ class unordered_set
         using key_equal         = KeyEqual;                                 /**< KeyEqual */
         using hasher            = Hash;                                     /**< Hash */
 
+        using allocator_type    = safe_device_allocator<Key>;               /**< safe_device_allocator<Key> */
+
         using reference         = value_type&;                              /**< value_type& */
         using const_reference   = const value_type&;                        /**< const value_type& */
         using pointer           = value_type*;                              /**< value_type* */
@@ -119,6 +122,13 @@ class unordered_set
          * \brief Empty constructor
          */
         unordered_set() = default;
+
+        /**
+         * \brief Returns the container allocator
+         * \return The container allocator
+         */
+        allocator_type
+        get_allocator() const;
 
         /**
          * \brief Checks if the object is valid

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -27,6 +27,7 @@
 #include <stdgpu/bitset.cuh>
 #include <stdgpu/cstddef.h>
 #include <stdgpu/iterator.h>
+#include <stdgpu/memory.h>
 #include <stdgpu/mutex.cuh>
 #include <stdgpu/platform.h>
 #include <stdgpu/ranges.h>
@@ -64,6 +65,8 @@ class vector
     public:
         using value_type        = T;                                        /**< T */
 
+        using allocator_type    = safe_device_allocator<T>;                 /**< safe_device_allocator<T> */
+
         using index_type        = index_t;                                  /**< index_t */
         using difference_type   = std::ptrdiff_t;                           /**< std::ptrdiff_t */
 
@@ -94,6 +97,13 @@ class vector
          * \brief Empty constructor
          */
         vector() = default;
+
+        /**
+         * \brief Returns the container allocator
+         * \return The container allocator
+         */
+        allocator_type
+        get_allocator() const;
 
         /**
          * \brief Reads the value at position n


### PR DESCRIPTION
A further shortcoming of the container API is the lacking `Allocator` template parameter. Since the container are designed to operate on the device, the `allocator_type` is known. Add the definition and the respective `get_allocator()` function.