### PR TITLE
mutex: Fix attribute of mutex_ref porting aid

### DIFF
--- a/src/stdgpu/impl/mutex_detail.cuh
+++ b/src/stdgpu/impl/mutex_detail.cuh
@@ -23,7 +23,7 @@
 namespace stdgpu
 {
 
-inline STDGPU_HOST_DEVICE
+inline STDGPU_DEVICE_ONLY
 mutex_ref::operator mutex_array::reference()
 {
     return mutex_array::reference(_lock_bits[_n]);

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -180,7 +180,7 @@ class mutex_ref
          * \return The same reference object but represented as an instance of the more modern and lightweight mutex_array::reference class
          * \note This is a porting aid to mutex_array::reference which has the same API but is more lightweight than this class
          */
-        STDGPU_HOST_DEVICE
+        STDGPU_DEVICE_ONLY
         operator mutex_array::reference();
 
         /**


### PR DESCRIPTION
The recent introduction of `mutex_array::reference` (see #55) introduced a regression in the old `mutex_ref` class, i.e. the new porting aid function, which leads to compilation errors when using the CUDA backend. Change the attributes of the porting aid function from `STDGPU_HOST_DEVICE` to `STDGPU_DEVICE_ONLY` to fix this issue.