### PR TITLE
General: Add codecov CI task

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 <a href="https://dev.azure.com/patrickstotko/stdgpu/_build/latest?definitionId=3&branchName=master" alt="Build Status">
     <img src="https://dev.azure.com/patrickstotko/stdgpu/_apis/build/status/stotko.stdgpu?branchName=master"/>
 </a>
+<a href="https://codecov.io/gh/stotko/stdgpu">
+  <img src="https://codecov.io/gh/stotko/stdgpu/branch/master/graph/badge.svg" />
+</a>
 <a href="https://stotko.github.io/stdgpu" alt="Documentation">
     <img src="https://img.shields.io/badge/docs-doxygen-blue.svg"/>
 </a>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
 
   steps:
     - task: Bash@3
-      displayName: Install CMake 3.13+
+      displayName: Install CMake 3.15+
       inputs:
         targetType: 'inline'
         script: |
@@ -103,3 +103,57 @@ jobs:
         script: |
             set -e
             sh scripts/run_tests_$(BuildType).sh
+
+- job:
+  displayName: Code Coverage OpenMP
+  pool:
+    vmImage: 'ubuntu-18.04'
+
+  steps:
+    - task: Bash@3
+      displayName: Install CMake 3.15+
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/install_cmake_ubuntu1804.sh
+
+    - task: Bash@3
+      displayName: Install lcov
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/install_lcov_ubuntu1804.sh
+
+    - task: Bash@3
+      displayName: Configure project
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/ci/configure_openmp_lcov.sh
+
+    - task: Bash@3
+      displayName: Build project
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/build_debug.sh
+
+    - task: Bash@3
+      displayName: Run coverage
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/run_coverage.sh
+
+    - task: Bash@3
+      displayName: Upload coverage report
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            bash <(curl -s https://codecov.io/bash) -f build/stdgpu_coverage.info

--- a/cmake/code_coverage.cmake
+++ b/cmake/code_coverage.cmake
@@ -164,7 +164,9 @@ function(SETUP_TARGET_FOR_COVERAGE)
         COMMAND ${LCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.info --output-file ${Coverage_NAME}.total
         COMMAND ${LCOV_PATH} --remove ${Coverage_NAME}.total ${COVERAGE_EXCLUDES} --output-file ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
         COMMAND ${GENHTML_PATH} -o ${Coverage_NAME} ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
-        COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.base ${Coverage_NAME}.total ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned
+        # Modification: Keep cleaned version
+        COMMAND ${CMAKE_COMMAND} -E remove ${Coverage_NAME}.base ${Coverage_NAME}.total ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info
+        COMMAND ${CMAKE_COMMAND} -E rename ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info.cleaned ${PROJECT_BINARY_DIR}/${Coverage_NAME}.info
 
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         DEPENDS ${Coverage_DEPENDENCIES}

--- a/scripts/ci/configure_openmp_lcov.sh
+++ b/scripts/ci/configure_openmp_lcov.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Create build directory
+sh scripts/utils/create_empty_directory.sh build
+
+# Download external dependencies
+sh scripts/utils/download_dependencies.sh
+
+# Configure project
+sh scripts/utils/configure_debug.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_BUILD_TEST_COVERAGE=ON -Dthrust_ROOT=external/thrust

--- a/scripts/utils/install_lcov_ubuntu1804.sh
+++ b/scripts/utils/install_lcov_ubuntu1804.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+# Install lcov
+sudo apt-get update
+sudo apt-get install lcov


### PR DESCRIPTION
Due to the recent support of generating code coverty information (see #65), this process can now be automated by the CI. Setup a respective task in Azure Pipelines CI and upload the report to codecov.io. Furthermore, add the respective badge to the `README` file.