### PR TITLE
atomic: Add tests for operator equals functions

### DIFF
--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -237,11 +237,11 @@ TEST_F(stdgpu_atomic, load_and_store_unsigned_long_long_int)
 
 
 template <typename T>
-struct sum_seqeuence
+struct add_sequence
 {
     stdgpu::atomic<T> value;
 
-    sum_seqeuence(stdgpu::atomic<T> value)
+    add_sequence(stdgpu::atomic<T> value)
         : value(value)
     {
 
@@ -251,6 +251,25 @@ struct sum_seqeuence
     operator()(const T x)
     {
         value.fetch_add(x);
+    }
+};
+
+
+template <typename T>
+struct add_equals_sequence
+{
+    stdgpu::atomic<T> value;
+
+    add_equals_sequence(stdgpu::atomic<T> value)
+        : value(value)
+    {
+
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const T x)
+    {
+        value += x;
     }
 };
 
@@ -267,7 +286,28 @@ sequence_fetch_add()
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
     thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
-                     sum_seqeuence<T>(value));
+                     add_sequence<T>(value));
+
+    EXPECT_EQ(value.load(), T(N * (N + 1) / 2));
+
+    destroyDeviceArray<T>(sequence);
+    stdgpu::atomic<T>::destroyDeviceObject(value);
+}
+
+
+template <typename T>
+void
+sequence_operator_add_equals()
+{
+    const stdgpu::index_t N = 40000;
+    T* sequence = createDeviceArray<T>(N);
+    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
+                     T(1));
+
+    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+
+    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
+                     add_equals_sequence<T>(value));
 
     EXPECT_EQ(value.load(), T(N * (N + 1) / 2));
 
@@ -292,12 +332,28 @@ TEST_F(stdgpu_atomic, fetch_add_unsigned_long_long_int)
 }
 
 
+TEST_F(stdgpu_atomic, operator_add_equals_int)
+{
+    sequence_operator_add_equals<int>();
+}
+
+TEST_F(stdgpu_atomic, operator_add_equals_unsigned_int)
+{
+    sequence_operator_add_equals<unsigned int>();
+}
+
+TEST_F(stdgpu_atomic, operator_add_equals_unsigned_long_long_int)
+{
+    sequence_operator_add_equals<unsigned long long int>();
+}
+
+
 template <typename T>
-struct desum_sequence
+struct sub_sequence
 {
     stdgpu::atomic<T> value;
 
-    desum_sequence(stdgpu::atomic<T> value)
+    sub_sequence(stdgpu::atomic<T> value)
         : value(value)
     {
 
@@ -309,6 +365,26 @@ struct desum_sequence
         value.fetch_sub(x);
     }
 };
+
+
+template <typename T>
+struct sub_equals_sequence
+{
+    stdgpu::atomic<T> value;
+
+    sub_equals_sequence(stdgpu::atomic<T> value)
+        : value(value)
+    {
+
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const T x)
+    {
+        value -= x;
+    }
+};
+
 
 template <typename T>
 void
@@ -322,12 +398,38 @@ sequence_fetch_sub()
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
     thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
-                     sum_seqeuence<T>(value));
+                     add_sequence<T>(value));
 
     ASSERT_EQ(value.load(), T(N * (N + 1) / 2));
 
     thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
-                     desum_sequence<T>(value));
+                     sub_sequence<T>(value));
+
+    EXPECT_EQ(value.load(), T(0));
+
+    destroyDeviceArray<T>(sequence);
+    stdgpu::atomic<T>::destroyDeviceObject(value);
+}
+
+
+template <typename T>
+void
+sequence_operator_sub_equals()
+{
+    const stdgpu::index_t N = 40000;
+    T* sequence = createDeviceArray<T>(N);
+    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
+                     T(1));
+
+    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+
+    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
+                     add_equals_sequence<T>(value));
+
+    ASSERT_EQ(value.load(), T(N * (N + 1) / 2));
+
+    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
+                     sub_equals_sequence<T>(value));
 
     EXPECT_EQ(value.load(), T(0));
 
@@ -349,6 +451,22 @@ TEST_F(stdgpu_atomic, fetch_sub_unsigned_int)
 TEST_F(stdgpu_atomic, fetch_sub_unsigned_long_long_int)
 {
     sequence_fetch_sub<unsigned long long int>();
+}
+
+
+TEST_F(stdgpu_atomic, operator_sub_equals_int)
+{
+    sequence_operator_sub_equals<int>();
+}
+
+TEST_F(stdgpu_atomic, operator_sub_equals_unsigned_int)
+{
+    sequence_operator_sub_equals<unsigned int>();
+}
+
+TEST_F(stdgpu_atomic, operator_sub_equals_unsigned_long_long_int)
+{
+    sequence_operator_sub_equals<unsigned long long int>();
 }
 
 
@@ -383,6 +501,27 @@ struct or_sequence
 
 
 template <typename T>
+struct or_equals_sequence
+{
+    stdgpu::atomic<T> value;
+
+    or_equals_sequence(stdgpu::atomic<T> value)
+        : value(value)
+    {
+
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const stdgpu::index_t i)
+    {
+        T pattern = static_cast<T>(1) << i;
+
+        value |= pattern;
+    }
+};
+
+
+template <typename T>
 void
 sequence_fetch_or()
 {
@@ -392,6 +531,27 @@ sequence_fetch_or()
 
     thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0), thrust::counting_iterator<stdgpu::index_t>(N),
                      or_sequence<T>(value));
