### PR TITLE
unordered_map,unordered_set: Further extend unit tests

### DIFF
--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -1433,7 +1433,9 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_range_unique_parallel)
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
                      Key2ValueFunctor(hash_datastructure, positions, values));
 
-    hash_datastructure.insert(stdgpu::device_begin(values), stdgpu::device_end(values));
+    stdgpu::device_ptr<test_unordered_datastructure::value_type> values_begin   = stdgpu::device_begin(values);
+    stdgpu::device_ptr<test_unordered_datastructure::value_type> values_end     = stdgpu::device_end(values);
+    hash_datastructure.insert(values_begin, values_end);
 
     EXPECT_FALSE(hash_datastructure.empty());
     EXPECT_EQ(hash_datastructure.size(), N);
@@ -1457,7 +1459,9 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_const_range_unique_para
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
                      Key2ValueFunctor(hash_datastructure, positions, values));
 
-    hash_datastructure.insert(stdgpu::device_cbegin(values), stdgpu::device_cend(values));
+    stdgpu::device_ptr<const test_unordered_datastructure::value_type> values_begin = stdgpu::device_cbegin(values);
+    stdgpu::device_ptr<const test_unordered_datastructure::value_type> values_end   = stdgpu::device_cend(values);
+    hash_datastructure.insert(values_begin, values_end);
 
     EXPECT_FALSE(hash_datastructure.empty());
     EXPECT_EQ(hash_datastructure.size(), N);
@@ -1481,13 +1485,17 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_range_unique_parallel)
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
                      Key2ValueFunctor(hash_datastructure, positions, values));
 
-    hash_datastructure.insert(stdgpu::device_begin(values), stdgpu::device_end(values));
+    stdgpu::device_ptr<test_unordered_datastructure::value_type> values_begin   = stdgpu::device_begin(values);
+    stdgpu::device_ptr<test_unordered_datastructure::value_type> values_end     = stdgpu::device_end(values);
+    hash_datastructure.insert(values_begin, values_end);
 
     EXPECT_FALSE(hash_datastructure.empty());
     EXPECT_EQ(hash_datastructure.size(), N);
     EXPECT_TRUE(hash_datastructure.valid());
 
-    hash_datastructure.erase(stdgpu::device_begin(positions), stdgpu::device_end(positions));
+    stdgpu::device_ptr<test_unordered_datastructure::key_type> positions_begin  = stdgpu::device_begin(positions);
+    stdgpu::device_ptr<test_unordered_datastructure::key_type> positions_end    = stdgpu::device_end(positions);
+    hash_datastructure.erase(positions_begin, positions_end);
 
     EXPECT_TRUE(hash_datastructure.empty());
     EXPECT_EQ(hash_datastructure.size(), 0);
@@ -1511,13 +1519,17 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_const_range_unique_paral
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
                      Key2ValueFunctor(hash_datastructure, positions, values));
 
-    hash_datastructure.insert(stdgpu::device_cbegin(values), stdgpu::device_cend(values));
+    stdgpu::device_ptr<const test_unordered_datastructure::value_type> values_begin = stdgpu::device_cbegin(values);
+    stdgpu::device_ptr<const test_unordered_datastructure::value_type> values_end   = stdgpu::device_cend(values);
+    hash_datastructure.insert(values_begin, values_end);
 
     EXPECT_FALSE(hash_datastructure.empty());
     EXPECT_EQ(hash_datastructure.size(), N);
     EXPECT_TRUE(hash_datastructure.valid());
 
-    hash_datastructure.erase(stdgpu::device_cbegin(positions), stdgpu::device_cend(positions));
+    stdgpu::device_ptr<const test_unordered_datastructure::key_type> positions_begin    = stdgpu::device_cbegin(positions);
+    stdgpu::device_ptr<const test_unordered_datastructure::key_type> positions_end      = stdgpu::device_cend(positions);
+    hash_datastructure.erase(positions_begin, positions_end);
 
     EXPECT_TRUE(hash_datastructure.empty());
     EXPECT_EQ(hash_datastructure.size(), 0);

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -295,15 +295,15 @@ namespace
     }
 
 
