### PR TITLE
doc: Fix missing exclude of internal OpenMP backend

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -845,7 +845,8 @@ EXCLUDE_SYMLINKS       = NO
 # exclude all test directories for example use the pattern */test/*
 
 EXCLUDE_PATTERNS       = */impl/* \
-                         */cuda/*
+                         */cuda/* \
+                         */openmp/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
In #32, the OpenMP backend has been introduced. However, since the functions are considered as internal implementation details, they should not appear in the documentation. Fix the doxygen configuration to exclude it.