### PR TITLE
test: Also include deprecated functions into unit tests

### DIFF
--- a/cmake/cuda/set_device_flags.cmake
+++ b/cmake/cuda/set_device_flags.cmake
@@ -55,3 +55,8 @@ string(APPEND CMAKE_CUDA_FLAGS ${STDGPU_DEVICE_FLAGS})
 
 message(STATUS "Created device flags : ${STDGPU_DEVICE_FLAGS}")
 message(STATUS "Building with CUDA flags : ${CMAKE_CUDA_FLAGS}")
+
+# Auxiliary compiler flags for tests to be used with target_compile_options
+if(NOT MSVC)
+    set(STDGPU_TEST_DEVICE_FLAGS "$<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-declarations>")
+endif()

--- a/cmake/set_host_flags.cmake
+++ b/cmake/set_host_flags.cmake
@@ -17,3 +17,10 @@ string(APPEND CMAKE_CXX_FLAGS ${STDGPU_HOST_FLAGS})
 
 message(STATUS "Created host flags : ${STDGPU_HOST_FLAGS}")
 message(STATUS "Building with CXX flags : ${CMAKE_CXX_FLAGS}")
+
+# Auxiliary compiler flags for tests to be used with target_compile_options
+if(NOT MSVC)
+    set(STDGPU_TEST_HOST_FLAGS "$<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>")
+else()
+    set(STDGPU_TEST_HOST_FLAGS "$<$<COMPILE_LANGUAGE:CXX>:/wd4996>")
+endif()

--- a/test/stdgpu/CMakeLists.txt
+++ b/test/stdgpu/CMakeLists.txt
@@ -16,6 +16,12 @@ add_subdirectory(${STDGPU_BACKEND_DIRECTORY})
 target_include_directories(teststdgpu PRIVATE
                                       "${CMAKE_CURRENT_SOURCE_DIR}/..") # test_utils
 
+message(STATUS "Applying auxiliary test device flags: ${STDGPU_TEST_DEVICE_FLAGS}")
+message(STATUS "Applying auxiliary test host flags: ${STDGPU_TEST_HOST_FLAGS}")
+
+target_compile_options(teststdgpu PRIVATE ${STDGPU_TEST_DEVICE_FLAGS}
+                                          ${STDGPU_TEST_HOST_FLAGS})
+
 target_link_libraries(teststdgpu PRIVATE
                                  stdgpu::stdgpu
                                  gtest)

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -21,6 +21,7 @@
 
 #include <cmath>
 #include <thrust/equal.h>
+#include <thrust/fill.h>
 #include <thrust/execution_policy.h>
 #include <thrust/logical.h>
 
@@ -1228,4 +1229,73 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyManangedArray_double_free_shifted)
     destroyManagedArray<int>(array_managed_host_2);
 }
 
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_pinned_host_allocator)
+{
+    stdgpu::safe_pinned_host_allocator<int> a;
+    stdgpu::index64_t size = 42;
+    int default_value = 10;
+
+    int* array_host = a.allocate(size);
+
+    thrust::fill(stdgpu::host_begin(array_host), stdgpu::host_end(array_host),
+                 default_value);
+
+    EXPECT_TRUE( thrust::all_of(stdgpu::host_cbegin(array_host), stdgpu::host_cend(array_host),
+                                equal_to_number(default_value)) );
+
+
+    a.deallocate(array_host, size);
+}
+
+
+namespace
+{
+    struct default_construct
+    {
+        int default_value;
+
+        default_construct(const int default_value)
+            : default_value(default_value)
+        {
+
+        }
+
+        void
+        operator()(int& value) const
+        {
+            stdgpu::default_allocator_traits::construct(&value, default_value);
+        }
+    };
+
+
+    struct default_destroy
+    {
+        void
+        operator()(int& value) const
+        {
+            stdgpu::default_allocator_traits::destroy(&value);
+        }
+    };
+}
+
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, default_allocator_traits)
+{
+    stdgpu::index64_t size = 42;
+    int default_value = 10;
+
+    int* array_host = createHostArray<int>(size);
+
+    thrust::for_each(stdgpu::host_begin(array_host), stdgpu::host_end(array_host),
+                     default_construct(default_value));
+
+    EXPECT_TRUE( thrust::all_of(stdgpu::host_cbegin(array_host), stdgpu::host_cend(array_host),
+                                equal_to_number(default_value)) );
+
+    thrust::for_each(stdgpu::host_begin(array_host), stdgpu::host_end(array_host),
+                     default_destroy());
+
+    destroyHostArray<int>(array_host);
+}
 

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -241,7 +241,7 @@ lock_multiple(const stdgpu::mutex_array locks,
 }
 
 
