### PR TITLE
deque: Fix compilation error when calling device_range()

### DIFF
--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -48,6 +48,15 @@
 namespace stdgpu
 {
 
+namespace detail
+{
+
+template <typename T>
+struct deque_collect_positions;
+
+} // namespace detail
+
+
 /**
  * \brief A generic container similar to std::deque on the GPU
  * \tparam T The type of the stored elements
@@ -304,6 +313,9 @@ class deque
         device_range() const;
 
     private:
+
+        template <typename T2>
+        friend class detail::deque_collect_positions;
 
         STDGPU_DEVICE_ONLY bool
         occupied(const index_t n) const;


### PR DESCRIPTION
The `deque` class needs to compute the occupied entries when building a device range. However, since the internal function `occupied(index_t)` is private, the respective internal functor for computation must be a friend class. Otherwise, a compilation error occurs. Fix this issue by making the internal functor a friend class.