-    struct find_key_functor
+    struct non_const_find_key_functor
     {
         test_unordered_datastructure hash_datastructure;
         test_unordered_datastructure::key_type key;
-        test_unordered_datastructure::const_iterator* result;
+        test_unordered_datastructure::iterator* result;
 
-        find_key_functor(test_unordered_datastructure hash_datastructure,
-                         test_unordered_datastructure::key_type key,
-                         test_unordered_datastructure::const_iterator* result)
+        non_const_find_key_functor(const test_unordered_datastructure& hash_datastructure,
+                                   const test_unordered_datastructure::key_type& key,
+                                   test_unordered_datastructure::iterator* result)
             : hash_datastructure(hash_datastructure),
               key(key),
               result(result)
@@ -319,33 +319,15 @@ namespace
     };
 
 
-    test_unordered_datastructure::const_iterator
-    find_key(test_unordered_datastructure& hash_datastructure,
-             const test_unordered_datastructure::key_type& key)
+    struct const_find_key_functor
     {
-        test_unordered_datastructure::const_iterator* result = createDeviceArray<test_unordered_datastructure::const_iterator>(1);
-
-        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
-                         find_key_functor(hash_datastructure, key, result));
-
-        test_unordered_datastructure::const_iterator host_result;
-        copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
-
-        destroyDeviceArray<test_unordered_datastructure::const_iterator>(result);
-
-        return host_result;
-    }
-
-
-    struct bucket_iterator_functor
-    {
-        test_unordered_datastructure hash_datastructure;
+        const test_unordered_datastructure hash_datastructure;
         test_unordered_datastructure::key_type key;
         test_unordered_datastructure::const_iterator* result;
 
-        bucket_iterator_functor(test_unordered_datastructure hash_datastructure,
-                                test_unordered_datastructure::key_type key,
-                                test_unordered_datastructure::const_iterator* result)
+        const_find_key_functor(const test_unordered_datastructure& hash_datastructure,
+                               const test_unordered_datastructure::key_type& key,
+                               test_unordered_datastructure::const_iterator* result)
             : hash_datastructure(hash_datastructure),
               key(key),
               result(result)
@@ -356,19 +338,37 @@ namespace
         STDGPU_DEVICE_ONLY void
         operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
         {
-            *result = hash_datastructure.cbegin() + hash_datastructure.bucket(key);
+            *result = hash_datastructure.find(key);
         }
     };
 
 
+    test_unordered_datastructure::iterator
+    non_const_find_key(const test_unordered_datastructure& hash_datastructure,
+                       const test_unordered_datastructure::key_type& key)
+    {
+        test_unordered_datastructure::iterator* result = createDeviceArray<test_unordered_datastructure::iterator>(1);
+
+        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
+                         non_const_find_key_functor(hash_datastructure, key, result));
+
+        test_unordered_datastructure::iterator host_result;
+        copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
+
+        destroyDeviceArray<test_unordered_datastructure::iterator>(result);
+
+        return host_result;
+    }
+
+
     test_unordered_datastructure::const_iterator
-    bucket_iterator(const test_unordered_datastructure hash_datastructure,
-                    const test_unordered_datastructure::key_type& key)
+    const_find_key(const test_unordered_datastructure& hash_datastructure,
+                   const test_unordered_datastructure::key_type& key)
     {
         test_unordered_datastructure::const_iterator* result = createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
         thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
-                         bucket_iterator_functor(hash_datastructure, key, result));
+                         const_find_key_functor(hash_datastructure, key, result));
 
         test_unordered_datastructure::const_iterator host_result;
         copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -379,13 +379,196 @@ namespace
     }
 
 
