### PR TITLE
README: Add coverity badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 <a href="https://codecov.io/gh/stotko/stdgpu" alt="Code Coverage">
   <img src="https://codecov.io/gh/stotko/stdgpu/branch/master/graph/badge.svg" />
 </a>
+<a href="https://scan.coverity.com/projects/stotko-stdgpu" alt="Coverity Scan">
+   <img src="https://scan.coverity.com/projects/20259/badge.svg"/>
+</a>
 <a href="https://stotko.github.io/stdgpu" alt="Documentation">
     <img src="https://img.shields.io/badge/docs-doxygen-blue.svg"/>
 </a>


### PR DESCRIPTION
In addition to build testing and code coverage tracking, static analysis can be used to detect bugs and provide a further measure for code quality. Since the project uses Coverity Scan for static analysis, add the respective badge to the README.