### PR TITLE
test: Explicitly instantiate templates

### DIFF
--- a/test/stdgpu/CMakeLists.txt
+++ b/test/stdgpu/CMakeLists.txt
@@ -8,7 +8,8 @@ target_sources(teststdgpu PRIVATE algorithm.cpp
                                   functional.cpp
                                   iterator.cpp
                                   limits.cpp
-                                  memory.cpp)
+                                  memory.cpp
+                                  ranges.cpp)
 
 add_subdirectory(${STDGPU_BACKEND_DIRECTORY})
 

--- a/test/stdgpu/algorithm.cpp
+++ b/test/stdgpu/algorithm.cpp
@@ -44,6 +44,29 @@ class stdgpu_algorithm : public ::testing::Test
 };
 
 
+// Explicit template instantiations
+namespace stdgpu
+{
+
+template
+STDGPU_HOST_DEVICE const int&
+min<int>(const int&,
+         const int&);
+
+template
+STDGPU_HOST_DEVICE const int&
+max<int>(const int&,
+         const int&);
+
+template
+STDGPU_HOST_DEVICE const int&
+clamp<int>(const int&,
+           const int&,
+           const int&);
+
+} // namespace stdgpu
+
+
 template <typename T>
 void check()
 {

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -46,6 +46,162 @@ class stdgpu_atomic : public ::testing::Test
 };
 
 