-    struct end_iterator_functor
+    test_unordered_datastructure::const_iterator
+    find_key(const test_unordered_datastructure& hash_datastructure,
+             const test_unordered_datastructure::key_type& key)
+    {
+        test_unordered_datastructure::iterator non_const_iterator   = non_const_find_key(hash_datastructure, key);
+        test_unordered_datastructure::const_iterator const_iterator = const_find_key(hash_datastructure, key);
+
+        EXPECT_EQ(non_const_iterator, const_iterator);
+
+        return const_iterator;
+    }
+
+
+    struct non_const_begin_iterator_functor
     {
         test_unordered_datastructure hash_datastructure;
+        test_unordered_datastructure::iterator* result;
+
+        non_const_begin_iterator_functor(const test_unordered_datastructure& hash_datastructure,
+                                         test_unordered_datastructure::iterator* result)
+            : hash_datastructure(hash_datastructure),
+              result(result)
+        {
+
+        }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+        {
+            *result = hash_datastructure.begin();
+        }
+    };
+
+
+    struct const_begin_iterator_functor
+    {
+        const test_unordered_datastructure hash_datastructure;
         test_unordered_datastructure::const_iterator* result;
 
-        end_iterator_functor(test_unordered_datastructure hash_datastructure,
-                             test_unordered_datastructure::const_iterator* result)
+        const_begin_iterator_functor(const test_unordered_datastructure& hash_datastructure,
+                                     test_unordered_datastructure::const_iterator* result)
+            : hash_datastructure(hash_datastructure),
+              result(result)
+        {
+
+        }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+        {
+            *result = hash_datastructure.begin();
+        }
+    };
+
+
+    struct cbegin_iterator_functor
+    {
+        const test_unordered_datastructure hash_datastructure;
+        test_unordered_datastructure::const_iterator* result;
+
+        cbegin_iterator_functor(const test_unordered_datastructure& hash_datastructure,
+                                test_unordered_datastructure::const_iterator* result)
+            : hash_datastructure(hash_datastructure),
+              result(result)
+        {
+
+        }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+        {
+            *result = hash_datastructure.cbegin();
+        }
+    };
+
+
+    test_unordered_datastructure::iterator
+    non_const_begin_iterator(const test_unordered_datastructure& hash_datastructure)
+    {
+        test_unordered_datastructure::iterator* result = createDeviceArray<test_unordered_datastructure::iterator>(1);
+
+        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
+                         non_const_begin_iterator_functor(hash_datastructure, result));
+
+        test_unordered_datastructure::iterator host_result;
+        copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
+
+        destroyDeviceArray<test_unordered_datastructure::iterator>(result);
+
+        return host_result;
+    }
+
+
+    test_unordered_datastructure::const_iterator
+    const_begin_iterator(const test_unordered_datastructure& hash_datastructure)
+    {
+        test_unordered_datastructure::const_iterator* result = createDeviceArray<test_unordered_datastructure::const_iterator>(1);
+
+        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
+                         const_begin_iterator_functor(hash_datastructure, result));
+
+        test_unordered_datastructure::const_iterator host_result;
+        copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
+
+        destroyDeviceArray<test_unordered_datastructure::const_iterator>(result);
+
+        return host_result;
+    }
+
+
+    test_unordered_datastructure::const_iterator
+    cbegin_iterator(const test_unordered_datastructure& hash_datastructure)
+    {
+        test_unordered_datastructure::const_iterator* result = createDeviceArray<test_unordered_datastructure::const_iterator>(1);
+
+        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
+                         cbegin_iterator_functor(hash_datastructure, result));
+
+        test_unordered_datastructure::const_iterator host_result;
+        copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
+
+        destroyDeviceArray<test_unordered_datastructure::const_iterator>(result);
+
+        return host_result;
+    }
+
+
+    test_unordered_datastructure::const_iterator
+    begin_iterator(const test_unordered_datastructure& hash_datastructure)
+    {
+        test_unordered_datastructure::iterator non_const_iterator   = non_const_begin_iterator(hash_datastructure);
+        test_unordered_datastructure::const_iterator const_iterator = const_begin_iterator(hash_datastructure);
+        test_unordered_datastructure::const_iterator c_iterator     = cbegin_iterator(hash_datastructure);
+
+        EXPECT_EQ(non_const_iterator, const_iterator);
+        EXPECT_EQ(const_iterator, c_iterator);
+
+        return const_iterator;
+    }
+
+
+    struct non_const_end_iterator_functor
+    {
+        test_unordered_datastructure hash_datastructure;
+        test_unordered_datastructure::iterator* result;
+
+        non_const_end_iterator_functor(const test_unordered_datastructure& hash_datastructure,
+                                       test_unordered_datastructure::iterator* result)
+            : hash_datastructure(hash_datastructure),
+              result(result)
+        {
+
+        }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+        {
+            *result = hash_datastructure.end();
+        }
+    };
+
+
+    struct const_end_iterator_functor
+    {
+        const test_unordered_datastructure hash_datastructure;
+        test_unordered_datastructure::const_iterator* result;
+
+        const_end_iterator_functor(const test_unordered_datastructure& hash_datastructure,
+                                   test_unordered_datastructure::const_iterator* result)
+            : hash_datastructure(hash_datastructure),
+              result(result)
+        {
+
+        }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+        {
+            *result = hash_datastructure.end();
+        }
+    };
+
+
+    struct cend_iterator_functor
+    {
+        const test_unordered_datastructure hash_datastructure;
+        test_unordered_datastructure::const_iterator* result;
+
+        cend_iterator_functor(const test_unordered_datastructure& hash_datastructure,
+                              test_unordered_datastructure::const_iterator* result)
             : hash_datastructure(hash_datastructure),
               result(result)
         {
@@ -400,13 +583,30 @@ namespace
     };
 
 
+    test_unordered_datastructure::iterator
+    non_const_end_iterator(const test_unordered_datastructure& hash_datastructure)
+    {
+        test_unordered_datastructure::iterator* result = createDeviceArray<test_unordered_datastructure::iterator>(1);
+
+        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
+                         non_const_end_iterator_functor(hash_datastructure, result));
+
+        test_unordered_datastructure::iterator host_result;
+        copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
+
+        destroyDeviceArray<test_unordered_datastructure::iterator>(result);
+
+        return host_result;
+    }
+
+
     test_unordered_datastructure::const_iterator