-TEST_F(stdgpu_mutex, multple_try_lock_both_unlocked)
+TEST_F(stdgpu_mutex, multiple_try_lock_both_unlocked)
 {
     const stdgpu::index_t n_0 = 21;
     const stdgpu::index_t n_1 = 42;
@@ -263,7 +263,7 @@ TEST_F(stdgpu_mutex, multple_try_lock_both_unlocked)
 }
 
 
-TEST_F(stdgpu_mutex, multple_try_lock_first_unlocked_second_locked)
+TEST_F(stdgpu_mutex, multiple_try_lock_first_unlocked_second_locked)
 {
     const stdgpu::index_t n_0 = 21;
     const stdgpu::index_t n_1 = 42;
@@ -286,7 +286,7 @@ TEST_F(stdgpu_mutex, multple_try_lock_first_unlocked_second_locked)
 }
 
 
-TEST_F(stdgpu_mutex, multple_try_lock_first_locked_second_unlocked)
+TEST_F(stdgpu_mutex, multiple_try_lock_first_locked_second_unlocked)
 {
     const stdgpu::index_t n_0 = 21;
     const stdgpu::index_t n_1 = 42;
@@ -309,7 +309,7 @@ TEST_F(stdgpu_mutex, multple_try_lock_first_locked_second_unlocked)
 }
 
 
