### PR TITLE
cmake: Fix minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13...3.15)
+cmake_minimum_required(VERSION 3.15...3.16)
 
 
 project(stdgpu VERSION 1.1.0

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The following components (or newer versions) are required to build the library:
         - Clang 6: `sudo apt install clang`
     - Windows:
         - MSVC 19.2x (Visual Studio 2019)
-- CMake 3.13: `https://apt.kitware.com/`
+- CMake 3.15: `https://apt.kitware.com/`
 - Doxygen 1.8.13 (optional): `sudo apt install doxygen`
 - lcov 1.13 (optional): `sudo apt install lcov`
 

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -31,7 +31,7 @@ The following components (or newer versions) are required to build the library:
         - Clang 6: `sudo apt install clang`
     - Windows:
         - MSVC 19.2x (Visual Studio 2019)
-- CMake 3.13: `https://apt.kitware.com/`
+- CMake 3.15: `https://apt.kitware.com/`
 - Doxygen 1.8.13 (optional): `sudo apt install doxygen`
 - lcov 1.13 (optional): `sudo apt install lcov`
 

--- a/scripts/utils/install_cmake_ubuntu1804.sh
+++ b/scripts/utils/install_cmake_ubuntu1804.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-# Install CMake 3.13+ from official Kitware repository (see https://apt.kitware.com/)
+# Install CMake 3.15+ from official Kitware repository (see https://apt.kitware.com/)
 sudo apt-get update
 sudo rm /usr/local/bin/ccmake* /usr/local/bin/cmake* /usr/local/bin/cpack* /usr/local/bin/ctest*
 sudo apt-get install apt-transport-https ca-certificates gnupg software-properties-common wget


### PR DESCRIPTION
The current minimum required CMake version is set to 3.13 since the project uses some of its newly introduced features. However, the project is configured to use the `NEW` behavior of more recent CMake policies until version 3.15. Since the CI uses the newest version, this effectively only verifies builds where the minimum required version would be set to 3.15.

This caused a further implicit dependency getting unnoticed so far. When building on Windows, a further requirement is the `NEW` behavior of [CMake policy CMP00091](https://cmake.org/cmake/help/latest/policy/CMP0091.html). Fix this issue by increasing the minimum required CMake version. Futhermore, increase the maximum  version where policies are set to `NEW` to the most recent version 3.16.