### PR TITLE
atomic: Fix compare_exchange and add more operators as well as tests

### DIFF
--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -121,9 +121,9 @@ class atomic
 
         /**
          * \brief Atomically compares the current value with the given value and exchanges it with the desired one in case the both values are equal
-         * \param[in] expected The value to expect in the atomic object
+         * \param[in] expected A reference to the value to expect in the atomic object, will be updated with old value if it has not been changed
          * \param[in] desired The value to exchange with the atomic object
-         * \return The old value
+         * \return True if the value has been changed to desired, false otherwise
          */
         STDGPU_DEVICE_ONLY bool
         compare_exchange_weak(T& expected,
@@ -131,9 +131,9 @@ class atomic
 
         /**
          * \brief Atomically compares the current value with the given value and exchanges it with the desired one in case the both values are equal
-         * \param[in] expected The value to expect in the atomic object
+         * \param[in] expected A reference to the value to expect in the atomic object, will be updated with old value if it has not been changed
          * \param[in] desired The value to exchange with the atomic object
-         * \return The old value
+         * \return True if the value has been changed to desired, false otherwise
          */
         STDGPU_DEVICE_ONLY bool
         compare_exchange_strong(T& expected,
@@ -383,9 +383,9 @@ class atomic_ref
 
         /**
          * \brief Atomically compares the current value with the given value and exchanges it with the desired one in case the both values are equal
-         * \param[in] expected The value to expect in the atomic object
+         * \param[in] expected A reference to the value to expect in the atomic object, will be updated with old value if it has not been changed
          * \param[in] desired The value to exchange with the atomic object
-         * \return The old value
+         * \return True if the value has been changed to desired, false otherwise
          */
         STDGPU_DEVICE_ONLY bool
         compare_exchange_weak(T& expected,
@@ -393,9 +393,9 @@ class atomic_ref
 
         /**
          * \brief Atomically compares the current value with the given value and exchanges it with the desired one in case the both values are equal
-         * \param[in] expected The value to expect in the atomic object
+         * \param[in] expected A reference to the value to expect in the atomic object, will be updated with old value if it has not been changed
          * \param[in] desired The value to exchange with the atomic object
-         * \return The old value
+         * \return True if the value has been changed to desired, false otherwise
          */
         STDGPU_DEVICE_ONLY bool
         compare_exchange_strong(T& expected,

--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -101,6 +101,16 @@ class atomic
         STDGPU_HOST_DEVICE T
         load() const;
 
+
+        /**
+         * \brief Loads and returns the current value of the atomic object
+         * \return The current value of this object
+         * \note Equivalent to load()
+         */
+        STDGPU_HOST_DEVICE
+        operator T() const;
+
+
         /**
          * \brief Replaces the current value with desired
          * \param[in] desired The value to store to the atomic object
@@ -108,6 +118,16 @@ class atomic
          */
         STDGPU_HOST_DEVICE void
         store(const T desired);
+
+
+        /**
+         * \brief Replaces the current value with desired
+         * \param[in] desired The value to store to the atomic object
+         * \return The desired value
+         * \note Equivalent to store()
+         */
+        STDGPU_HOST_DEVICE T
+        operator=(const T desired);
 
 
         /**
@@ -363,6 +383,16 @@ class atomic_ref
         STDGPU_HOST_DEVICE T
         load() const;
 
+
+        /**
+         * \brief Loads and returns the current value of the atomic object
+         * \return The current value of this object
+         * \note Equivalent to load()
+         */
+        STDGPU_HOST_DEVICE
+        operator T() const;
+
+
         /**
          * \brief Replaces the current value with desired
          * \param[in] desired The value to store to the atomic object
@@ -370,6 +400,16 @@ class atomic_ref
          */
         STDGPU_HOST_DEVICE void
         store(const T desired);
+
+
+        /**
+         * \brief Replaces the current value with desired
+         * \param[in] desired The value to store to the atomic object
+         * \return The desired value
+         * \note Equivalent to store()
+         */
+        STDGPU_HOST_DEVICE T
+        operator=(const T desired);
 
 
         /**

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -77,9 +77,15 @@ template <typename T>
 inline STDGPU_HOST_DEVICE T
 atomic<T>::load() const
 {
-    if (_value == nullptr) return 0;
-
     return _value_ref.load();
+}
+
+
+template <typename T>
+inline STDGPU_HOST_DEVICE
+atomic<T>::operator T() const
+{
+    return _value_ref.operator T();
 }
 
 
@@ -87,9 +93,15 @@ template <typename T>
 inline STDGPU_HOST_DEVICE void
 atomic<T>::store(const T desired)
 {
-    if (_value == nullptr) return;
-
     _value_ref.store(desired);
+}
+
+
+template <typename T>
+inline STDGPU_HOST_DEVICE T
+atomic<T>::operator=(const T desired)
+{
+    return _value_ref.operator=(desired);
 }
 
 
@@ -317,6 +329,14 @@ atomic_ref<T>::load() const
 
 
 template <typename T>
+inline STDGPU_HOST_DEVICE
+atomic_ref<T>::operator T() const
+{
+    return load();
+}
+
+
+template <typename T>
 inline STDGPU_HOST_DEVICE void
 atomic_ref<T>::store(const T desired)
 {
@@ -327,6 +347,16 @@ atomic_ref<T>::store(const T desired)
     #else
         copyHost2DeviceArray<T>(&desired, 1, _value, MemoryCopy::NO_CHECK);
     #endif
+}
+
+
+template <typename T>
+inline STDGPU_HOST_DEVICE T
+atomic_ref<T>::operator=(const T desired)
+{
+    store(desired);
+
+    return desired;
 }
 
 

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -353,7 +353,15 @@ inline STDGPU_DEVICE_ONLY bool
 atomic_ref<T>::compare_exchange_strong(T& expected,
                                        const T desired)
 {
-    return stdgpu::STDGPU_BACKEND_NAMESPACE::atomic_compare_exchange(_value, expected, desired) == expected;
+    T old = stdgpu::STDGPU_BACKEND_NAMESPACE::atomic_compare_exchange(_value, expected, desired);
+    bool changed = (old == expected);
+
+    if (!changed)
+    {
+        expected = old;
+    }
+
+    return changed;
 }
 
 

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -17,9 +17,11 @@
 
 #include <limits>
 #include <thrust/for_each.h>
+#include <thrust/functional.h>
 #include <thrust/generate.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/sequence.h>
+#include <thrust/reduce.h>
 #include <thrust/sort.h>
 
 #include <test_utils.h>
@@ -233,6 +235,68 @@ TEST_F(stdgpu_atomic, load_and_store_unsigned_int)
 TEST_F(stdgpu_atomic, load_and_store_unsigned_long_long_int)
 {
     load_and_store<unsigned long long int>();
+}
+
+
+template <typename T>
+struct exchange_sequence
+{
+    stdgpu::atomic<T> value;
+
+    exchange_sequence(stdgpu::atomic<T> value)
+        : value(value)
+    {
+
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(T& x)
+    {
+        x = value.exchange(x);
+    }
+};
+
+
+template <typename T>
+void
+sequence_exchange()
+{
+    const stdgpu::index_t N = 40000;
+    T* sequence = createDeviceArray<T>(N - 1);
+    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
+                     T(1));
+
+    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+    value.store(N);
+
+    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
+                     exchange_sequence<T>(value));
+
+    T sum = value.load()
+          + thrust::reduce(stdgpu::device_cbegin(sequence), stdgpu::device_cend(sequence),
+                           T(0),
+                           thrust::plus<T>());
+
+    EXPECT_EQ(sum, T(N * (N + 1) / 2));
+
+    destroyDeviceArray<T>(sequence);
+    stdgpu::atomic<T>::destroyDeviceObject(value);
+}
+
+
+TEST_F(stdgpu_atomic, exchange_int)
+{
+    sequence_exchange<int>();
+}
+
+TEST_F(stdgpu_atomic, exchange_unsigned_int)
+{
+    sequence_exchange<unsigned int>();
+}
+
+TEST_F(stdgpu_atomic, exchange_unsigned_long_long_int)
+{
+    sequence_exchange<unsigned long long int>();
 }
 
 

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -237,6 +237,122 @@ TEST_F(stdgpu_atomic, load_and_store_unsigned_long_long_int)
 
 
 template <typename T>
+struct add_sequence_with_compare_exchange_weak
+{
+    stdgpu::atomic<T> value;
+
+    add_sequence_with_compare_exchange_weak(stdgpu::atomic<T> value)
+        : value(value)
+    {
+
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const T x)
+    {
+        T old = value.load();
+        while (!value.compare_exchange_weak(old, old + x))
+        ;   // Wait until exchanged
+    }
+};
+
+
+template <typename T>
+struct add_sequence_with_compare_exchange_strong
+{
+    stdgpu::atomic<T> value;
+
+    add_sequence_with_compare_exchange_strong(stdgpu::atomic<T> value)
+        : value(value)
+    {
+
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const T x)
+    {
+        T old = value.load();
+        while (!value.compare_exchange_strong(old, old + x))
+        ;   // Wait until exchanged
+    }
+};
+
+
+template <typename T>
+void
+sequence_compare_exchange_weak()
+{
+    const stdgpu::index_t N = 40000;
+    T* sequence = createDeviceArray<T>(N);
+    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
+                     T(1));
+
+    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+
+    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
+                     add_sequence_with_compare_exchange_weak<T>(value));
+
+    EXPECT_EQ(value.load(), T(N * (N + 1) / 2));
+
+    destroyDeviceArray<T>(sequence);
+    stdgpu::atomic<T>::destroyDeviceObject(value);
+}
+
+
+template <typename T>
+void
+sequence_compare_exchange_strong()
+{
+    const stdgpu::index_t N = 40000;
+    T* sequence = createDeviceArray<T>(N);
+    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
+                     T(1));
+
+    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+
+    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
+                     add_sequence_with_compare_exchange_strong<T>(value));
+
+    EXPECT_EQ(value.load(), T(N * (N + 1) / 2));
+
+    destroyDeviceArray<T>(sequence);
+    stdgpu::atomic<T>::destroyDeviceObject(value);
+}
+
+
+TEST_F(stdgpu_atomic, compare_exchange_weak_int)
+{
+    sequence_compare_exchange_weak<int>();
+}
+
+TEST_F(stdgpu_atomic, compare_exchange_weak_unsigned_int)
+{
+    sequence_compare_exchange_weak<unsigned int>();
+}
+
+TEST_F(stdgpu_atomic, compare_exchange_weak_unsigned_long_long_int)
+{
+    sequence_compare_exchange_weak<unsigned long long int>();
+}
+
+
+TEST_F(stdgpu_atomic, compare_exchange_strong_int)
+{
+    sequence_compare_exchange_strong<int>();
+}
+
+TEST_F(stdgpu_atomic, compare_exchange_strong_unsigned_int)
+{
+    sequence_compare_exchange_strong<unsigned int>();
+}
+
+TEST_F(stdgpu_atomic, compare_exchange_strong_unsigned_long_long_int)
+{
+    sequence_compare_exchange_strong<unsigned long long int>();
+}
+
+
+template <typename T>
 struct add_sequence
 {
     stdgpu::atomic<T> value;

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -239,6 +239,39 @@ TEST_F(stdgpu_atomic, load_and_store_unsigned_long_long_int)
 
 
 template <typename T>
+void
+operator_load_and_store()
+{
+    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+
+    EXPECT_EQ(value, T());
+
+    value = T(42);
+
+    EXPECT_EQ(value, T(42));
+
+    stdgpu::atomic<T>::destroyDeviceObject(value);
+}
+
+
+
+TEST_F(stdgpu_atomic, operator_load_and_store_int)
+{
+    operator_load_and_store<int>();
+}
+
+TEST_F(stdgpu_atomic, operator_load_and_store_unsigned_int)
+{
+    operator_load_and_store<unsigned int>();
+}
+
+TEST_F(stdgpu_atomic, operator_load_and_store_unsigned_long_long_int)
+{
+    operator_load_and_store<unsigned long long int>();
+}
+
+
+template <typename T>
 struct exchange_sequence
 {
     stdgpu::atomic<T> value;


### PR DESCRIPTION
In #75, more unit tests have been introduced to increase the test coverage. However, some functions are still not yet tested. Extend the tests to cover all defined functions. Furthermore, add operator-versions of `load()` and `store()` and fix the behavior of `compare_exchange_{weak,strong}`.