-    end_iterator(const test_unordered_datastructure hash_datastructure)
+    const_end_iterator(const test_unordered_datastructure& hash_datastructure)
     {
         test_unordered_datastructure::const_iterator* result = createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
         thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
-                         end_iterator_functor(hash_datastructure, result));
+                         const_end_iterator_functor(hash_datastructure, result));
 
         test_unordered_datastructure::const_iterator host_result;
         copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -414,6 +614,45 @@ namespace
         destroyDeviceArray<test_unordered_datastructure::const_iterator>(result);
 
         return host_result;
+    }
+
+
+    test_unordered_datastructure::const_iterator
+    cend_iterator(const test_unordered_datastructure& hash_datastructure)
+    {
+        test_unordered_datastructure::const_iterator* result = createDeviceArray<test_unordered_datastructure::const_iterator>(1);
+
+        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
+                         cend_iterator_functor(hash_datastructure, result));
+
+        test_unordered_datastructure::const_iterator host_result;
+        copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
+
+        destroyDeviceArray<test_unordered_datastructure::const_iterator>(result);
+
+        return host_result;
+    }
+
+
+    test_unordered_datastructure::const_iterator
+    end_iterator(const test_unordered_datastructure& hash_datastructure)
+    {
+        test_unordered_datastructure::iterator non_const_iterator   = non_const_end_iterator(hash_datastructure);
+        test_unordered_datastructure::const_iterator const_iterator = const_end_iterator(hash_datastructure);
+        test_unordered_datastructure::const_iterator c_iterator     = cend_iterator(hash_datastructure);
+
+        EXPECT_EQ(non_const_iterator, const_iterator);
+        EXPECT_EQ(const_iterator, c_iterator);
+
+        return const_iterator;
+    }
+
+
+    test_unordered_datastructure::const_iterator
+    bucket_iterator(const test_unordered_datastructure& hash_datastructure,
+                    const test_unordered_datastructure::key_type& key)
+    {
+        return begin_iterator(hash_datastructure) + hash_datastructure.bucket(key);
     }
 }
 

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -295,6 +295,48 @@ namespace
     }
 
 
