### PR TITLE
unordered_map,unordered_set: Extend unit tests

### DIFF
--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -200,6 +200,13 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, hash_number_collisions)
 }
 
 
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, empty_size_limits)
+{
+    EXPECT_LE(hash_datastructure.size(), hash_datastructure.max_size());
+    EXPECT_LE(hash_datastructure.load_factor(), hash_datastructure.max_load_factor());
+}
+
+
 namespace
 {
     struct insert_single

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -1292,6 +1292,7 @@ namespace
         stdgpu::index_t number_inserted = thrust::reduce(stdgpu::device_cbegin(inserted), stdgpu::device_cend(inserted));
 
         EXPECT_EQ(number_inserted, N);
+        EXPECT_FALSE(hash_datastructure.empty());
         EXPECT_EQ(hash_datastructure.size(), N);
         EXPECT_TRUE(hash_datastructure.valid());
 
@@ -1319,6 +1320,7 @@ namespace
         stdgpu::index_t number_inserted = thrust::reduce(stdgpu::device_cbegin(inserted), stdgpu::device_cend(inserted));
 
         EXPECT_EQ(number_inserted, N);
+        EXPECT_FALSE(hash_datastructure.empty());
         EXPECT_EQ(hash_datastructure.size(), N);
         EXPECT_TRUE(hash_datastructure.valid());
 
@@ -1345,12 +1347,39 @@ namespace
         stdgpu::index_t number_erased = thrust::reduce(stdgpu::device_cbegin(erased), stdgpu::device_cend(erased));
 
         EXPECT_EQ(number_erased, N);
+        EXPECT_TRUE(hash_datastructure.empty());
         EXPECT_EQ(hash_datastructure.size(), 0);
 
 
         destroyDeviceArray<test_unordered_datastructure::key_type>(positions);
         destroyDeviceArray<stdgpu::index_t>(erased);
     }
+
+    struct Key2ValueFunctor
+    {
+        test_unordered_datastructure hash_datastructure;
+        test_unordered_datastructure::key_type* keys;
+        test_unordered_datastructure::value_type* values;
+
+        Key2ValueFunctor(const test_unordered_datastructure& hash_datastructure,
+                         test_unordered_datastructure::key_type* keys,
+                         test_unordered_datastructure::value_type* values)
+            : hash_datastructure(hash_datastructure),
+              keys(keys),
+              values(values)
+        {
+
+        }
+
+        STDGPU_HOST_DEVICE void
+        operator()(const stdgpu::index_t i)
+        {
+            test_unordered_datastructure::allocator_type a = hash_datastructure.get_allocator();
+            stdgpu::allocator_traits<test_unordered_datastructure::allocator_type>::construct(a,
+                                                                                              &(values[i]),
+                                                                                              STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(keys[i]));
+        }
+    };
 }
 
 
@@ -1382,6 +1411,114 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_unique_parallel)
 
     erase_unique_parallel(hash_datastructure, host_positions, N);
 
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
+}
+
+
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_range_unique_parallel)
+{
+    const stdgpu::index_t N = 100000;
+
+    test_unordered_datastructure::key_type* host_positions  = create_unique_random_host_keys(N);
+    test_unordered_datastructure::key_type* positions       = copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
+    test_unordered_datastructure::value_type* values        = createDeviceArray<test_unordered_datastructure::value_type>(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     Key2ValueFunctor(hash_datastructure, positions, values));
+
+    hash_datastructure.insert(stdgpu::device_begin(values), stdgpu::device_end(values));
+
+    EXPECT_FALSE(hash_datastructure.empty());
+    EXPECT_EQ(hash_datastructure.size(), N);
+    EXPECT_TRUE(hash_datastructure.valid());
+
+
+    destroyDeviceArray<test_unordered_datastructure::value_type>(values);
+    destroyDeviceArray<test_unordered_datastructure::key_type>(positions);
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
+}
+
+
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_const_range_unique_parallel)
+{
+    const stdgpu::index_t N = 100000;
+
+    test_unordered_datastructure::key_type* host_positions  = create_unique_random_host_keys(N);
+    test_unordered_datastructure::key_type* positions       = copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
+    test_unordered_datastructure::value_type* values        = createDeviceArray<test_unordered_datastructure::value_type>(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     Key2ValueFunctor(hash_datastructure, positions, values));
+
+    hash_datastructure.insert(stdgpu::device_cbegin(values), stdgpu::device_cend(values));
+
+    EXPECT_FALSE(hash_datastructure.empty());
+    EXPECT_EQ(hash_datastructure.size(), N);
+    EXPECT_TRUE(hash_datastructure.valid());
+
+
+    destroyDeviceArray<test_unordered_datastructure::value_type>(values);
+    destroyDeviceArray<test_unordered_datastructure::key_type>(positions);
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
+}
+
+
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_range_unique_parallel)
+{
+    const stdgpu::index_t N = 100000;
+
+    test_unordered_datastructure::key_type* host_positions  = create_unique_random_host_keys(N);
+    test_unordered_datastructure::key_type* positions       = copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
+    test_unordered_datastructure::value_type* values        = createDeviceArray<test_unordered_datastructure::value_type>(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     Key2ValueFunctor(hash_datastructure, positions, values));
+
+    hash_datastructure.insert(stdgpu::device_begin(values), stdgpu::device_end(values));
+
+    EXPECT_FALSE(hash_datastructure.empty());
+    EXPECT_EQ(hash_datastructure.size(), N);
+    EXPECT_TRUE(hash_datastructure.valid());
+
+    hash_datastructure.erase(stdgpu::device_begin(positions), stdgpu::device_end(positions));
+
+    EXPECT_TRUE(hash_datastructure.empty());
+    EXPECT_EQ(hash_datastructure.size(), 0);
+    EXPECT_TRUE(hash_datastructure.valid());
+
+
+    destroyDeviceArray<test_unordered_datastructure::value_type>(values);
+    destroyDeviceArray<test_unordered_datastructure::key_type>(positions);
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
+}
+
+
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_const_range_unique_parallel)
+{
+    const stdgpu::index_t N = 100000;
+
+    test_unordered_datastructure::key_type* host_positions  = create_unique_random_host_keys(N);
+    test_unordered_datastructure::key_type* positions       = copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
+    test_unordered_datastructure::value_type* values        = createDeviceArray<test_unordered_datastructure::value_type>(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     Key2ValueFunctor(hash_datastructure, positions, values));
+
+    hash_datastructure.insert(stdgpu::device_cbegin(values), stdgpu::device_cend(values));
+
+    EXPECT_FALSE(hash_datastructure.empty());
+    EXPECT_EQ(hash_datastructure.size(), N);
+    EXPECT_TRUE(hash_datastructure.valid());
+
+    hash_datastructure.erase(stdgpu::device_cbegin(positions), stdgpu::device_cend(positions));
+
+    EXPECT_TRUE(hash_datastructure.empty());
+    EXPECT_EQ(hash_datastructure.size(), 0);
+    EXPECT_TRUE(hash_datastructure.valid());
+
+
+    destroyDeviceArray<test_unordered_datastructure::value_type>(values);
+    destroyDeviceArray<test_unordered_datastructure::key_type>(positions);
     destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
 }
 
