### PR TITLE
scripts: Port install script to native CMake install command-line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Command | Effect
 <code>sh&nbsp;scripts/run_tests_&lt;build_type&gt;.sh</code> | Runs the unit tests. Requires that project is built.
 <code>sh&nbsp;scripts/create_documentation.sh</code> | Builds the documentation locally. Requires doxygen and that project is configured (or set up).
 <code>sh&nbsp;scripts/run_coverage.sh</code> | Builds a test coverage report locally. Requires lcov and that project is configured (or set up).
-<code>sh&nbsp;scripts/install.sh</code> | Installs the project at the configured install path (default: `./bin`).
+<code>sh&nbsp;scripts/install_&lt;build_type&gt;.sh</code> | Installs the project at the configured install path (default: `./bin`).
 
 
 ## Usage

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -57,7 +57,7 @@ Command | Effect
 <code>sh&nbsp;scripts/run_tests_&lt;build_type&gt;.sh</code> | Runs the unit tests. Requires that project is built.
 <code>sh&nbsp;scripts/create_documentation.sh</code> | Builds the documentation locally. Requires doxygen and that project is configured (or set up).
 <code>sh&nbsp;scripts/run_coverage.sh</code> | Builds a test coverage report locally. Requires lcov and that project is configured (or set up).
-<code>sh&nbsp;scripts/install.sh</code> | Installs the project at the configured install path (default: `./bin`).
+<code>sh&nbsp;scripts/install_&lt;build_type&gt;.sh</code> | Installs the project at the configured install path (default: `./bin`).
 
 
 \section usage Usage

--- a/scripts/install_debug.sh
+++ b/scripts/install_debug.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+# Install project
+cmake -E cmake_echo_color --blue ">>>>> Install stdgpu project"
+cmake --install build --config Debug --component stdgpu

--- a/scripts/install_release.sh
+++ b/scripts/install_release.sh
@@ -3,4 +3,4 @@ set -e
 
 # Install project
 cmake -E cmake_echo_color --blue ">>>>> Install stdgpu project"
-cmake -DCOMPONENT="stdgpu" -P build/cmake_install.cmake
+cmake --install build --config Release --component stdgpu


### PR DESCRIPTION
Due to the recent CMake version fix (see #71), we can now depend on further features of this version. Port the install script to the new native command-line interface which has been introduced in CMake 3.15. This also adds support for multi-configuration generators.