+    struct contains_key_functor
+    {
+        test_unordered_datastructure hash_datastructure;
+        test_unordered_datastructure::key_type key;
+        stdgpu::index_t* contained;
+
+        contains_key_functor(test_unordered_datastructure hash_datastructure,
+                             test_unordered_datastructure::key_type key,
+                             stdgpu::index_t* contained)
+            : hash_datastructure(hash_datastructure),
+              key(key),
+              contained(contained)
+        {
+
+        }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+        {
+            *contained = hash_datastructure.contains(key) ? 1 : 0;
+        }
+    };
+
+
+    bool
+    contains_key(const test_unordered_datastructure& hash_datastructure,
+                 const test_unordered_datastructure::key_type& key)
+    {
+        stdgpu::index_t* contained = createDeviceArray<stdgpu::index_t>(1);
+
+        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
+                         contains_key_functor(hash_datastructure, key, contained));
+
+        stdgpu::index_t host_contained;
+        copyDevice2HostArray<stdgpu::index_t>(contained, 1, &host_contained, MemoryCopy::NO_CHECK);
+
+        destroyDeviceArray<stdgpu::index_t>(contained);
+
+        return host_contained == 1;
+    }
+
+
     struct non_const_find_key_functor
     {
         test_unordered_datastructure hash_datastructure;
@@ -725,6 +767,10 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_collision)
     EXPECT_NE(index_2, end_iterator(hash_datastructure));
     EXPECT_NE(index_3, end_iterator(hash_datastructure));
     EXPECT_NE(index_4, end_iterator(hash_datastructure));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_1));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_2));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_3));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_4));
 
     // No collisions
     EXPECT_EQ(index_1, bucket_iterator(hash_datastructure, position_1));
@@ -758,6 +804,8 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_no_collision)
     // Found
     EXPECT_NE(index_1, end_iterator(hash_datastructure));
     EXPECT_NE(index_2, end_iterator(hash_datastructure));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_1));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_2));
 
     // No collisions
     EXPECT_EQ(index_1, bucket_iterator(hash_datastructure, position_1));
@@ -780,6 +828,8 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_no_collision)
     // Not found
     EXPECT_EQ(index_1, end_iterator(hash_datastructure));
     EXPECT_EQ(index_2, end_iterator(hash_datastructure));
+    EXPECT_FALSE(contains_key(hash_datastructure, position_1));
+    EXPECT_FALSE(contains_key(hash_datastructure, position_2));
 }
 
 
@@ -822,6 +872,10 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_collision)
     EXPECT_NE(index_2, end_iterator(hash_datastructure));
     EXPECT_NE(index_3, end_iterator(hash_datastructure));
     EXPECT_NE(index_4, end_iterator(hash_datastructure));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_1));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_2));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_3));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_4));
 
     // No collisions
     EXPECT_EQ(index_1, bucket_iterator(hash_datastructure, position_1));
@@ -860,6 +914,10 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_collision)
     EXPECT_EQ(index_2, end_iterator(hash_datastructure));
     EXPECT_EQ(index_3, end_iterator(hash_datastructure));
     EXPECT_EQ(index_4, end_iterator(hash_datastructure));
+    EXPECT_FALSE(contains_key(hash_datastructure, position_1));
+    EXPECT_FALSE(contains_key(hash_datastructure, position_2));
+    EXPECT_FALSE(contains_key(hash_datastructure, position_3));
+    EXPECT_FALSE(contains_key(hash_datastructure, position_4));
 }
 
 
@@ -875,6 +933,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_double)
 
     test_unordered_datastructure::const_iterator index = find_key(hash_datastructure, position);
     EXPECT_NE(index, end_iterator(hash_datastructure));
+    EXPECT_TRUE(contains_key(hash_datastructure, position));
     EXPECT_EQ(index, bucket_iterator(hash_datastructure, position));
 
     bool inserted_2 = insert_key(hash_datastructure, position);
@@ -883,6 +942,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_double)
 
     index = find_key(hash_datastructure, position);
     EXPECT_NE(index, end_iterator(hash_datastructure));
+    EXPECT_TRUE(contains_key(hash_datastructure, position));
     EXPECT_EQ(index, bucket_iterator(hash_datastructure, position));
 }
 