+// Explicit template instantiations
+namespace stdgpu
+{
+
+template
+class atomic<unsigned int>;
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::fetch_add<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::fetch_sub<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::fetch_and<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::fetch_or<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::fetch_xor<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::fetch_min<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::fetch_max<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::fetch_inc_mod<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::fetch_dec_mod<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::operator++<unsigned int, void>();
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::operator++<unsigned int, void>(int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::operator--<unsigned int, void>();
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::operator--<unsigned int, void>(int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::operator+=<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::operator-=<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::operator&=<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::operator|=<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic<unsigned int>::operator^=<unsigned int, void>(const unsigned int);
+
+template
+class atomic_ref<unsigned int>;
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::fetch_add<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::fetch_sub<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::fetch_and<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::fetch_or<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::fetch_xor<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::fetch_min<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::fetch_max<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::fetch_inc_mod<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::fetch_dec_mod<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::operator++<unsigned int, void>();
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::operator++<unsigned int, void>(int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::operator--<unsigned int, void>();
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::operator--<unsigned int, void>(int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::operator+=<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::operator-=<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::operator&=<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::operator|=<unsigned int, void>(const unsigned int);
+
+template
+STDGPU_DEVICE_ONLY unsigned int
+atomic_ref<unsigned int>::operator^=<unsigned int, void>(const unsigned int);
+
+} // namespace stdgpu
+
 
 template <typename T>
 void

--- a/test/stdgpu/bit.cpp
+++ b/test/stdgpu/bit.cpp
@@ -43,6 +43,38 @@ class stdgpu_bit : public ::testing::Test
 };
 
 
+// Explicit template instantiations
+namespace stdgpu
+{
+
+template
+STDGPU_HOST_DEVICE bool
+ispow2<unsigned int>(const unsigned int);
+
+template
+STDGPU_HOST_DEVICE unsigned int
+mod2<unsigned int>(const unsigned int,
+                   const unsigned int);
+
+template
+STDGPU_HOST_DEVICE unsigned int
+log2pow2<unsigned int>(const unsigned int number);
+
+template
+STDGPU_HOST_DEVICE unsigned long long int
+log2pow2<unsigned long long int>(const unsigned long long int);
+
+template
+STDGPU_HOST_DEVICE int
+popcount<unsigned int>(const unsigned int number);
+
+template
+STDGPU_HOST_DEVICE int
+popcount<unsigned long long int>(const unsigned long long int);
+
+} // namespace stdgpu
+
+
 void
 thread_ispow2_random(const stdgpu::index_t iterations,
                      const std::unordered_set<size_t>& pow2_list)

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -43,6 +43,27 @@ class stdgpu_deque : public ::testing::Test
 };
 
 
+// Explicit template instantiations
+namespace stdgpu
+{
+
+template
+class deque<int>;
+
+// Instantiation of variadic templates emit warnings in CUDA backend
+/*
+template
+STDGPU_DEVICE_ONLY bool
+deque<int>::emplace_back<int>(int&&);
+
+template
+STDGPU_DEVICE_ONLY bool
+deque<int>::emplace_front<int>(int&&);
+*/
+
+} // namespace stdgpu
+
+
 template <typename T>
 struct pop_back_deque
 {

--- a/test/stdgpu/functional.cpp
+++ b/test/stdgpu/functional.cpp
@@ -41,6 +41,67 @@ class stdgpu_functional : public ::testing::Test
 };
 
 
+// Explicit template instantiations
+namespace stdgpu
+{
+
+template
+class hash<bool>;
+
+template
+class hash<char>;
+
+template
+class hash<signed char>;
+
+template
+class hash<unsigned char>;
+
+template
+class hash<wchar_t>;
+
+template
+class hash<char16_t>;
+
+template
+class hash<char32_t>;
+
+template
+class hash<short>;
+
+template
+class hash<unsigned short>;
+
+template
+class hash<int>;
+
+template
+class hash<unsigned int>;
+
+template
+class hash<long>;
+
+template
+class hash<unsigned long>;
+
+template
+class hash<long long>;
+
+template
+class hash<unsigned long long>;
+
+template
+class hash<float>;
+
+template
+class hash<double>;
+
+template
+class hash<long double>;
+
+} // namespace stdgpu
+
+
 template <typename T>
 void
 check_integer()

--- a/test/stdgpu/iterator.cpp
+++ b/test/stdgpu/iterator.cpp
@@ -43,6 +43,132 @@ class stdgpu_iterator : public ::testing::Test
 };
 
 
+// Explicit template instantiations
+namespace stdgpu
+{
+
+template
+device_ptr<int>
+make_device<int>(int*);
+
+template
+host_ptr<int>
+make_host<int>(int*);
+
+template
+index64_t
+size(int*);
+
+template
+host_ptr<int>
+host_begin<int>(int*);
+
+template
+host_ptr<int>
+host_end<int>(int*);
+
+template
+device_ptr<int>
+device_begin<int>(int*);
+
+template
+device_ptr<int>
+device_end<int>(int*);
+
+template
+host_ptr<const int>
+host_begin<int>(const int*);
+
+template
+host_ptr<const int>
+host_end<int>(const int*);
+
+template
+device_ptr<const int>
+device_begin<int>(const int*);
+
+template
+device_ptr<const int>
+device_end<int>(const int*);
+
+template
+host_ptr<const int>
+host_cbegin<int>(const int*);
+
+template
+host_ptr<const int>
+host_cend<int>(const int*);
+
+template
+device_ptr<const int>
+device_cbegin<int>(const int*);
+
+template
+device_ptr<const int>
+device_cend<int>(const int*);
+
+/*
+template
+auto
+host_begin<vector<int>>(vector<int>& host_container) -> decltype(host_container.host_begin());
+
+template
+auto
+host_end<vector<int>>(vector<int>& host_container) -> decltype(host_container.host_end());
+
+template
+auto
+device_begin<vector<int>>(vector<int>& device_container) -> decltype(device_container.device_begin());
+
+template
+auto
+device_end<vector<int>>(vector<int>& device_container) -> decltype(device_container.device_end());
+
+template
+auto
+host_begin<vector<int>>(const vector<int>& host_container) -> decltype(host_container.host_begin());
+
+template
+auto
+host_end<vector<int>>(const vector<int>& host_container) -> decltype(host_container.host_end());
+
+template
+auto
+device_begin<vector<int>>(const vector<int>& device_container) -> decltype(device_container.device_begin());
+
+template
+auto
+device_end<vector<int>>(const vector<int>& device_container) -> decltype(device_container.device_end());
+
+template
+auto
+host_cbegin<vector<int>>(const vector<int>& host_container) -> decltype(host_container.host_cbegin());
+
+template
+auto
+host_cend<vector<int>>(const vector<int>& host_container) -> decltype(host_container.host_cend());
+
+template
+auto
+device_cbegin<vector<int>>(const vector<int>& device_container) -> decltype(device_container.device_cbegin());
+
+template
+auto
+device_cend<vector<int>>(const vector<int>& device_container) -> decltype(device_container.device_cend());
+
+template
+class back_insert_iterator<deque<int>>;
+
+template
+class front_insert_iterator<deque<int>>;
+
+template
+class insert_iterator<unordered_set<int>>;
+*/
+
+} // namespace stdgpu
+
+
 TEST_F(stdgpu_iterator, size_device_void)
 {
     int* array = createDeviceArray<int>(42);

--- a/test/stdgpu/limits.cpp
+++ b/test/stdgpu/limits.cpp
@@ -39,6 +39,67 @@ class stdgpu_limits : public ::testing::Test
 };
 
 
+// Explicit template instantiations
+namespace stdgpu
+{
+
+template
+class numeric_limits<bool>;
+
+template
+class numeric_limits<char>;
+
+template
+class numeric_limits<signed char>;
+
+template
+class numeric_limits<unsigned char>;
+
+template
+class numeric_limits<wchar_t>;
+
+template
+class numeric_limits<char16_t>;
+
+template
+class numeric_limits<char32_t>;
+
+template
+class numeric_limits<short>;
+
+template
+class numeric_limits<unsigned short>;
+
+template
+class numeric_limits<int>;
+
+template
+class numeric_limits<unsigned int>;
+
+template
+class numeric_limits<long>;
+
+template
+class numeric_limits<unsigned long>;
+
+template
+class numeric_limits<long long>;
+
+template
+class numeric_limits<unsigned long long>;
+
+template
+class numeric_limits<float>;
+
+template
+class numeric_limits<double>;
+
+template
+class numeric_limits<long double>;
+
+} // namespace stdgpu
+
+
 template <typename Type>
 void check()
 {

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -66,6 +66,138 @@ struct equal_to_number
 };
 
 
+// Explicit template instantiations
+template
+int*
+createDeviceArray<int>(const stdgpu::index64_t,
+                       const int);
+
+template
+int*
+createHostArray<int>(const stdgpu::index64_t,
+                     const int);
+
+template
+int*
+createManagedArray<int>(const stdgpu::index64_t,
+                        const int,
+                        const Initialization);
+
+template
+void
+destroyDeviceArray<int>(int*&);
+
+template
+void
+destroyHostArray<int>(int*&);
+
+template
+void
+destroyManagedArray<int>(int*&);
+
+template
+int*
+copyCreateDevice2HostArray<int>(const int*,
+                                const stdgpu::index64_t,
+                                const MemoryCopy);
+
+template
+int*
+copyCreateHost2DeviceArray<int>(const int*,
+                                const stdgpu::index64_t,
+                                const MemoryCopy);
+
+template
+int*
+copyCreateHost2HostArray<int>(const int*,
+                              const stdgpu::index64_t,
+                              const MemoryCopy);
+
+template
+int*
+copyCreateDevice2DeviceArray<int>(const int*,
+                                  const stdgpu::index64_t,
+                                  const MemoryCopy);
+
+template
+void
+copyDevice2HostArray<int>(const int*,
+                          const stdgpu::index64_t,
+                          int*,
+                          const MemoryCopy);
+
+template
+void
+copyHost2DeviceArray<int>(const int*,
+                          const stdgpu::index64_t,
+                          int*,
+                          const MemoryCopy);
+
+template
+void
+copyHost2HostArray<int>(const int*,
+                        const stdgpu::index64_t,
+                        int*,
+                        const MemoryCopy);
+
+template
+void
+copyDevice2DeviceArray<int>(const int*,
+                            const stdgpu::index64_t,
+                            int*,
+                            const MemoryCopy);
+
+namespace stdgpu
+{
+
+template
+class safe_device_allocator<int>;
+
+template
+class safe_host_allocator<int>;
+
+template
+class safe_managed_allocator<int>;
+
+template
+class allocator_traits<safe_device_allocator<int>>;
+
+template
+STDGPU_HOST_DEVICE void
+allocator_traits<safe_device_allocator<int>>::construct<int>(safe_device_allocator<int>&,
+                                                             int*);
+
+template
+STDGPU_HOST_DEVICE void
+allocator_traits<safe_device_allocator<int>>::destroy<int>(safe_device_allocator<int>&,
+                                                           int*);
+
+template
+STDGPU_HOST_DEVICE void
+destroy_at<int>(int*);
+
+template
+void
+destroy<int*>(int*,
+              int*);
+
+template
+int*
+destroy_n<int*, index_t>(int*,
+                         index_t);
+
+template
+dynamic_memory_type
+get_dynamic_memory_type<int>(int*);
+
+template
+index64_t
+size_bytes<int>(int*);
+
+} // namespace stdgpu
+
+
+
 TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_device)
 {
     int* array_device = createDeviceArray<int>(42);

--- a/test/stdgpu/ranges.cpp
+++ b/test/stdgpu/ranges.cpp
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2020 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <thrust/functional.h>
+
+#include <stdgpu/ranges.h>
+
+
+
+class stdgpu_ranges : public ::testing::Test
+{
+    protected:
+        // Called before each test
+        virtual void SetUp()
+        {
+
+        }
+
+        // Called after each test
+        virtual void TearDown()
+        {
+
+        }
+
+};
+
+
+// Explicit template instantiations
+namespace stdgpu
+{
+
+template
+class device_range<int>;
+
+template
+class host_range<int>;
+
+template
+class transform_range<device_range<int>, thrust::identity<int>>;
+
+} // namespace stdgpu
+
+
+/*
+TEST_F(stdgpu_ranges, test_name)
+{
+
+}
+*/
+
+

--- a/test/stdgpu/unordered_map.inc
+++ b/test/stdgpu/unordered_map.inc
@@ -21,6 +21,23 @@
 
 
 
+// Explicit template instantiations
+namespace stdgpu
+{
+
+template
+class unordered_map<int, float>;
+
+// Instantiation of variadic templates emit warnings in CUDA backend
+/*
+template
+STDGPU_DEVICE_ONLY thrust::pair<typename unordered_map<int, float>::iterator, bool>
+unordered_map<int, float>::emplace<int, float>(int&&, float&&);
+*/
+
+} // namespace stdgpu
+
+
 struct dummy
 {
     // no data in dummy

--- a/test/stdgpu/unordered_set.inc
+++ b/test/stdgpu/unordered_set.inc
@@ -21,6 +21,23 @@
 
 
 
+// Explicit template instantiations
+namespace stdgpu
+{
+
+template
+class unordered_set<int>;
+
+// Instantiation of variadic templates emit warnings in CUDA backend
+/*
+template
+STDGPU_DEVICE_ONLY thrust::pair<typename unordered_set<int>::iterator, bool>
+unordered_set<int>::emplace<int>(int&&);
+*/
+
+} // namespace stdgpu
+
+
 struct vec3int16
 {
     vec3int16() = default;

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -43,6 +43,23 @@ class stdgpu_vector : public ::testing::Test
 };
 
 
+// Explicit template instantiations
+namespace stdgpu
+{
+
+template
+class vector<int>;
+
+// Instantiation of variadic templates emit warnings in CUDA backend
+/*
+template
+STDGPU_DEVICE_ONLY bool
+vector<int>::emplace_back<int>(int&&);
+*/
+
+} // namespace stdgpu
+
+
 template <typename T>
 struct pop_back_vector
 {


### PR DESCRIPTION
A further step to improve the reliability of the library and to reduce the likelihood of introducing regressions is the extension of the unit tests to perform explicit template instantiation. This not only ensures that every function, including the not-yet-tested ones, will compile but also makes the code coverage report a lot more realistic since these functions are currently discarded in the report. Although the list of instantiations is not totally complete, this significantly improves the overall (build) coverage.