### PR TITLE
memory: Add allocator_traits and deprecate old specialized version

### DIFF
--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -104,7 +104,7 @@ class deque
          * \brief Returns the container allocator
          * \return The container allocator
          */
-        allocator_type
+        STDGPU_HOST_DEVICE allocator_type
         get_allocator() const;
 
         /**

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -101,7 +101,7 @@ class unordered_base
          * \brief Returns the container allocator
          * \return The container allocator
          */
-        allocator_type
+        STDGPU_HOST_DEVICE allocator_type
         get_allocator() const;
 
         /**

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -41,7 +41,7 @@ struct select1st
 } // namespace detail
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::allocator_type
+inline STDGPU_HOST_DEVICE typename unordered_map<Key, T, Hash, KeyEqual>::allocator_type
 unordered_map<Key, T, Hash, KeyEqual>::get_allocator() const
 {
     return _base.get_allocator();

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -26,7 +26,7 @@ namespace stdgpu
 {
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::allocator_type
+inline STDGPU_HOST_DEVICE typename unordered_set<Key, Hash, KeyEqual>::allocator_type
 unordered_set<Key, Hash, KeyEqual>::get_allocator() const
 {
     return _base.get_allocator();

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -139,7 +139,7 @@ class unordered_map
          * \brief Returns the container allocator
          * \return The container allocator
          */
-        allocator_type
+        STDGPU_HOST_DEVICE allocator_type
         get_allocator() const;
 
         /**

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -127,7 +127,7 @@ class unordered_set
          * \brief Returns the container allocator
          * \return The container allocator
          */
-        allocator_type
+        STDGPU_HOST_DEVICE allocator_type
         get_allocator() const;
 
         /**

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -105,7 +105,7 @@ class vector
          * \brief Returns the container allocator
          * \return The container allocator
          */
-        allocator_type
+        STDGPU_HOST_DEVICE allocator_type
         get_allocator() const;
 
         /**


### PR DESCRIPTION
The containers use `default_allocator_traits` as well as the `allocate()` and `deallocate()` functions of its allocator directly. Although this approach was sufficient to relax several restrictions, it is inconsistent and does not reflect the desired behavior specified in the C++ standard. Introduce `allocator_traits<Allocator>` which resolves this problem and provide a standardized access the allocators. Deprecate the old `default_allocator_traits` which do not model the interface correctly. Note that the current implementation is oversimplified and always uses the fallback solution rather than detecting the capabilities of `Allocator`. Furthermore, this fixes an attribute issue in the recently introduced `get_allocator()` functions (see #56).