@@ -1441,6 +1578,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_and_erase_unique_parall
 
     EXPECT_EQ(number_inserted, N);
     EXPECT_EQ(number_erased, N);
+    EXPECT_TRUE(hash_datastructure.empty());
     EXPECT_EQ(hash_datastructure.size(), 0);
     EXPECT_TRUE(hash_datastructure.valid());
 

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -1600,6 +1600,104 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_and_erase_unique_parall
 
 namespace
 {
+    struct store_bucket_sizes
+    {
+        test_unordered_datastructure hash_datastructure;
+        stdgpu::index_t* bucket_sizes;
+
+        store_bucket_sizes(test_unordered_datastructure hash_datastructure,
+                           stdgpu::index_t* bucket_sizes)
+            : hash_datastructure(hash_datastructure),
+              bucket_sizes(bucket_sizes)
+        {
+
+        }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(const stdgpu::index_t i)
+        {
+            bucket_sizes[i] = hash_datastructure.bucket_size(i);
+        }
+    };
+
+
+    struct store_counts
+    {
+        test_unordered_datastructure hash_datastructure;
+        test_unordered_datastructure::key_type* keys;
+        stdgpu::index_t* counts;
+
+        store_counts(test_unordered_datastructure hash_datastructure,
+                     test_unordered_datastructure::key_type* keys,
+                     stdgpu::index_t* counts)
+            : hash_datastructure(hash_datastructure),
+              keys(keys),
+              counts(counts)
+        {
+
+        }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(const stdgpu::index_t i)
+        {
+            counts[i] = hash_datastructure.count(keys[i]);
+        }
+    };
+}
+
+
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_size_sum)
+{
+    const stdgpu::index_t N = 10000;
+
+    test_unordered_datastructure::key_type* host_positions  = insert_unique_parallel(hash_datastructure, N);
+    test_unordered_datastructure::key_type* positions       = copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
+
+    stdgpu::index_t* bucket_sizes = createDeviceArray<stdgpu::index_t>(hash_datastructure.bucket_count());
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(hash_datastructure.bucket_count()),
+                     store_bucket_sizes(hash_datastructure, bucket_sizes));
+
+    stdgpu::index_t bucket_size_sum = thrust::reduce(stdgpu::device_cbegin(bucket_sizes), stdgpu::device_cend(bucket_sizes));
+
+    EXPECT_EQ(bucket_size_sum, N);
+    EXPECT_FALSE(hash_datastructure.empty());
+    EXPECT_EQ(hash_datastructure.size(), N);
+    EXPECT_TRUE(hash_datastructure.valid());
+
+    destroyDeviceArray<stdgpu::index_t>(bucket_sizes);
+    destroyDeviceArray<test_unordered_datastructure::key_type>(positions);
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
+}
+
+
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, count_sum)
+{
+    const stdgpu::index_t N = 10000;
+
+    test_unordered_datastructure::key_type* host_positions  = insert_unique_parallel(hash_datastructure, N);
+    test_unordered_datastructure::key_type* positions       = copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
+
+    stdgpu::index_t* counts = createDeviceArray<stdgpu::index_t>(N);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     store_counts(hash_datastructure, positions, counts));
+
+    stdgpu::index_t counts_sum = thrust::reduce(stdgpu::device_cbegin(counts), stdgpu::device_cend(counts));
+
+    EXPECT_EQ(counts_sum, N);
+    EXPECT_FALSE(hash_datastructure.empty());
+    EXPECT_EQ(hash_datastructure.size(), N);
+    EXPECT_TRUE(hash_datastructure.valid());
+
+    destroyDeviceArray<stdgpu::index_t>(counts);
+    destroyDeviceArray<test_unordered_datastructure::key_type>(positions);
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
+}
+
+
+namespace
+{
     struct for_each_counter
     {
         stdgpu::atomic<unsigned int> counter;


### PR DESCRIPTION
Although both `unordered_map` and `unordered_set` have probably the most extensive unit test suite, their code coverage is rather low. This is partially caused by the plethora of "read" operations to obtain certain kinds of information regarding their state. Extend the test suite to cover more of their operations and to increase the coverage.