+
+    T value_pattern = value.load();
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_TRUE(bit_set(value_pattern, i));
+    }
+
+    stdgpu::atomic<T>::destroyDeviceObject(value);
+}
+
+
+template <typename T>
+void
+sequence_operator_or_equals()
+{
+    const stdgpu::index_t N = std::numeric_limits<T>::digits + std::numeric_limits<T>::is_signed;
+
+    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+
+    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0), thrust::counting_iterator<stdgpu::index_t>(N),
+                     or_equals_sequence<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -419,6 +579,22 @@ TEST_F(stdgpu_atomic, fetch_or_unsigned_long_long_int)
 }
 
 
+TEST_F(stdgpu_atomic, operator_or_equals_int)
+{
+    sequence_operator_or_equals<int>();
+}
+
+TEST_F(stdgpu_atomic, operator_or_equals_unsigned_int)
+{
+    sequence_operator_or_equals<unsigned int>();
+}
+
+TEST_F(stdgpu_atomic, operator_or_equals_unsigned_long_long_int)
+{
+    sequence_operator_or_equals<unsigned long long int>();
+}
+
+
 template <typename T>
 struct and_sequence
 {
@@ -439,6 +615,30 @@ struct and_sequence
         T pattern = one_pattern - (static_cast<T>(1) << i);
 
         value.fetch_and(pattern);
+    }
+};
+
+
+template <typename T>
+struct and_equals_sequence
+{
+    stdgpu::atomic<T> value;
+    T one_pattern;
+
+    and_equals_sequence(stdgpu::atomic<T> value,
+                        T one_pattern)
+        : value(value),
+          one_pattern(one_pattern)
+    {
+
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const stdgpu::index_t i)
+    {
+        T pattern = one_pattern - (static_cast<T>(1) << i);
+
+        value &= pattern;
     }
 };
 
@@ -475,6 +675,38 @@ sequence_fetch_and()
 }
 
 
+template <typename T>
+void
+sequence_operator_and_equals()
+{
+    const stdgpu::index_t N = std::numeric_limits<T>::digits + std::numeric_limits<T>::is_signed;
+
+    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+
+    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0), thrust::counting_iterator<stdgpu::index_t>(N),
+                     or_equals_sequence<T>(value));
+
+    T value_pattern = value.load();
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        ASSERT_TRUE(bit_set(value_pattern, i));
+    }
+
+    T one_pattern = value.load();   // We previously filled this with 1's
+
+    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0), thrust::counting_iterator<stdgpu::index_t>(N),
+                     and_equals_sequence<T>(value, one_pattern));
+
+    value_pattern = value.load();
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_FALSE(bit_set(value_pattern, i));
+    }
+
+    stdgpu::atomic<T>::destroyDeviceObject(value);
+}
+
+
 TEST_F(stdgpu_atomic, fetch_and_int)
 {
     sequence_fetch_and<int>();
@@ -488,6 +720,22 @@ TEST_F(stdgpu_atomic, fetch_and_unsigned_int)
 TEST_F(stdgpu_atomic, fetch_and_unsigned_long_long_int)
 {
     sequence_fetch_and<unsigned long long int>();
+}
+
+
+TEST_F(stdgpu_atomic, operator_and_equals_int)
+{
+    sequence_operator_and_equals<int>();
+}
+
+TEST_F(stdgpu_atomic, operator_and_equals_unsigned_int)
+{
+    sequence_operator_and_equals<unsigned int>();
+}
+
+TEST_F(stdgpu_atomic, operator_and_equals_unsigned_long_long_int)
+{
+    sequence_operator_and_equals<unsigned long long int>();
 }
 
 
@@ -513,6 +761,27 @@ struct xor_sequence
 
 
 template <typename T>
+struct xor_equals_sequence
+{
+    stdgpu::atomic<T> value;
+
+    xor_equals_sequence(stdgpu::atomic<T> value)
+        : value(value)
+    {
+
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const stdgpu::index_t i)
+    {
+        T pattern = static_cast<T>(1) << i;
+
+        value ^= pattern;
+    }
+};
+
+
+template <typename T>
 void
 sequence_fetch_xor()
 {
@@ -522,6 +791,27 @@ sequence_fetch_xor()
 
     thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0), thrust::counting_iterator<stdgpu::index_t>(N),
                      xor_sequence<T>(value));
+
+    T value_pattern = value.load();
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_TRUE(bit_set(value_pattern, i));
+    }
+
+    stdgpu::atomic<T>::destroyDeviceObject(value);
+}
+
+
+template <typename T>
+void
+sequence_operator_xor_equals()
+{
+    const stdgpu::index_t N = std::numeric_limits<T>::digits + std::numeric_limits<T>::is_signed;
+
+    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+
+    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0), thrust::counting_iterator<stdgpu::index_t>(N),
+                     xor_equals_sequence<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -546,6 +836,22 @@ TEST_F(stdgpu_atomic, fetch_xor_unsigned_int)
 TEST_F(stdgpu_atomic, fetch_xor_unsigned_long_long_int)
 {
     sequence_fetch_xor<unsigned long long int>();
+}
+
+
+TEST_F(stdgpu_atomic, operator_xor_equals_int)
+{
+    sequence_operator_xor_equals<int>();
+}
+
+TEST_F(stdgpu_atomic, operator_xor_equals_unsigned_int)
+{
+    sequence_operator_xor_equals<unsigned int>();
+}
+
+TEST_F(stdgpu_atomic, operator_xor_equals_unsigned_long_long_int)
+{
+    sequence_operator_xor_equals<unsigned long long int>();
 }
 
 


### PR DESCRIPTION
The `operator<op>=` functions with `<op>= {+, -, |, &, ^}` of the `atomic` class are not yet covered in the unit tests. Extend the test suite to fix this problem.