### PR TITLE
General: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps to reproduce**
+If possible, provide a *Minimal Reproducable Example*. Describe the steps to reproduce the bug.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+A clear and concise description of what actually happens.
+
+**System (please complete the following information):**
+ - OS: [e.g. Ubuntu 18.04, Windows 10]
+ - Compiler: [e.g. GCC 7, MSVC 19.2x (Visual Studio 2019)]
+ - Backend: [e.g. CUDA, OpenMP]
+ - Library version [e.g. 1.0.0, master]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.


### PR DESCRIPTION
In order to make the issue management and reporting process easier, GitHub supports issue templates. Add templates for both bug reports and feature requests to improve the interaction with the community.