### PR TITLE
vector: Disallow non-defined bool specialization

### DIFF
--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -76,6 +76,9 @@ class vector
         using const_pointer     = const value_type*;                        /**< const value_type* */
 
 
+        static_assert(!std::is_same<T, bool>::value, "std::vector<bool> specialization not provided");
+
+
         /**
          * \brief Creates an object of this class on the GPU (device)
          * \param[in] capacity The capacity of the object


### PR DESCRIPTION
Until now, a specialization of `vector<bool>` is not given. Since the naming convention regarding `bitset` is still not decided (see #54), disallow the usage of `vector<bool>` since the implementation may not meet user expectation. This may be relaxed in the future.