@@ -899,6 +959,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_double)
 
     test_unordered_datastructure::const_iterator index = find_key(hash_datastructure, position);
     EXPECT_NE(index, end_iterator(hash_datastructure));
+    EXPECT_TRUE(contains_key(hash_datastructure, position));
     EXPECT_EQ(index, bucket_iterator(hash_datastructure, position));
 
 
@@ -909,6 +970,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_double)
 
     index = find_key(hash_datastructure, position);
     EXPECT_EQ(index, end_iterator(hash_datastructure));
+    EXPECT_FALSE(contains_key(hash_datastructure, position));
 
     bool erased_2 = erase_key(hash_datastructure, position);
     EXPECT_FALSE(erased_2);
@@ -916,6 +978,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_double)
 
     index = find_key(hash_datastructure, position);
     EXPECT_EQ(index, end_iterator(hash_datastructure));
+    EXPECT_FALSE(contains_key(hash_datastructure, position));
 }
 
 
@@ -1040,6 +1103,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_multiple_no_collision)
 
     test_unordered_datastructure::const_iterator index = find_key(hash_datastructure, position);
     EXPECT_NE(index, end_iterator(hash_datastructure));
+    EXPECT_TRUE(contains_key(hash_datastructure, position));
     EXPECT_EQ(index, bucket_iterator(hash_datastructure, position));
 
 
@@ -1061,6 +1125,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_multiple_collision)
 
     test_unordered_datastructure::const_iterator index = find_key(hash_datastructure, position_1);
     EXPECT_NE(index, end_iterator(hash_datastructure));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_1));
     EXPECT_EQ(index, bucket_iterator(hash_datastructure, position_1));
 
 
@@ -1082,6 +1147,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_multiple_collision_head_
 
     test_unordered_datastructure::const_iterator index_1 = find_key(hash_datastructure, position_1);
     EXPECT_NE(index_1, end_iterator(hash_datastructure));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_1));
     EXPECT_EQ(index_1, bucket_iterator(hash_datastructure, position_1));
 
     bool inserted_2 = insert_key(hash_datastructure, position_2);
@@ -1090,6 +1156,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_multiple_collision_head_
 
     test_unordered_datastructure::const_iterator index_2 = find_key(hash_datastructure, position_2);
     EXPECT_NE(index_2, end_iterator(hash_datastructure));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_2));
     EXPECT_NE(index_2, bucket_iterator(hash_datastructure, position_2));
 
 
@@ -1112,6 +1179,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_multiple_collision_tail_
 
     test_unordered_datastructure::const_iterator index_1 = find_key(hash_datastructure, position_1);
     EXPECT_NE(index_1, end_iterator(hash_datastructure));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_1));
     EXPECT_EQ(index_1, bucket_iterator(hash_datastructure, position_1));
 
     bool inserted_2 = insert_key(hash_datastructure, position_2);
@@ -1120,6 +1188,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_multiple_collision_tail_
 
     test_unordered_datastructure::const_iterator index_2 = find_key(hash_datastructure, position_2);
     EXPECT_NE(index_2, end_iterator(hash_datastructure));
+    EXPECT_TRUE(contains_key(hash_datastructure, position_2));
     EXPECT_NE(index_2, bucket_iterator(hash_datastructure, position_2));
 
 

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -207,6 +207,21 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, empty_size_limits)
 }
 
 
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, hash_objects)
+{
+    test_unordered_datastructure::key_equal key_equals  = hash_datastructure.key_eq();
+    test_unordered_datastructure::hasher hash           = hash_datastructure.hash_function();
+
+    test_unordered_datastructure::key_type key = random_key(test_utils::random_seed())(0);
+
+    std::size_t key_hash_1 = hash(key);
+    std::size_t key_hash_2 = hash(key);
+
+    EXPECT_TRUE(key_equals(key, key));
+    EXPECT_EQ(key_hash_1, key_hash_2);
+}
+
+
 namespace
 {
     struct insert_single


### PR DESCRIPTION
The code coverage of `unordered_map` and `unordered_set` has been recently improved (see #77), but it is still incomplete. Take a further step towards full coverage by extending the unit tests even further. This also fixes a minor bug in #77.