-TEST_F(stdgpu_mutex, multple_try_lock_both_locked)
+TEST_F(stdgpu_mutex, multiple_try_lock_both_locked)
 {
     const stdgpu::index_t n_0 = 21;
     const stdgpu::index_t n_1 = 42;
@@ -325,6 +325,176 @@ TEST_F(stdgpu_mutex, multple_try_lock_both_locked)
 
 
     EXPECT_EQ(lock_multiple(locks, n_0, n_1), 0);
+
+
+    // Nothing has changed
+    EXPECT_TRUE(equal(locks, locks_check));
+
+    stdgpu::mutex_array::destroyDeviceObject(locks_check);
+}
+
+
+struct lock_multiple_functor_new_reference
+{
+    stdgpu::mutex_array locks;
+
+    lock_multiple_functor_new_reference(stdgpu::mutex_array locks)
+        : locks(locks)
+    {
+
+    }
+
+    STDGPU_DEVICE_ONLY int
+    operator()(const thrust::tuple<stdgpu::index_t, stdgpu::index_t> i)
+    {
+        stdgpu::mutex_array::reference ref_0 = static_cast<stdgpu::mutex_array::reference>(locks[thrust::get<0>(i)]);
+        stdgpu::mutex_array::reference ref_1 = static_cast<stdgpu::mutex_array::reference>(locks[thrust::get<1>(i)]);
+        return stdgpu::try_lock(ref_0, ref_1);
+    }
+};
+
+int
+lock_multiple_new_reference(const stdgpu::mutex_array locks,
+                            const stdgpu::index_t n_0,
+                            const stdgpu::index_t n_1)
+{
+    int* result = createDeviceArray<int>(1);
+
+    thrust::transform(thrust::make_zip_iterator(thrust::make_tuple(thrust::counting_iterator<stdgpu::index_t>(n_0),     thrust::counting_iterator<stdgpu::index_t>(n_1))),
+                      thrust::make_zip_iterator(thrust::make_tuple(thrust::counting_iterator<stdgpu::index_t>(n_0 + 1), thrust::counting_iterator<stdgpu::index_t>(n_1 + 1))),
+                      stdgpu::device_begin(result),
+                      lock_multiple_functor_new_reference(locks));
+
+    int host_result;
+    copyDevice2HostArray<int>(result, 1, &host_result, MemoryCopy::NO_CHECK);
+
+    destroyDeviceArray<int>(result);
+
+    return host_result;
+}
+
+
+struct lock_single_functor_new_reference
+{
+    stdgpu::mutex_array locks;
+
+    lock_single_functor_new_reference(stdgpu::mutex_array locks)
+        : locks(locks)
+    {
+
+    }
+
+    STDGPU_DEVICE_ONLY bool
+    operator()(const stdgpu::index_t i)
+    {
+        stdgpu::mutex_array::reference ref = static_cast<stdgpu::mutex_array::reference>(locks[i]);
+        return ref.try_lock();
+    }
+};
+
+bool
+lock_single_new_reference(const stdgpu::mutex_array locks,
+                          const stdgpu::index_t n)
+{
+    uint8_t* result = createDeviceArray<uint8_t>(1);
+
+    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(n), thrust::counting_iterator<stdgpu::index_t>(n + 1),
+                      stdgpu::device_begin(result),
+                      lock_single_functor_new_reference(locks));
+
+    uint8_t host_result;
+    copyDevice2HostArray<uint8_t>(result, 1, &host_result, MemoryCopy::NO_CHECK);
+
+    destroyDeviceArray<uint8_t>(result);
+
+    return static_cast<bool>(host_result);
+}
+
+
+TEST_F(stdgpu_mutex, multiple_try_lock_both_unlocked_new_reference)
+{
+    const stdgpu::index_t n_0 = 21;
+    const stdgpu::index_t n_1 = 42;
+
+    stdgpu::mutex_array locks_check = stdgpu::mutex_array::createDeviceObject(locks_size);
+
+    ASSERT_TRUE(equal(locks, locks_check));
+
+
+    EXPECT_EQ(lock_multiple_new_reference(locks, n_0, n_1), -1);
+
+
+    // Both mutexes should be locked now
+    ASSERT_TRUE(lock_single_new_reference(locks_check, n_0));
+    ASSERT_TRUE(lock_single_new_reference(locks_check, n_1));
+    EXPECT_TRUE(equal(locks, locks_check));
+
+    stdgpu::mutex_array::destroyDeviceObject(locks_check);
+}
+
+
+TEST_F(stdgpu_mutex, multiple_try_lock_first_unlocked_second_locked_new_reference)
+{
+    const stdgpu::index_t n_0 = 21;
+    const stdgpu::index_t n_1 = 42;
+
+    ASSERT_TRUE(lock_single_new_reference(locks, n_1));
+
+    stdgpu::mutex_array locks_check = stdgpu::mutex_array::createDeviceObject(locks_size);
+    ASSERT_TRUE(lock_single_new_reference(locks_check, n_1));
+
+    ASSERT_TRUE(equal(locks, locks_check));
+
+
+    EXPECT_EQ(lock_multiple_new_reference(locks, n_0, n_1), 1);
+
+
+    // Nothing has changed
+    EXPECT_TRUE(equal(locks, locks_check));
+
+    stdgpu::mutex_array::destroyDeviceObject(locks_check);
+}
+
+
+TEST_F(stdgpu_mutex, multiple_try_lock_first_locked_second_unlocked_new_reference)
+{
+    const stdgpu::index_t n_0 = 21;
+    const stdgpu::index_t n_1 = 42;
+
+    ASSERT_TRUE(lock_single_new_reference(locks, n_0));
+
+    stdgpu::mutex_array locks_check = stdgpu::mutex_array::createDeviceObject(locks_size);
+    ASSERT_TRUE(lock_single_new_reference(locks_check, n_0));
+
+    ASSERT_TRUE(equal(locks, locks_check));
+
+
+    EXPECT_EQ(lock_multiple_new_reference(locks, n_0, n_1), 0);
+
+
+    // Nothing has changed
+    EXPECT_TRUE(equal(locks, locks_check));
+
+    stdgpu::mutex_array::destroyDeviceObject(locks_check);
+}
+
+
+TEST_F(stdgpu_mutex, multiple_try_lock_both_locked_new_reference)
+{
+    const stdgpu::index_t n_0 = 21;
+    const stdgpu::index_t n_1 = 42;
+
+    ASSERT_TRUE(lock_single_new_reference(locks, n_0));
+    ASSERT_TRUE(lock_single_new_reference(locks, n_1));
+
+    stdgpu::mutex_array locks_check = stdgpu::mutex_array::createDeviceObject(locks_size);
+    ASSERT_TRUE(lock_single_new_reference(locks_check, n_0));
+    ASSERT_TRUE(lock_single_new_reference(locks_check, n_1));
+
+    ASSERT_TRUE(equal(locks, locks_check));
+
+
+    EXPECT_EQ(lock_multiple_new_reference(locks, n_0, n_1), 0);
 
 
     // Nothing has changed

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -2199,3 +2199,18 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, clear)
 }
 
 
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, deprecated_createDeviceObject)
+{
+    const stdgpu::index_t buckets = static_cast<stdgpu::index_t>(pow(2, 17));
+    const stdgpu::index_t excess  = 1000;
+
+    test_unordered_datastructure deprecated_hash_datastructure = test_unordered_datastructure::createDeviceObject(buckets, excess);
+
+    EXPECT_EQ(deprecated_hash_datastructure.bucket_count(), buckets);
+    EXPECT_EQ(deprecated_hash_datastructure.excess_count(), excess);
+    EXPECT_EQ(deprecated_hash_datastructure.total_count(),  buckets + excess);
+
+    test_unordered_datastructure::destroyDeviceObject(deprecated_hash_datastructure);
+}
+
+


### PR DESCRIPTION
Deprecated functions are currently not tested at all since they induce warnings in the build process. Suppress these warnings exclusively for the test executable target to avoid further noise. Furthermore, add tests for the deprecated functions in the `unordered_map`, `unordered_set`, `memory` and `mutex` modules.