### PR TITLE
General: Fix shadow warnings

### DIFF
--- a/cmake/cuda/set_device_flags.cmake
+++ b/cmake/cuda/set_device_flags.cmake
@@ -42,6 +42,8 @@ endif()
 if(NOT MSVC)
     string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wall")
     string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wextra")
+    #string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wshadow") # Currently disabled due to thrust
+
     if(${CMAKE_BUILD_TYPE} MATCHES "Release" OR ${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
         message(STATUS "Appended optimization flag (-O3,/O2) implicitly")
     endif()

--- a/cmake/set_host_flags.cmake
+++ b/cmake/set_host_flags.cmake
@@ -3,6 +3,8 @@ if(NOT MSVC)
     string(APPEND STDGPU_HOST_FLAGS " -Wall")
     string(APPEND STDGPU_HOST_FLAGS " -pedantic")
     string(APPEND STDGPU_HOST_FLAGS " -Wextra")
+    #string(APPEND STDGPU_HOST_FLAGS " -Wshadow") # Currently disabled due to thrust
+
     if(${CMAKE_BUILD_TYPE} MATCHES "Release" OR ${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
         string(APPEND STDGPU_HOST_FLAGS " -O3")
     endif()

--- a/examples/cuda/thrust_towards_ranges.cu
+++ b/examples/cuda/thrust_towards_ranges.cu
@@ -36,21 +36,23 @@ struct square_int
 };
 
 
-struct atomic_sum
+class atomic_sum
 {
-    stdgpu::atomic<int> sum;
+    public:
+        atomic_sum(stdgpu::atomic<int> sum)
+            : _sum(sum)
+        {
 
-    atomic_sum(stdgpu::atomic<int> sum)
-        : sum(sum)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const int x)
+        {
+            _sum.fetch_add(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const int x)
-    {
-        sum.fetch_add(x);
-    }
+    private:
+        stdgpu::atomic<int> _sum;
 };
 
 

--- a/examples/openmp/thrust_towards_ranges.cpp
+++ b/examples/openmp/thrust_towards_ranges.cpp
@@ -36,21 +36,23 @@ struct square_int
 };
 
 
-struct atomic_sum
+class atomic_sum
 {
-    stdgpu::atomic<int> sum;
+    public:
+        atomic_sum(stdgpu::atomic<int> sum)
+            : _sum(sum)
+        {
 
-    atomic_sum(stdgpu::atomic<int> sum)
-        : sum(sum)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const int x)
+        {
+            _sum.fetch_add(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const int x)
-    {
-        sum.fetch_add(x);
-    }
+    private:
+        stdgpu::atomic<int> _sum;
 };
 
 

--- a/src/stdgpu/impl/bitset.inc
+++ b/src/stdgpu/impl/bitset.inc
@@ -46,41 +46,45 @@ div_up(const index_t a,
     return result;
 }
 
-struct set_bits
+class set_bits
 {
-    bitset bits;
-    const bool value;
+    public:
+        set_bits(const bitset& bits,
+                 const bool value)
+            : _bits(bits),
+              _value(value)
+        {
 
-    set_bits(const bitset& bits,
-             const bool value)
-        : bits(bits),
-          value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const index_t i)
+        {
+            _bits.set(i, _value);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const index_t i)
-    {
-        bits.set(i, value);
-    }
+    private:
+        bitset _bits;
+        const bool _value;
 };
 
-struct flip_bits
+class flip_bits
 {
-    bitset bits;
+    public:
+        flip_bits(const bitset& bits)
+            : _bits(bits)
+        {
 
-    flip_bits(const bitset& bits)
-        : bits(bits)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const index_t i)
+        {
+            _bits.flip(i);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const index_t i)
-    {
-        bits.flip(i);
-    }
+    private:
+        bitset _bits;
 };
 
 template <typename T>

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -513,24 +513,26 @@ namespace detail
 {
 
 template <typename T>
-struct deque_collect_positions
+class deque_collect_positions
 {
-    deque<T> d;
-
-    deque_collect_positions(const deque<T>& d)
-        : d(d)
-    {
-
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const index_t i)
-    {
-        if (d.occupied(i))
+    public:
+        deque_collect_positions(const deque<T>& d)
+            : _d(d)
         {
-            d._range_indices.push_back(i);
+
         }
-    }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(const index_t i)
+        {
+            if (_d.occupied(i))
+            {
+                _d._range_indices.push_back(i);
+            }
+        }
+
+    private:
+        deque<T> _d;
 };
 
 } // namespace detail

--- a/src/stdgpu/impl/iterator_detail.h
+++ b/src/stdgpu/impl/iterator_detail.h
@@ -259,7 +259,7 @@ class back_insert_iterator_proxy
     public:
         STDGPU_HOST_DEVICE
         back_insert_iterator_proxy(const Container& c)
-            : c(c)
+            : _c(c)
         {
 
         }
@@ -267,12 +267,12 @@ class back_insert_iterator_proxy
         STDGPU_HOST_DEVICE back_insert_iterator_proxy
         operator=(const typename Container::value_type& value)
         {
-            c.push_back(value);
+            _c.push_back(value);
             return *this;
         }
 
     private:
-        Container c;
+        Container _c;
 };
 
 template <typename Container>
@@ -294,7 +294,7 @@ class front_insert_iterator_proxy
     public:
         STDGPU_HOST_DEVICE
         front_insert_iterator_proxy(const Container& c)
-            : c(c)
+            : _c(c)
         {
 
         }
@@ -302,12 +302,12 @@ class front_insert_iterator_proxy
         STDGPU_HOST_DEVICE front_insert_iterator_proxy
         operator=(const typename Container::value_type& value)
         {
-            c.push_front(value);
+            _c.push_front(value);
             return *this;
         }
 
     private:
-        Container c;
+        Container _c;
 };
 
 template <typename Container>
@@ -329,7 +329,7 @@ class insert_iterator_proxy
     public:
         STDGPU_HOST_DEVICE
         insert_iterator_proxy(const Container& c)
-            : c(c)
+            : _c(c)
         {
 
         }
@@ -337,12 +337,12 @@ class insert_iterator_proxy
         STDGPU_HOST_DEVICE insert_iterator_proxy
         operator=(const typename Container::value_type& value)
         {
-            c.insert(value);
+            _c.insert(value);
             return *this;
         }
 
     private:
-        Container c;
+        Container _c;
 };
 
 template <typename Container>
@@ -363,7 +363,7 @@ struct insert_iterator_base
 template <typename Container>
 STDGPU_HOST_DEVICE
 back_insert_iterator<Container>::back_insert_iterator(Container& c)
-    : c(c)
+    : _c(c)
 {
 
 }
@@ -373,7 +373,7 @@ template <typename Container>
 STDGPU_HOST_DEVICE typename back_insert_iterator<Container>::super_t::reference
 back_insert_iterator<Container>::dereference() const
 {
-    return detail::back_insert_iterator_proxy<Container>(c);
+    return detail::back_insert_iterator_proxy<Container>(_c);
 }
 
 
@@ -388,7 +388,7 @@ back_inserter(Container& c)
 template <typename Container>
 STDGPU_HOST_DEVICE
 front_insert_iterator<Container>::front_insert_iterator(Container& c)
-    : c(c)
+    : _c(c)
 {
 
 }
@@ -398,7 +398,7 @@ template <typename Container>
 STDGPU_HOST_DEVICE typename front_insert_iterator<Container>::super_t::reference
 front_insert_iterator<Container>::dereference() const
 {
-    return detail::front_insert_iterator_proxy<Container>(c);
+    return detail::front_insert_iterator_proxy<Container>(_c);
 }
 
 
@@ -413,7 +413,7 @@ front_inserter(Container& c)
 template <typename Container>
 STDGPU_HOST_DEVICE
 insert_iterator<Container>::insert_iterator(Container& c)
-    : c(c)
+    : _c(c)
 {
 
 }
@@ -423,7 +423,7 @@ template <typename Container>
 STDGPU_HOST_DEVICE typename insert_iterator<Container>::super_t::reference
 insert_iterator<Container>::dereference() const
 {
-    return detail::insert_iterator_proxy<Container>(c);
+    return detail::insert_iterator_proxy<Container>(_c);
 }
 
 

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -53,22 +53,24 @@ memcpy(void* destination,
        const bool external_memory);
 
 template <typename T>
-struct construct_value
+class construct_value
 {
-    T value;
+    public:
+        STDGPU_HOST_DEVICE
+        construct_value(const T& value)
+            : _value(value)
+        {
 
-    STDGPU_HOST_DEVICE
-    construct_value(const T& value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_HOST_DEVICE void
+        operator()(T& t) const
+        {
+            ::new (static_cast<void*>(&t)) T(_value);
+        }
 
-    STDGPU_HOST_DEVICE void
-    operator()(T& t) const
-    {
-        ::new (static_cast<void*>(&t)) T(value);
-    }
+    private:
+        T _value;
 };
 
 template <typename Iterator, typename T>

--- a/src/stdgpu/impl/mutex.inc
+++ b/src/stdgpu/impl/mutex.inc
@@ -45,21 +45,23 @@ mutex_array::destroyDeviceObject(mutex_array& device_object)
 namespace detail
 {
 
-struct unlocked
+class unlocked
 {
-    mutex_array lock_bits;
+    public:
+        unlocked(const mutex_array& lock_bits)
+            : _lock_bits(lock_bits)
+        {
 
-    unlocked(const mutex_array& lock_bits)
-        : lock_bits(lock_bits)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY bool
+        operator()(const index_t i) const
+        {
+            return !(_lock_bits[i].locked());
+        }
 
-    STDGPU_DEVICE_ONLY bool
-    operator()(const index_t i) const
-    {
-        return !(lock_bits[i].locked());
-    }
+    private:
+        mutex_array _lock_bits;
 };
 
 } // namespace detail

--- a/src/stdgpu/iterator.h
+++ b/src/stdgpu/iterator.h
@@ -447,7 +447,7 @@ class back_insert_iterator
         STDGPU_HOST_DEVICE typename super_t::reference
         dereference() const;
 
-        Container c;
+        Container _c;
 };
 
 /**
@@ -486,7 +486,7 @@ class front_insert_iterator
         STDGPU_HOST_DEVICE typename super_t::reference
         dereference() const;
 
-        Container c;
+        Container _c;
 };
 
 /**
@@ -528,7 +528,7 @@ class insert_iterator
         STDGPU_HOST_DEVICE typename super_t::reference
         dereference() const;
 
-        Container c;
+        Container _c;
 };
 
 /**

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -272,21 +272,23 @@ TEST_F(stdgpu_atomic, operator_load_and_store_unsigned_long_long_int)
 
 
 template <typename T>
-struct exchange_sequence
+class exchange_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        exchange_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    exchange_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(T& x)
+        {
+            x = _value.exchange(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(T& x)
-    {
-        x = value.exchange(x);
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
@@ -334,44 +336,48 @@ TEST_F(stdgpu_atomic, exchange_unsigned_long_long_int)
 
 
 template <typename T>
-struct add_sequence_with_compare_exchange_weak
+class add_sequence_with_compare_exchange_weak
 {
-    stdgpu::atomic<T> value;
+    public:
+        add_sequence_with_compare_exchange_weak(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    add_sequence_with_compare_exchange_weak(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            T old = _value.load();
+            while (!_value.compare_exchange_weak(old, old + x))
+            ;   // Wait until exchanged
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        T old = value.load();
-        while (!value.compare_exchange_weak(old, old + x))
-        ;   // Wait until exchanged
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
 template <typename T>
-struct add_sequence_with_compare_exchange_strong
+class add_sequence_with_compare_exchange_strong
 {
-    stdgpu::atomic<T> value;
+    public:
+        add_sequence_with_compare_exchange_strong(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    add_sequence_with_compare_exchange_strong(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            T old = _value.load();
+            while (!_value.compare_exchange_strong(old, old + x))
+            ;   // Wait until exchanged
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        T old = value.load();
-        while (!value.compare_exchange_strong(old, old + x))
-        ;   // Wait until exchanged
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
@@ -450,40 +456,44 @@ TEST_F(stdgpu_atomic, compare_exchange_strong_unsigned_long_long_int)
 
 
 template <typename T>
-struct add_sequence
+class add_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        add_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    add_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _value.fetch_add(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        value.fetch_add(x);
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
 template <typename T>
-struct add_equals_sequence
+class add_equals_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        add_equals_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    add_equals_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _value += x;
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        value += x;
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
@@ -562,40 +572,44 @@ TEST_F(stdgpu_atomic, operator_add_equals_unsigned_long_long_int)
 
 
 template <typename T>
-struct sub_sequence
+class sub_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        sub_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    sub_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _value.fetch_sub(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        value.fetch_sub(x);
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
 template <typename T>
-struct sub_equals_sequence
+class sub_equals_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        sub_equals_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    sub_equals_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _value -= x;
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        value -= x;
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
@@ -693,44 +707,48 @@ bit_set(const T value,
 
 
 template <typename T>
-struct or_sequence
+class or_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        or_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    or_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const stdgpu::index_t i)
+        {
+            T pattern = static_cast<T>(1) << i;
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
-    {
-        T pattern = static_cast<T>(1) << i;
+            _value.fetch_or(pattern);
+        }
 
-        value.fetch_or(pattern);
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
 template <typename T>
-struct or_equals_sequence
+class or_equals_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        or_equals_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    or_equals_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const stdgpu::index_t i)
+        {
+            T pattern = static_cast<T>(1) << i;
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
-    {
-        T pattern = static_cast<T>(1) << i;
+            _value |= pattern;
+        }
 
-        value |= pattern;
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
@@ -809,50 +827,54 @@ TEST_F(stdgpu_atomic, operator_or_equals_unsigned_long_long_int)
 
 
 template <typename T>
-struct and_sequence
+class and_sequence
 {
-    stdgpu::atomic<T> value;
-    T one_pattern;
+    public:
+        and_sequence(stdgpu::atomic<T> value,
+                     T one_pattern)
+            : _value(value),
+              _one_pattern(one_pattern)
+        {
 
-    and_sequence(stdgpu::atomic<T> value,
-                 T one_pattern)
-        : value(value),
-          one_pattern(one_pattern)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const stdgpu::index_t i)
+        {
+            T pattern = _one_pattern - (static_cast<T>(1) << i);
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
-    {
-        T pattern = one_pattern - (static_cast<T>(1) << i);
+            _value.fetch_and(pattern);
+        }
 
-        value.fetch_and(pattern);
-    }
+    private:
+        stdgpu::atomic<T> _value;
+        T _one_pattern;
 };
 
 
 template <typename T>
-struct and_equals_sequence
+class and_equals_sequence
 {
-    stdgpu::atomic<T> value;
-    T one_pattern;
+    public:
+        and_equals_sequence(stdgpu::atomic<T> value,
+                            T one_pattern)
+            : _value(value),
+              _one_pattern(one_pattern)
+        {
 
-    and_equals_sequence(stdgpu::atomic<T> value,
-                        T one_pattern)
-        : value(value),
-          one_pattern(one_pattern)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const stdgpu::index_t i)
+        {
+            T pattern = _one_pattern - (static_cast<T>(1) << i);
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
-    {
-        T pattern = one_pattern - (static_cast<T>(1) << i);
+            _value &= pattern;
+        }
 
-        value &= pattern;
-    }
+    private:
+        stdgpu::atomic<T> _value;
+        T _one_pattern;
 };
 
 
@@ -953,44 +975,48 @@ TEST_F(stdgpu_atomic, operator_and_equals_unsigned_long_long_int)
 
 
 template <typename T>
-struct xor_sequence
+class xor_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        xor_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    xor_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const stdgpu::index_t i)
+        {
+            T pattern = static_cast<T>(1) << i;
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
-    {
-        T pattern = static_cast<T>(1) << i;
+            _value.fetch_xor(pattern);
+        }
 
-        value.fetch_xor(pattern);
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
 template <typename T>
-struct xor_equals_sequence
+class xor_equals_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        xor_equals_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    xor_equals_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const stdgpu::index_t i)
+        {
+            T pattern = static_cast<T>(1) << i;
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
-    {
-        T pattern = static_cast<T>(1) << i;
+            _value ^= pattern;
+        }
 
-        value ^= pattern;
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
@@ -1069,21 +1095,23 @@ TEST_F(stdgpu_atomic, operator_xor_equals_unsigned_long_long_int)
 
 
 template <typename T>
-struct min_sequence
+class min_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        min_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    min_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _value.fetch_min(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        value.fetch_min(x);
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
@@ -1126,21 +1154,23 @@ TEST_F(stdgpu_atomic, fetch_min_unsigned_long_long_int)
 
 
 template <typename T>
-struct max_sequence
+class max_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        max_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    max_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _value.fetch_max(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        value.fetch_max(x);
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
@@ -1183,21 +1213,23 @@ TEST_F(stdgpu_atomic, fetch_max_unsigned_long_long_int)
 
 
 template <typename T>
-struct inc_mod_sequence
+class inc_mod_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        inc_mod_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    inc_mod_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _value.fetch_inc_mod(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        value.fetch_inc_mod(x);
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
@@ -1239,21 +1271,23 @@ TEST_F(stdgpu_atomic, fetch_inc_mod_unsigned_int)
 
 
 template <typename T>
-struct dec_mod_dequence
+class dec_mod_dequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        dec_mod_dequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    dec_mod_dequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _value.fetch_dec_mod(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        value.fetch_dec_mod(x);
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
@@ -1295,21 +1329,23 @@ TEST_F(stdgpu_atomic, fetch_dec_mod_unsigned_int)
 
 
 template <typename T>
-struct pre_inc_sequence
+class pre_inc_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        pre_inc_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    pre_inc_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY T
+        operator()()
+        {
+            return ++_value;
+        }
 
-    STDGPU_DEVICE_ONLY T
-    operator()()
-    {
-        return ++value;
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
@@ -1357,21 +1393,23 @@ TEST_F(stdgpu_atomic, pre_inc_operator_unsigned_long_long_int)
 
 
 template <typename T>
-struct post_inc_sequence
+class post_inc_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        post_inc_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    post_inc_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY T
+        operator()()
+        {
+            return _value++;
+        }
 
-    STDGPU_DEVICE_ONLY T
-    operator()()
-    {
-        return value++;
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
@@ -1419,21 +1457,23 @@ TEST_F(stdgpu_atomic, post_inc_operator_unsigned_long_long_int)
 
 
 template <typename T>
-struct pre_dec_sequence
+class pre_dec_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        pre_dec_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    pre_dec_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY T
+        operator()()
+        {
+            return --_value;
+        }
 
-    STDGPU_DEVICE_ONLY T
-    operator()()
-    {
-        return --value;
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 
@@ -1488,21 +1528,23 @@ TEST_F(stdgpu_atomic, pre_dec_operator_unsigned_long_long_int)
 
 
 template <typename T>
-struct post_dec_sequence
+class post_dec_sequence
 {
-    stdgpu::atomic<T> value;
+    public:
+        post_dec_sequence(stdgpu::atomic<T> value)
+            : _value(value)
+        {
 
-    post_dec_sequence(stdgpu::atomic<T> value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY T
+        operator()()
+        {
+            return _value--;
+        }
 
-    STDGPU_DEVICE_ONLY T
-    operator()()
-    {
-        return value--;
-    }
+    private:
+        stdgpu::atomic<T> _value;
 };
 
 

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -57,88 +57,96 @@ TEST_F(stdgpu_bitset, default_values)
 }
 
 
-struct set_all_bits
+class set_all_bits
 {
-    stdgpu::bitset bitset;
-
-    set_all_bits(stdgpu::bitset bitset)
-        : bitset(bitset)
-    {
-
-    }
-
-    STDGPU_DEVICE_ONLY bool
-    operator()(const stdgpu::index_t i)
-    {
-        bitset.set(i);
-
-        return bitset[i];
-    }
-};
-
-
-struct reset_all_bits
-{
-    stdgpu::bitset bitset;
-
-    reset_all_bits(stdgpu::bitset bitset)
-        : bitset(bitset)
-    {
-
-    }
-
-    STDGPU_DEVICE_ONLY bool
-    operator()(const stdgpu::index_t i)
-    {
-        bitset.reset(i);
-
-        return bitset[i];
-    }
-};
-
-
-struct set_and_reset_all_bits
-{
-    stdgpu::bitset bitset;
-
-    set_and_reset_all_bits(stdgpu::bitset bitset)
-        : bitset(bitset)
-    {
-
-    }
-
-    STDGPU_DEVICE_ONLY bool
-    operator()(const stdgpu::index_t i)
-    {
-        bitset.set(i);
-
-        if (bitset[i])
+    public:
+        set_all_bits(stdgpu::bitset bitset)
+            : _bitset(bitset)
         {
-            bitset.reset(i);
+
         }
 
-        return bitset[i];
-    }
+        STDGPU_DEVICE_ONLY bool
+        operator()(const stdgpu::index_t i)
+        {
+            _bitset.set(i);
+
+            return _bitset[i];
+        }
+
+    private:
+        stdgpu::bitset _bitset;
 };
 
 
-struct flip_all_bits
+class reset_all_bits
 {
-    stdgpu::bitset bitset;
+    public:
+        reset_all_bits(stdgpu::bitset bitset)
+            : _bitset(bitset)
+        {
 
-    flip_all_bits(stdgpu::bitset bitset)
-        : bitset(bitset)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY bool
+        operator()(const stdgpu::index_t i)
+        {
+            _bitset.reset(i);
 
-    STDGPU_DEVICE_ONLY bool
-    operator()(const stdgpu::index_t i)
-    {
-        bitset.flip(i);
+            return _bitset[i];
+        }
 
-        return bitset[i];
-    }
+    private:
+        stdgpu::bitset _bitset;
+};
+
+
+class set_and_reset_all_bits
+{
+    public:
+        set_and_reset_all_bits(stdgpu::bitset bitset)
+            : _bitset(bitset)
+        {
+
+        }
+
+        STDGPU_DEVICE_ONLY bool
+        operator()(const stdgpu::index_t i)
+        {
+            _bitset.set(i);
+
+            if (_bitset[i])
+            {
+                _bitset.reset(i);
+            }
+
+            return _bitset[i];
+        }
+
+    private:
+        stdgpu::bitset _bitset;
+};
+
+
+class flip_all_bits
+{
+    public:
+        flip_all_bits(stdgpu::bitset bitset)
+            : _bitset(bitset)
+        {
+
+        }
+
+        STDGPU_DEVICE_ONLY bool
+        operator()(const stdgpu::index_t i)
+        {
+            _bitset.flip(i);
+
+            return _bitset[i];
+        }
+
+    private:
+        stdgpu::bitset _bitset;
 };
 
 
@@ -285,112 +293,120 @@ generate_shuffled_sequence(const stdgpu::index_t size)
 }
 
 
-struct set_bits
+class set_bits
 {
-    stdgpu::bitset bitset;
-    stdgpu::index_t* positions;
-    uint8_t* set;
-
-    set_bits(stdgpu::bitset bitset,
-             stdgpu::index_t* positions,
-             uint8_t* set)
-        : bitset(bitset),
-          positions(positions),
-          set(set)
-    {
-
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
-    {
-        bitset.set(positions[i]);
-
-        set[positions[i]] = bitset[positions[i]];
-    }
-};
-
-
-struct reset_bits
-{
-    stdgpu::bitset bitset;
-    stdgpu::index_t* positions;
-    uint8_t* set;
-
-    reset_bits(stdgpu::bitset bitset,
-               stdgpu::index_t* positions,
-               uint8_t* set)
-        : bitset(bitset),
-          positions(positions),
-          set(set)
-    {
-
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
-    {
-        bitset.reset(positions[i]);
-
-        set[positions[i]] = bitset[positions[i]];
-    }
-};
-
-
-struct set_and_reset_bits
-{
-    stdgpu::bitset bitset;
-    stdgpu::index_t* positions;
-    uint8_t* set;
-
-    set_and_reset_bits(stdgpu::bitset bitset,
-                      stdgpu::index_t* positions,
-                      uint8_t* set)
-        : bitset(bitset),
-          positions(positions),
-          set(set)
-    {
-
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
-    {
-        bitset.set(positions[i]);
-
-        if (bitset[positions[i]])
+    public:
+        set_bits(stdgpu::bitset bitset,
+                 stdgpu::index_t* positions,
+                 uint8_t* set)
+            : _bitset(bitset),
+              _positions(positions),
+              _set(set)
         {
-            bitset.reset(positions[i]);
+
         }
 
-        set[positions[i]] = bitset[positions[i]];
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const stdgpu::index_t i)
+        {
+            _bitset.set(_positions[i]);
+
+            _set[_positions[i]] = _bitset[_positions[i]];
+        }
+
+    private:
+        stdgpu::bitset _bitset;
+        stdgpu::index_t* _positions;
+        uint8_t* _set;
 };
 
 
-struct flip_bits
+class reset_bits
 {
-    stdgpu::bitset bitset;
-    stdgpu::index_t* positions;
-    uint8_t* set;
+    public:
+        reset_bits(stdgpu::bitset bitset,
+                   stdgpu::index_t* positions,
+                    uint8_t* set)
+            : _bitset(bitset),
+              _positions(positions),
+              _set(set)
+        {
 
-    flip_bits(stdgpu::bitset bitset,
-              stdgpu::index_t* positions,
-              uint8_t* set)
-        : bitset(bitset),
-          positions(positions),
-          set(set)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const stdgpu::index_t i)
+        {
+            _bitset.reset(_positions[i]);
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
-    {
-        bitset.flip(positions[i]);
+            _set[_positions[i]] = _bitset[_positions[i]];
+        }
 
-        set[positions[i]] = bitset[positions[i]];
-    }
+    private:
+        stdgpu::bitset _bitset;
+        stdgpu::index_t* _positions;
+        uint8_t* _set;
+};
+
+
+class set_and_reset_bits
+{
+    public:
+        set_and_reset_bits(stdgpu::bitset bitset,
+                           stdgpu::index_t* positions,
+                           uint8_t* set)
+            : _bitset(bitset),
+              _positions(positions),
+              _set(set)
+        {
+
+        }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(const stdgpu::index_t i)
+        {
+            _bitset.set(_positions[i]);
+
+            if (_bitset[_positions[i]])
+            {
+                _bitset.reset(_positions[i]);
+            }
+
+            _set[_positions[i]] = _bitset[_positions[i]];
+        }
+
+    private:
+        stdgpu::bitset _bitset;
+        stdgpu::index_t* _positions;
+        uint8_t* _set;
+};
+
+
+class flip_bits
+{
+    public:
+        flip_bits(stdgpu::bitset bitset,
+                  stdgpu::index_t* positions,
+                  uint8_t* set)
+            : _bitset(bitset),
+              _positions(positions),
+              _set(set)
+        {
+
+        }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(const stdgpu::index_t i)
+        {
+            _bitset.flip(_positions[i]);
+
+            _set[_positions[i]] = _bitset[_positions[i]];
+        }
+
+    private:
+        stdgpu::bitset _bitset;
+        stdgpu::index_t* _positions;
+        uint8_t* _set;
 };
 
 

--- a/test/stdgpu/cuda/atomic.cu
+++ b/test/stdgpu/cuda/atomic.cu
@@ -51,21 +51,23 @@ class stdgpu_cuda_atomic : public ::testing::Test
 
 
 template <typename T>
-struct subtract
+class subtract
 {
-    T* value;
+    public:
+        subtract(T* value)
+            : _value(value)
+        {
 
-    subtract(T* value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            atomicSub(_value, x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        atomicSub(value, x);
-    }
+    private:
+        T* _value;
 };
 
 
@@ -167,67 +169,73 @@ TEST_F(stdgpu_cuda_atomic, float_sub)
 }
 
 
-struct random_float
+class random_float
 {
-    stdgpu::index_t seed;
-    float min, max;
+    public:
+        STDGPU_HOST_DEVICE
+        random_float(const stdgpu::index_t seed,
+                     const float min,
+                     const float max)
+            : _seed(seed),
+              _min(min),
+              _max(max)
+        {
 
-    STDGPU_HOST_DEVICE
-    random_float(const stdgpu::index_t seed,
-                 const float min,
-                 const float max)
-        : seed(seed),
-          min(min),
-          max(max)
-    {
+        }
 
-    }
+        STDGPU_HOST_DEVICE float
+        operator()(const stdgpu::index_t n) const
+        {
+            thrust::default_random_engine rng(_seed);
+            thrust::uniform_real_distribution<float> dist(_min, _max);
+            rng.discard(n);
 
-    STDGPU_HOST_DEVICE float
-    operator()(const stdgpu::index_t n) const
-    {
-        thrust::default_random_engine rng(seed);
-        thrust::uniform_real_distribution<float> dist(min, max);
-        rng.discard(n);
+            return dist(rng);
+        }
 
-        return dist(rng);
-    }
+    private:
+        stdgpu::index_t _seed;
+        float _min, _max;
 };
 
 
-struct find_min
+class find_min
 {
-    float* value;
+    public:
+        find_min(float* value)
+            : _value(value)
+        {
 
-    find_min(float* value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const float x)
+        {
+            atomicMin(_value, x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const float x)
-    {
-        atomicMin(value, x);
-    }
+    private:
+        float* _value;
 };
 
 
-struct find_max
+class find_max
 {
-    float* value;
+    public:
+        find_max(float* value)
+            : _value(value)
+        {
 
-    find_max(float* value)
-        : value(value)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const float x)
+        {
+            atomicMax(_value, x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const float x)
-    {
-        atomicMax(value, x);
-    }
+    private:
+        float* _value;
 };
 
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -65,119 +65,131 @@ deque<int>::emplace_front<int>(int&&);
 
 
 template <typename T>
-struct pop_back_deque
+class pop_back_deque
 {
-    stdgpu::deque<T> pool;
+    public:
+        pop_back_deque(stdgpu::deque<T> pool)
+            : _pool(pool)
+        {
 
-    pop_back_deque(stdgpu::deque<T> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(STDGPU_MAYBE_UNUSED const T x)
+        {
+            _pool.pop_back();
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(STDGPU_MAYBE_UNUSED const T x)
-    {
-        pool.pop_back();
-    }
+    private:
+        stdgpu::deque<T> _pool;
 };
 
 template <typename Pair>
-struct pop_back_deque_const_type
+class pop_back_deque_const_type
 {
-    stdgpu::deque<Pair> pool;
+    public:
+        pop_back_deque_const_type(stdgpu::deque<Pair> pool)
+            : _pool(pool)
+        {
 
-    pop_back_deque_const_type(stdgpu::deque<Pair> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        inline STDGPU_HOST_DEVICE void
+        operator()(STDGPU_MAYBE_UNUSED const typename Pair::first_type& first)
+        {
+            _pool.pop_back();
+        }
 
-    inline STDGPU_HOST_DEVICE void
-    operator()(STDGPU_MAYBE_UNUSED const typename Pair::first_type& first)
-    {
-        pool.pop_back();
-    }
+    private:
+        stdgpu::deque<Pair> _pool;
 };
 
 
 template <typename T>
-struct push_back_deque
+class push_back_deque
 {
-    stdgpu::deque<T> pool;
+    public:
+        push_back_deque(stdgpu::deque<T> pool)
+            : _pool(pool)
+        {
 
-    push_back_deque(stdgpu::deque<T> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _pool.push_back(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        pool.push_back(x);
-    }
+    private:
+        stdgpu::deque<T> _pool;
 };
 
 template <typename Pair>
-struct push_back_deque_const_type
+class push_back_deque_const_type
 {
-    stdgpu::deque<Pair> pool;
-    typename Pair::second_type second;
+    public:
+        push_back_deque_const_type(stdgpu::deque<Pair> pool,
+                                   const typename Pair::second_type& second)
+            : _pool(pool),
+              _second(second)
+        {
 
-    push_back_deque_const_type(stdgpu::deque<Pair> pool,
-                               const typename Pair::second_type& second)
-        : pool(pool),
-          second(second)
-    {
+        }
 
-    }
+        inline STDGPU_HOST_DEVICE void
+        operator()(const typename Pair::first_type& first)
+        {
+            _pool.push_back(thrust::make_pair(first, _second));
+        }
 
-    inline STDGPU_HOST_DEVICE void
-    operator()(const typename Pair::first_type& first)
-    {
-        pool.push_back(thrust::make_pair(first, second));
-    }
+    private:
+        stdgpu::deque<Pair> _pool;
+        typename Pair::second_type _second;
 };
 
 
 template <typename T>
-struct emplace_back_deque
+class emplace_back_deque
 {
-    stdgpu::deque<T> pool;
+    public:
+        emplace_back_deque(stdgpu::deque<T> pool)
+            : _pool(pool)
+        {
 
-    emplace_back_deque(stdgpu::deque<T> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _pool.emplace_back(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        pool.emplace_back(x);
-    }
+    private:
+        stdgpu::deque<T> _pool;
 };
 
 template <typename Pair>
-struct emplace_back_deque_const_type
+class emplace_back_deque_const_type
 {
-    stdgpu::deque<Pair> pool;
-    typename Pair::second_type second;
+    public:
+        emplace_back_deque_const_type(stdgpu::deque<Pair> pool,
+                                      const typename Pair::second_type& second)
+            : _pool(pool),
+              _second(second)
+        {
 
-    emplace_back_deque_const_type(stdgpu::deque<Pair> pool,
-                                  const typename Pair::second_type& second)
-        : pool(pool),
-          second(second)
-    {
+        }
 
-    }
+        inline STDGPU_HOST_DEVICE void
+        operator()(const typename Pair::first_type& first)
+        {
+            _pool.emplace_back(first, _second);
+        }
 
-    inline STDGPU_HOST_DEVICE void
-    operator()(const typename Pair::first_type& first)
-    {
-        pool.emplace_back(first, second);
-    }
+    private:
+        stdgpu::deque<Pair> _pool;
+        typename Pair::second_type _second;
 };
 
 
@@ -204,7 +216,7 @@ class nondefault_int_deque
 
         STDGPU_HOST_DEVICE
         nondefault_int_deque(const int x)
-            : x(x)
+            : _x(x)
         {
 
         }
@@ -212,11 +224,11 @@ class nondefault_int_deque
         STDGPU_HOST_DEVICE
         operator int() const
         {
-            return x;
+            return _x;
         }
 
     private:
-        int x;
+        int _x;
 };
 
 
@@ -655,119 +667,131 @@ TEST_F(stdgpu_deque, emplace_back_nondefault_type)
 
 
 template <typename T>
-struct pop_front_deque
+class pop_front_deque
 {
-    stdgpu::deque<T> pool;
+    public:
+        pop_front_deque(stdgpu::deque<T> pool)
+            : _pool(pool)
+        {
 
-    pop_front_deque(stdgpu::deque<T> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(STDGPU_MAYBE_UNUSED const T x)
+        {
+            _pool.pop_front();
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(STDGPU_MAYBE_UNUSED const T x)
-    {
-        pool.pop_front();
-    }
+    private:
+        stdgpu::deque<T> _pool;
 };
 
 template <typename Pair>
-struct pop_front_deque_const_type
+class pop_front_deque_const_type
 {
-    stdgpu::deque<Pair> pool;
+    public:
+        pop_front_deque_const_type(stdgpu::deque<Pair> pool)
+            : _pool(pool)
+        {
 
-    pop_front_deque_const_type(stdgpu::deque<Pair> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        inline STDGPU_HOST_DEVICE void
+        operator()(STDGPU_MAYBE_UNUSED const typename Pair::first_type& first)
+        {
+            _pool.pop_front();
+        }
 
-    inline STDGPU_HOST_DEVICE void
-    operator()(STDGPU_MAYBE_UNUSED const typename Pair::first_type& first)
-    {
-        pool.pop_front();
-    }
+    private:
+        stdgpu::deque<Pair> _pool;
 };
 
 
 template <typename T>
-struct push_front_deque
+class push_front_deque
 {
-    stdgpu::deque<T> pool;
+    public:
+        push_front_deque(stdgpu::deque<T> pool)
+            : _pool(pool)
+        {
 
-    push_front_deque(stdgpu::deque<T> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _pool.push_front(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        pool.push_front(x);
-    }
+    private:
+        stdgpu::deque<T> _pool;
 };
 
 template <typename Pair>
-struct push_front_deque_const_type
+class push_front_deque_const_type
 {
-    stdgpu::deque<Pair> pool;
-    typename Pair::second_type second;
+    public:
+        push_front_deque_const_type(stdgpu::deque<Pair> pool,
+                                    const typename Pair::second_type& second)
+            : _pool(pool),
+              _second(second)
+        {
 
-    push_front_deque_const_type(stdgpu::deque<Pair> pool,
-                                const typename Pair::second_type& second)
-        : pool(pool),
-          second(second)
-    {
+        }
 
-    }
+        inline STDGPU_HOST_DEVICE void
+        operator()(const typename Pair::first_type& first)
+        {
+            _pool.push_front(thrust::make_pair(first, _second));
+        }
 
-    inline STDGPU_HOST_DEVICE void
-    operator()(const typename Pair::first_type& first)
-    {
-        pool.push_front(thrust::make_pair(first, second));
-    }
+    private:
+        stdgpu::deque<Pair> _pool;
+        typename Pair::second_type _second;
 };
 
 
 template <typename T>
-struct emplace_front_deque
+class emplace_front_deque
 {
-    stdgpu::deque<T> pool;
+    public:
+        emplace_front_deque(stdgpu::deque<T> pool)
+            : _pool(pool)
+        {
 
-    emplace_front_deque(stdgpu::deque<T> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _pool.emplace_front(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        pool.emplace_front(x);
-    }
+    private:
+        stdgpu::deque<T> _pool;
 };
 
 template <typename Pair>
-struct emplace_front_deque_const_type
+class emplace_front_deque_const_type
 {
-    stdgpu::deque<Pair> pool;
-    typename Pair::second_type second;
+    public:
+        emplace_front_deque_const_type(stdgpu::deque<Pair> pool,
+                                       const typename Pair::second_type& second)
+            : _pool(pool),
+              _second(second)
+        {
 
-    emplace_front_deque_const_type(stdgpu::deque<Pair> pool,
-                                   const typename Pair::second_type& second)
-        : pool(pool),
-          second(second)
-    {
+        }
 
-    }
+        inline STDGPU_HOST_DEVICE void
+        operator()(const typename Pair::first_type& first)
+        {
+            _pool.emplace_front(first, _second);
+        }
 
-    inline STDGPU_HOST_DEVICE void
-    operator()(const typename Pair::first_type& first)
-    {
-        pool.emplace_front(first, second);
-    }
+    private:
+        stdgpu::deque<Pair> _pool;
+        typename Pair::second_type _second;
 };
 
 
@@ -1307,31 +1331,33 @@ TEST_F(stdgpu_deque, clear_nondefault_type)
 
 
 template <typename T>
-struct simultaneous_push_back_and_pop_back_deque
+class simultaneous_push_back_and_pop_back_deque
 {
-    stdgpu::deque<T> pool;
-    stdgpu::deque<T> pool_validation;
-
-    simultaneous_push_back_and_pop_back_deque(stdgpu::deque<T> pool,
-                                              stdgpu::deque<T> pool_validation)
-        : pool(pool),
-          pool_validation(pool_validation)
-    {
-
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        pool.push_back(x);
-
-        thrust::pair<T, bool> popped = pool.pop_back();
-
-        if (popped.second)
+    public:
+        simultaneous_push_back_and_pop_back_deque(stdgpu::deque<T> pool,
+                                                  stdgpu::deque<T> pool_validation)
+            : _pool(pool),
+              _pool_validation(pool_validation)
         {
-            pool_validation.push_back(popped.first);
+
         }
-    }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _pool.push_back(x);
+
+            thrust::pair<T, bool> popped = _pool.pop_back();
+
+            if (popped.second)
+            {
+                _pool_validation.push_back(popped.first);
+            }
+        }
+
+    private:
+        stdgpu::deque<T> _pool;
+        stdgpu::deque<T> _pool_validation;
 };
 
 
@@ -1371,31 +1397,33 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_back)
 
 
 template <typename T>
-struct simultaneous_push_front_and_pop_front_deque
+class simultaneous_push_front_and_pop_front_deque
 {
-    stdgpu::deque<T> pool;
-    stdgpu::deque<T> pool_validation;
-
-    simultaneous_push_front_and_pop_front_deque(stdgpu::deque<T> pool,
-                                                stdgpu::deque<T> pool_validation)
-        : pool(pool),
-          pool_validation(pool_validation)
-    {
-
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        pool.push_front(x);
-
-        thrust::pair<T, bool> popped = pool.pop_front();
-
-        if (popped.second)
+    public:
+        simultaneous_push_front_and_pop_front_deque(stdgpu::deque<T> pool,
+                                                    stdgpu::deque<T> pool_validation)
+            : _pool(pool),
+              _pool_validation(pool_validation)
         {
-            pool_validation.push_front(popped.first);
+
         }
-    }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _pool.push_front(x);
+
+            thrust::pair<T, bool> popped = _pool.pop_front();
+
+            if (popped.second)
+            {
+                _pool_validation.push_front(popped.first);
+            }
+        }
+
+    private:
+        stdgpu::deque<T> _pool;
+        stdgpu::deque<T> _pool_validation;
 };
 
 
@@ -1435,31 +1463,33 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_front)
 
 
 template <typename T>
-struct simultaneous_push_front_and_pop_back_deque
+class simultaneous_push_front_and_pop_back_deque
 {
-    stdgpu::deque<T> pool;
-    stdgpu::deque<T> pool_validation;
-
-    simultaneous_push_front_and_pop_back_deque(stdgpu::deque<T> pool,
-                                               stdgpu::deque<T> pool_validation)
-        : pool(pool),
-          pool_validation(pool_validation)
-    {
-
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        pool.push_front(x);
-
-        thrust::pair<T, bool> popped = pool.pop_back();
-
-        if (popped.second)
+    public:
+        simultaneous_push_front_and_pop_back_deque(stdgpu::deque<T> pool,
+                                                   stdgpu::deque<T> pool_validation)
+            : _pool(pool),
+              _pool_validation(pool_validation)
         {
-            pool_validation.push_front(popped.first);
+
         }
-    }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _pool.push_front(x);
+
+            thrust::pair<T, bool> popped = _pool.pop_back();
+
+            if (popped.second)
+            {
+                _pool_validation.push_front(popped.first);
+            }
+        }
+
+    private:
+        stdgpu::deque<T> _pool;
+        stdgpu::deque<T> _pool_validation;
 };
 
 
@@ -1499,31 +1529,33 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_back)
 
 
 template <typename T>
-struct simultaneous_push_back_and_pop_front_deque
+class simultaneous_push_back_and_pop_front_deque
 {
-    stdgpu::deque<T> pool;
-    stdgpu::deque<T> pool_validation;
-
-    simultaneous_push_back_and_pop_front_deque(stdgpu::deque<T> pool,
-                                               stdgpu::deque<T> pool_validation)
-        : pool(pool),
-          pool_validation(pool_validation)
-    {
-
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        pool.push_back(x);
-
-        thrust::pair<T, bool> popped = pool.pop_back();
-
-        if (popped.second)
+    public:
+        simultaneous_push_back_and_pop_front_deque(stdgpu::deque<T> pool,
+                                                   stdgpu::deque<T> pool_validation)
+            : _pool(pool),
+              _pool_validation(pool_validation)
         {
-            pool_validation.push_back(popped.first);
+
         }
-    }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _pool.push_back(x);
+
+            thrust::pair<T, bool> popped = _pool.pop_back();
+
+            if (popped.second)
+            {
+                _pool_validation.push_back(popped.first);
+            }
+        }
+
+    private:
+        stdgpu::deque<T> _pool;
+        stdgpu::deque<T> _pool_validation;
 };
 
 
@@ -1562,21 +1594,23 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_front)
 }
 
 
-struct at_non_const_deque
+class at_non_const_deque
 {
-    stdgpu::deque<int> pool;
+    public:
+        at_non_const_deque(stdgpu::deque<int> pool)
+            : _pool(pool)
+        {
 
-    at_non_const_deque(stdgpu::deque<int> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const int x)
+        {
+            _pool.at(x) = x * x;
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const int x)
-    {
-        pool.at(x) = x * x;
-    }
+    private:
+        stdgpu::deque<int> _pool;
 };
 
 
@@ -1602,21 +1636,23 @@ TEST_F(stdgpu_deque, at_non_const)
 }
 
 
-struct access_operator_non_const_deque
+class access_operator_non_const_deque
 {
-    stdgpu::deque<int> pool;
+    public:
+        access_operator_non_const_deque(stdgpu::deque<int> pool)
+            : _pool(pool)
+        {
 
-    access_operator_non_const_deque(stdgpu::deque<int> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const int x)
+        {
+            _pool[x] = x * x;
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const int x)
-    {
-        pool[x] = x * x;
-    }
+    private:
+        stdgpu::deque<int> _pool;
 };
 
 
@@ -1714,46 +1750,50 @@ TEST_F(stdgpu_deque, shrink_to_fit)
 namespace
 {
     template <typename T>
-    struct non_const_front_functor
+    class non_const_front_functor
     {
-        stdgpu::deque<T> pool;
-        T* result;
+        public:
+            non_const_front_functor(const stdgpu::deque<T>& pool,
+                                    T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        non_const_front_functor(const stdgpu::deque<T>& pool,
-                                T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _pool.front();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = pool.front();
-        }
+        private:
+            stdgpu::deque<T> _pool;
+            T* _result;
     };
 
 
     template <typename T>
-    struct const_front_functor
+    class const_front_functor
     {
-        const stdgpu::deque<T> pool;
-        T* result;
+        public:
+            const_front_functor(const stdgpu::deque<T>& pool,
+                                T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        const_front_functor(const stdgpu::deque<T>& pool,
-                            T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _pool.front();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = pool.front();
-        }
+        private:
+            const stdgpu::deque<T> _pool;
+            T* _result;
     };
 
 
@@ -1806,46 +1846,50 @@ namespace
 
 
     template <typename T>
-    struct non_const_back_functor
+    class non_const_back_functor
     {
-        stdgpu::deque<T> pool;
-        T* result;
+        public:
+            non_const_back_functor(const stdgpu::deque<T>& pool,
+                                   T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        non_const_back_functor(const stdgpu::deque<T>& pool,
-                               T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _pool.back();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = pool.back();
-        }
+        private:
+            stdgpu::deque<T> _pool;
+            T* _result;
     };
 
 
     template <typename T>
-    struct const_back_functor
+    class const_back_functor
     {
-        const stdgpu::deque<T> pool;
-        T* result;
+        public:
+            const_back_functor(const stdgpu::deque<T>& pool,
+                               T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        const_back_functor(const stdgpu::deque<T>& pool,
-                           T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _pool.back();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = pool.back();
-        }
+        private:
+            const stdgpu::deque<T> _pool;
+            T* _result;
     };
 
 
@@ -1898,46 +1942,50 @@ namespace
 
 
     template <typename T>
-    struct non_const_operator_access_functor
+    class non_const_operator_access_functor
     {
-        stdgpu::deque<T> pool;
-        T* result;
+        public:
+            non_const_operator_access_functor(const stdgpu::deque<T>& pool,
+                                              T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        non_const_operator_access_functor(const stdgpu::deque<T>& pool,
-                                          T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                *_result = _pool[i];
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            *result = pool[i];
-        }
+        private:
+            stdgpu::deque<T> _pool;
+            T* _result;
     };
 
 
     template <typename T>
-    struct const_operator_access_functor
+    class const_operator_access_functor
     {
-        const stdgpu::deque<T> pool;
-        T* result;
+        public:
+            const_operator_access_functor(const stdgpu::deque<T>& pool,
+                                          T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        const_operator_access_functor(const stdgpu::deque<T>& pool,
-                                      T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                *_result = _pool[i];
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            *result = pool[i];
-        }
+        private:
+            const stdgpu::deque<T> _pool;
+            T* _result;
     };
 
 
@@ -1993,46 +2041,50 @@ namespace
 
 
     template <typename T>
-    struct non_const_at_functor
+    class non_const_at_functor
     {
-        stdgpu::deque<T> pool;
-        T* result;
+        public:
+            non_const_at_functor(const stdgpu::deque<T>& pool,
+                                 T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        non_const_at_functor(const stdgpu::deque<T>& pool,
-                             T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                *_result = _pool.at(i);
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            *result = pool.at(i);
-        }
+        private:
+            stdgpu::deque<T> _pool;
+            T* _result;
     };
 
 
     template <typename T>
-    struct const_at_functor
+    class const_at_functor
     {
-        const stdgpu::deque<T> pool;
-        T* result;
+        public:
+            const_at_functor(const stdgpu::deque<T>& pool,
+                             T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        const_at_functor(const stdgpu::deque<T>& pool,
-                         T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                *_result = _pool.at(i);
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            *result = pool.at(i);
-        }
+        private:
+            const stdgpu::deque<T> _pool;
+            T* _result;
     };
 
 

--- a/test/stdgpu/iterator.cpp
+++ b/test/stdgpu/iterator.cpp
@@ -345,63 +345,69 @@ TEST_F(stdgpu_iterator, host_cbegin_cend)
 }
 
 
-struct back_insert_interface
+class back_insert_interface
 {
-    using value_type = std::vector<int>::value_type;
+    public:
+        using value_type = std::vector<int>::value_type;
 
-    back_insert_interface(std::vector<int>& vector)
-        : vector(vector)
-    {
+        back_insert_interface(std::vector<int>& vector)
+            : _vector(vector)
+        {
 
-    }
+        }
 
-    void
-    push_back(const int x)
-    {
-        vector.push_back(x);
-    }
+        void
+        push_back(const int x)
+        {
+            _vector.push_back(x);
+        }
 
-    std::vector<int>& vector;
+    private:
+        std::vector<int>& _vector;
 };
 
 
-struct front_insert_interface
+class front_insert_interface
 {
-    using value_type = std::vector<int>::value_type;
+    public:
+        using value_type = std::vector<int>::value_type;
 
-    front_insert_interface(std::vector<int>& vector)
-        : vector(vector)
-    {
+        front_insert_interface(std::vector<int>& vector)
+            : _vector(vector)
+        {
 
-    }
+        }
 
-    void
-    push_front(const int x)
-    {
-        vector.push_back(x);
-    }
+        void
+        push_front(const int x)
+        {
+            _vector.push_back(x);
+        }
 
-    std::vector<int>& vector;
+    private:
+        std::vector<int>& _vector;
 };
 
 
-struct insert_interface
+class insert_interface
 {
-    using value_type = std::vector<int>::value_type;
+    public:
+        using value_type = std::vector<int>::value_type;
 
-    insert_interface(std::vector<int>& vector)
-        : vector(vector)
-    {
+        insert_interface(std::vector<int>& vector)
+            : _vector(vector)
+        {
 
-    }
+        }
 
-    void
-    insert(const int x)
-    {
-        vector.push_back(x);
-    }
+        void
+        insert(const int x)
+        {
+            _vector.push_back(x);
+        }
 
-    std::vector<int>& vector;
+    private:
+        std::vector<int>& _vector;
 };
 
 

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -49,21 +49,23 @@ class STDGPU_MEMORY_TEST_CLASS : public ::testing::Test
 };
 
 
-struct equal_to_number
+class equal_to_number
 {
-    int number;
+    public:
+        equal_to_number(const int number)
+            : _number(number)
+        {
 
-    equal_to_number(const int number_int)
-        : number(number_int)
-    {
+        }
 
-    }
+        STDGPU_HOST_DEVICE bool
+        operator()(const int value)
+        {
+            return (value == _number);
+        }
 
-    STDGPU_HOST_DEVICE bool
-    operator()(const int value)
-    {
-        return (value == number);
-    }
+    private:
+        int _number;
 };
 
 
@@ -1334,29 +1336,31 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_hint_deallocate)
 
 namespace
 {
-    struct Counter
+    class Counter
     {
-        // Some member to let the class have a suitable size
-        int x = 0;
+        public:
+            static int constructor_calls;
+            static int destructor_calls;
 
-        static int constructor_calls;
-        static int destructor_calls;
+            STDGPU_HOST_DEVICE
+            Counter()
+            {
+                #if STDGPU_CODE == STDGPU_CODE_HOST
+                    Counter::constructor_calls++;
+                #endif
+            }
 
-        STDGPU_HOST_DEVICE
-        Counter()
-        {
-            #if STDGPU_CODE == STDGPU_CODE_HOST
-                Counter::constructor_calls++;
-            #endif
-        }
+            STDGPU_HOST_DEVICE
+            ~Counter()
+            {
+                #if STDGPU_CODE == STDGPU_CODE_HOST
+                    Counter::destructor_calls++;
+                #endif
+            }
 
-        STDGPU_HOST_DEVICE
-        ~Counter()
-        {
-            #if STDGPU_CODE == STDGPU_CODE_HOST
-                Counter::destructor_calls++;
-            #endif
-        }
+        private:
+            // Some member to let the class have a suitable size
+            int x = 0;
     };
 
     int Counter::constructor_calls = 0;
@@ -1364,28 +1368,32 @@ namespace
 
 
     template <typename Allocator>
-    struct traits_construct
+    class traits_construct
     {
-        Allocator a;
+        public:
+            void
+            operator()(typename Allocator::value_type& value)
+            {
+                stdgpu::allocator_traits<Allocator>::construct(a, &value);
+            }
 
-        void
-        operator()(typename Allocator::value_type& value)
-        {
-            stdgpu::allocator_traits<Allocator>::construct(a, &value);
-        }
+        private:
+            Allocator a;
     };
 
 
     template <typename Allocator>
-    struct traits_destroy
+    class traits_destroy
     {
-        Allocator a;
+        public:
+            void
+            operator()(typename Allocator::value_type& value)
+            {
+                stdgpu::allocator_traits<Allocator>::destroy(a, &value);
+            }
 
-        void
-        operator()(typename Allocator::value_type& value)
-        {
-            stdgpu::allocator_traits<Allocator>::destroy(a, &value);
-        }
+        private:
+            Allocator a;
     };
 }
 
@@ -1524,21 +1532,23 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_pinned_host_allocator)
 
 namespace
 {
-    struct default_construct
+    class default_construct
     {
-        int default_value;
+        public:
+            default_construct(const int default_value)
+                : _default_value(default_value)
+            {
 
-        default_construct(const int default_value)
-            : default_value(default_value)
-        {
+            }
 
-        }
+            void
+            operator()(int& value) const
+            {
+                stdgpu::default_allocator_traits::construct(&value, _default_value);
+            }
 
-        void
-        operator()(int& value) const
-        {
-            stdgpu::default_allocator_traits::construct(&value, default_value);
-        }
+        private:
+            int _default_value;
     };
 
 

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -55,41 +55,43 @@ TEST_F(stdgpu_mutex, default_values)
 }
 
 
-struct lock_and_unlock
+class lock_and_unlock
 {
-    stdgpu::mutex_array locks;
-
-    lock_and_unlock(stdgpu::mutex_array locks)
-        : locks(locks)
-    {
-
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
-    {
-        // --- SEQUENTIAL PART ---
-        bool leave_loop = false;
-        while (!leave_loop)
+    public:
+        lock_and_unlock(stdgpu::mutex_array locks)
+            : _locks(locks)
         {
-            if (locks[i].try_lock())
-            {
-                // START --- critical section --- START
 
-                // Waste time ...
-                long j = 0;
-                for (int k = 0; k < 10000; k++)
-                {
-                    j += k;
-                }
-
-                //  END  --- critical section ---  END
-                leave_loop = true;
-                locks[i].unlock();
-            }
         }
-        // --- SEQUENTIAL PART ---
-    }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(const stdgpu::index_t i)
+        {
+            // --- SEQUENTIAL PART ---
+            bool leave_loop = false;
+            while (!leave_loop)
+            {
+                if (_locks[i].try_lock())
+                {
+                    // START --- critical section --- START
+
+                    // Waste time ...
+                    long j = 0;
+                    for (int k = 0; k < 10000; k++)
+                    {
+                        j += k;
+                    }
+
+                    //  END  --- critical section ---  END
+                    leave_loop = true;
+                    _locks[i].unlock();
+                }
+            }
+            // --- SEQUENTIAL PART ---
+        }
+
+    private:
+        stdgpu::mutex_array _locks;
 };
 
 
@@ -102,24 +104,26 @@ TEST_F(stdgpu_mutex, parallel_lock_and_unlock)
 }
 
 
-struct same_state
+class same_state
 {
-    stdgpu::mutex_array locks_1;
-    stdgpu::mutex_array locks_2;
+    public:
+        same_state(stdgpu::mutex_array locks_1,
+                   stdgpu::mutex_array locks_2)
+            : _locks_1(locks_1),
+              _locks_2(locks_2)
+        {
 
-    same_state(stdgpu::mutex_array locks_1,
-               stdgpu::mutex_array locks_2)
-        : locks_1(locks_1),
-          locks_2(locks_2)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY bool
+        operator()(const stdgpu::index_t i)
+        {
+            return _locks_1[i].locked() == _locks_2[i].locked();
+        }
 
-    STDGPU_DEVICE_ONLY bool
-    operator()(const stdgpu::index_t i)
-    {
-        return locks_1[i].locked() == locks_2[i].locked();
-    }
+    private:
+        stdgpu::mutex_array _locks_1;
+        stdgpu::mutex_array _locks_2;
 };
 
 
@@ -144,21 +148,23 @@ equal(const stdgpu::mutex_array& locks_1,
 }
 
 
-struct lock_single_functor
+class lock_single_functor
 {
-    stdgpu::mutex_array locks;
+    public:
+        lock_single_functor(stdgpu::mutex_array locks)
+            : _locks(locks)
+        {
 
-    lock_single_functor(stdgpu::mutex_array locks)
-        : locks(locks)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY bool
+        operator()(const stdgpu::index_t i)
+        {
+            return _locks[i].try_lock();
+        }
 
-    STDGPU_DEVICE_ONLY bool
-    operator()(const stdgpu::index_t i)
-    {
-        return locks[i].try_lock();
-    }
+    private:
+        stdgpu::mutex_array _locks;
 };
 
 
@@ -203,21 +209,23 @@ TEST_F(stdgpu_mutex, single_try_lock_while_locked)
 }
 
 
-struct lock_multiple_functor
+class lock_multiple_functor
 {
-    stdgpu::mutex_array locks;
+    public:
+        lock_multiple_functor(stdgpu::mutex_array locks)
+            : _locks(locks)
+        {
 
-    lock_multiple_functor(stdgpu::mutex_array locks)
-        : locks(locks)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY int
+        operator()(const thrust::tuple<stdgpu::index_t, stdgpu::index_t> i)
+        {
+            return stdgpu::try_lock(_locks[thrust::get<0>(i)], _locks[thrust::get<1>(i)]);
+        }
 
-    STDGPU_DEVICE_ONLY int
-    operator()(const thrust::tuple<stdgpu::index_t, stdgpu::index_t> i)
-    {
-        return stdgpu::try_lock(locks[thrust::get<0>(i)], locks[thrust::get<1>(i)]);
-    }
+    private:
+        stdgpu::mutex_array _locks;
 };
 
 int
@@ -334,23 +342,25 @@ TEST_F(stdgpu_mutex, multiple_try_lock_both_locked)
 }
 
 
-struct lock_multiple_functor_new_reference
+class lock_multiple_functor_new_reference
 {
-    stdgpu::mutex_array locks;
+    public:
+        lock_multiple_functor_new_reference(stdgpu::mutex_array locks)
+            : _locks(locks)
+        {
 
-    lock_multiple_functor_new_reference(stdgpu::mutex_array locks)
-        : locks(locks)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY int
+        operator()(const thrust::tuple<stdgpu::index_t, stdgpu::index_t> i)
+        {
+            stdgpu::mutex_array::reference ref_0 = static_cast<stdgpu::mutex_array::reference>(_locks[thrust::get<0>(i)]);
+            stdgpu::mutex_array::reference ref_1 = static_cast<stdgpu::mutex_array::reference>(_locks[thrust::get<1>(i)]);
+            return stdgpu::try_lock(ref_0, ref_1);
+        }
 
-    STDGPU_DEVICE_ONLY int
-    operator()(const thrust::tuple<stdgpu::index_t, stdgpu::index_t> i)
-    {
-        stdgpu::mutex_array::reference ref_0 = static_cast<stdgpu::mutex_array::reference>(locks[thrust::get<0>(i)]);
-        stdgpu::mutex_array::reference ref_1 = static_cast<stdgpu::mutex_array::reference>(locks[thrust::get<1>(i)]);
-        return stdgpu::try_lock(ref_0, ref_1);
-    }
+    private:
+        stdgpu::mutex_array _locks;
 };
 
 int
@@ -374,22 +384,24 @@ lock_multiple_new_reference(const stdgpu::mutex_array locks,
 }
 
 
-struct lock_single_functor_new_reference
+class lock_single_functor_new_reference
 {
-    stdgpu::mutex_array locks;
+    public:
+        lock_single_functor_new_reference(stdgpu::mutex_array locks)
+            : _locks(locks)
+        {
 
-    lock_single_functor_new_reference(stdgpu::mutex_array locks)
-        : locks(locks)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY bool
+        operator()(const stdgpu::index_t i)
+        {
+            stdgpu::mutex_array::reference ref = static_cast<stdgpu::mutex_array::reference>(_locks[i]);
+            return ref.try_lock();
+        }
 
-    STDGPU_DEVICE_ONLY bool
-    operator()(const stdgpu::index_t i)
-    {
-        stdgpu::mutex_array::reference ref = static_cast<stdgpu::mutex_array::reference>(locks[i]);
-        return ref.try_lock();
-    }
+    private:
+        stdgpu::mutex_array _locks;
 };
 
 bool

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -106,49 +106,53 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, hash_inside_range)
 
 namespace
 {
-    struct random_key
+    class random_key
     {
-        stdgpu::index_t seed;
+        public:
+            STDGPU_HOST_DEVICE
+            random_key(const stdgpu::index_t seed)
+                : _seed(seed)
+            {
 
-        STDGPU_HOST_DEVICE
-        random_key(const stdgpu::index_t seed)
-            : seed(seed)
-        {
+            }
 
-        }
+            STDGPU_HOST_DEVICE test_unordered_datastructure::key_type
+            operator()(const stdgpu::index_t n) const
+            {
+                thrust::default_random_engine rng(_seed);
+                thrust::uniform_real_distribution<std::int16_t> dist(stdgpu::numeric_limits<std::int16_t>::min(), stdgpu::numeric_limits<std::int16_t>::max());
+                rng.discard(3 * n);
 
-        STDGPU_HOST_DEVICE test_unordered_datastructure::key_type
-        operator()(const stdgpu::index_t n) const
-        {
-            thrust::default_random_engine rng(seed);
-            thrust::uniform_real_distribution<std::int16_t> dist(stdgpu::numeric_limits<std::int16_t>::min(), stdgpu::numeric_limits<std::int16_t>::max());
-            rng.discard(3 * n);
+                return test_unordered_datastructure::key_type(dist(rng), dist(rng), dist(rng));
+            }
 
-            return test_unordered_datastructure::key_type(dist(rng), dist(rng), dist(rng));
-        }
+        private:
+            stdgpu::index_t _seed;
     };
 
 
-    struct count_buckets_hits
+    class count_buckets_hits
     {
-        test_unordered_datastructure hash_datastructure;
-        int* bucket_hits;
+        public:
+            count_buckets_hits(test_unordered_datastructure hash_datastructure,
+                               int* bucket_hits)
+                : _hash_datastructure(hash_datastructure),
+                  _bucket_hits(bucket_hits)
+            {
 
-        count_buckets_hits(test_unordered_datastructure hash_datastructure,
-                           int* bucket_hits)
-            : hash_datastructure(hash_datastructure),
-              bucket_hits(bucket_hits)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const test_unordered_datastructure::key_type key)
+            {
+                stdgpu::index_t bucket = _hash_datastructure.bucket(key);
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const test_unordered_datastructure::key_type key)
-        {
-            stdgpu::index_t bucket = hash_datastructure.bucket(key);
+                stdgpu::atomic_ref<int>(_bucket_hits[bucket]).fetch_add(1);
+            }
 
-            stdgpu::atomic_ref<int>(bucket_hits[bucket]).fetch_add(1);
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            int* _bucket_hits;
     };
 
 
@@ -224,29 +228,31 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, hash_objects)
 
 namespace
 {
-    struct insert_single
+    class insert_single
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::key_type key;
-        stdgpu::index_t* inserted;
+        public:
+            insert_single(test_unordered_datastructure hash_datastructure,
+                          test_unordered_datastructure::key_type key,
+                          stdgpu::index_t* inserted)
+                : _hash_datastructure(hash_datastructure),
+                  _key(key),
+                  _inserted(inserted)
+            {
 
-        insert_single(test_unordered_datastructure hash_datastructure,
-                      test_unordered_datastructure::key_type key,
-                      stdgpu::index_t* inserted)
-            : hash_datastructure(hash_datastructure),
-              key(key),
-              inserted(inserted)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                thrust::pair<test_unordered_datastructure::iterator, bool> success = _hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(_key));
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            thrust::pair<test_unordered_datastructure::iterator, bool> success = hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(key));
+                *_inserted = success.second ? 1 : 0;
+            }
 
-            *inserted = success.second ? 1 : 0;
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type _key;
+            stdgpu::index_t* _inserted;
     };
 
 
@@ -268,27 +274,29 @@ namespace
     }
 
 
-    struct erase_single
+    class erase_single
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::key_type key;
-        stdgpu::index_t* erased;
+        public:
+            erase_single(test_unordered_datastructure hash_datastructure,
+                         test_unordered_datastructure::key_type key,
+                         stdgpu::index_t* erased)
+                : _hash_datastructure(hash_datastructure),
+                  _key(key),
+                  _erased(erased)
+            {
 
-        erase_single(test_unordered_datastructure hash_datastructure,
-                     test_unordered_datastructure::key_type key,
-                     stdgpu::index_t* erased)
-            : hash_datastructure(hash_datastructure),
-              key(key),
-              erased(erased)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_erased = _hash_datastructure.erase(_key);
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *erased = hash_datastructure.erase(key);
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type _key;
+            stdgpu::index_t* _erased;
     };
 
 
@@ -310,27 +318,29 @@ namespace
     }
 
 
-    struct contains_key_functor
+    class contains_key_functor
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::key_type key;
-        stdgpu::index_t* contained;
+        public:
+            contains_key_functor(test_unordered_datastructure hash_datastructure,
+                                 test_unordered_datastructure::key_type key,
+                                 stdgpu::index_t* contained)
+                : _hash_datastructure(hash_datastructure),
+                  _key(key),
+                  _contained(contained)
+            {
 
-        contains_key_functor(test_unordered_datastructure hash_datastructure,
-                             test_unordered_datastructure::key_type key,
-                             stdgpu::index_t* contained)
-            : hash_datastructure(hash_datastructure),
-              key(key),
-              contained(contained)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_contained = _hash_datastructure.contains(_key) ? 1 : 0;
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *contained = hash_datastructure.contains(key) ? 1 : 0;
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type _key;
+            stdgpu::index_t* _contained;
     };
 
 
@@ -352,51 +362,55 @@ namespace
     }
 
 
-    struct non_const_find_key_functor
+    class non_const_find_key_functor
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::key_type key;
-        test_unordered_datastructure::iterator* result;
+        public:
+            non_const_find_key_functor(const test_unordered_datastructure& hash_datastructure,
+                                       const test_unordered_datastructure::key_type& key,
+                                       test_unordered_datastructure::iterator* result)
+                : _hash_datastructure(hash_datastructure),
+                  _key(key),
+                  _result(result)
+            {
 
-        non_const_find_key_functor(const test_unordered_datastructure& hash_datastructure,
-                                   const test_unordered_datastructure::key_type& key,
-                                   test_unordered_datastructure::iterator* result)
-            : hash_datastructure(hash_datastructure),
-              key(key),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _hash_datastructure.find(_key);
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = hash_datastructure.find(key);
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type _key;
+            test_unordered_datastructure::iterator* _result;
     };
 
 
-    struct const_find_key_functor
+    class const_find_key_functor
     {
-        const test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::key_type key;
-        test_unordered_datastructure::const_iterator* result;
+        public:
+            const_find_key_functor(const test_unordered_datastructure& hash_datastructure,
+                                   const test_unordered_datastructure::key_type& key,
+                                   test_unordered_datastructure::const_iterator* result)
+                : _hash_datastructure(hash_datastructure),
+                  _key(key),
+                  _result(result)
+            {
 
-        const_find_key_functor(const test_unordered_datastructure& hash_datastructure,
-                               const test_unordered_datastructure::key_type& key,
-                               test_unordered_datastructure::const_iterator* result)
-            : hash_datastructure(hash_datastructure),
-              key(key),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _hash_datastructure.find(_key);
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = hash_datastructure.find(key);
-        }
+        private:
+            const test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type _key;
+            test_unordered_datastructure::const_iterator* _result;
     };
 
 
@@ -449,66 +463,72 @@ namespace
     }
 
 
-    struct non_const_begin_iterator_functor
+    class non_const_begin_iterator_functor
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::iterator* result;
+        public:
+            non_const_begin_iterator_functor(const test_unordered_datastructure& hash_datastructure,
+                                             test_unordered_datastructure::iterator* result)
+                : _hash_datastructure(hash_datastructure),
+                  _result(result)
+            {
 
-        non_const_begin_iterator_functor(const test_unordered_datastructure& hash_datastructure,
-                                         test_unordered_datastructure::iterator* result)
-            : hash_datastructure(hash_datastructure),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _hash_datastructure.begin();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = hash_datastructure.begin();
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::iterator* _result;
     };
 
 
-    struct const_begin_iterator_functor
+    class const_begin_iterator_functor
     {
-        const test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::const_iterator* result;
+        public:
+            const_begin_iterator_functor(const test_unordered_datastructure& hash_datastructure,
+                                         test_unordered_datastructure::const_iterator* result)
+                : _hash_datastructure(hash_datastructure),
+                  _result(result)
+            {
 
-        const_begin_iterator_functor(const test_unordered_datastructure& hash_datastructure,
-                                     test_unordered_datastructure::const_iterator* result)
-            : hash_datastructure(hash_datastructure),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _hash_datastructure.begin();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = hash_datastructure.begin();
-        }
+        private:
+            const test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::const_iterator* _result;
     };
 
 
-    struct cbegin_iterator_functor
+    class cbegin_iterator_functor
     {
-        const test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::const_iterator* result;
+        public:
+            cbegin_iterator_functor(const test_unordered_datastructure& hash_datastructure,
+                                    test_unordered_datastructure::const_iterator* result)
+                : _hash_datastructure(hash_datastructure),
+                  _result(result)
+            {
 
-        cbegin_iterator_functor(const test_unordered_datastructure& hash_datastructure,
-                                test_unordered_datastructure::const_iterator* result)
-            : hash_datastructure(hash_datastructure),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _hash_datastructure.cbegin();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = hash_datastructure.cbegin();
-        }
+        private:
+            const test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::const_iterator* _result;
     };
 
 
@@ -577,66 +597,72 @@ namespace
     }
 
 
-    struct non_const_end_iterator_functor
+    class non_const_end_iterator_functor
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::iterator* result;
+        public:
+            non_const_end_iterator_functor(const test_unordered_datastructure& hash_datastructure,
+                                           test_unordered_datastructure::iterator* result)
+                : _hash_datastructure(hash_datastructure),
+                  _result(result)
+            {
 
-        non_const_end_iterator_functor(const test_unordered_datastructure& hash_datastructure,
-                                       test_unordered_datastructure::iterator* result)
-            : hash_datastructure(hash_datastructure),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _hash_datastructure.end();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = hash_datastructure.end();
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::iterator* _result;
     };
 
 
-    struct const_end_iterator_functor
+    class const_end_iterator_functor
     {
-        const test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::const_iterator* result;
+        public:
+            const_end_iterator_functor(const test_unordered_datastructure& hash_datastructure,
+                                       test_unordered_datastructure::const_iterator* result)
+                : _hash_datastructure(hash_datastructure),
+                  _result(result)
+            {
 
-        const_end_iterator_functor(const test_unordered_datastructure& hash_datastructure,
-                                   test_unordered_datastructure::const_iterator* result)
-            : hash_datastructure(hash_datastructure),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _hash_datastructure.end();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = hash_datastructure.end();
-        }
+        private:
+            const test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::const_iterator* _result;
     };
 
 
-    struct cend_iterator_functor
+    class cend_iterator_functor
     {
-        const test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::const_iterator* result;
+        public:
+            cend_iterator_functor(const test_unordered_datastructure& hash_datastructure,
+                                  test_unordered_datastructure::const_iterator* result)
+                : _hash_datastructure(hash_datastructure),
+                  _result(result)
+            {
 
-        cend_iterator_functor(const test_unordered_datastructure& hash_datastructure,
-                              test_unordered_datastructure::const_iterator* result)
-            : hash_datastructure(hash_datastructure),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _hash_datastructure.cend();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = hash_datastructure.cend();
-        }
+        private:
+            const test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::const_iterator* _result;
     };
 
 
@@ -999,55 +1025,60 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_double)
 
 namespace
 {
-    struct insert_multiple
+    class insert_multiple
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::key_type key;
-        stdgpu::index_t* inserted;
+        public:
+            insert_multiple(test_unordered_datastructure hash_datastructure,
+                            test_unordered_datastructure::key_type key,
+                            stdgpu::index_t* inserted)
+                : _hash_datastructure(hash_datastructure),
+                  _key(key),
+                  _inserted(inserted)
+            {
 
-        insert_multiple(test_unordered_datastructure hash_datastructure,
-                        test_unordered_datastructure::key_type key,
-                        stdgpu::index_t* inserted)
-            : hash_datastructure(hash_datastructure),
-              key(key),
-              inserted(inserted)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                thrust::pair<test_unordered_datastructure::iterator, bool> success = _hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(_key));
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            thrust::pair<test_unordered_datastructure::iterator, bool> success = hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(key));
+                _inserted[i] = success.second ? 1 : 0;
+            }
 
-            inserted[i] = success.second ? 1 : 0;
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type _key;
+            stdgpu::index_t* _inserted;
+
     };
 
 
-    struct erase_multiple
+    class erase_multiple
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::key_type key;
-        stdgpu::index_t* erased;
+        public:
+            erase_multiple(test_unordered_datastructure hash_datastructure,
+                           test_unordered_datastructure::key_type key,
+                           stdgpu::index_t* erased)
+                : _hash_datastructure(hash_datastructure),
+                  _key(key),
+                  _erased(erased)
+            {
 
-        erase_multiple(test_unordered_datastructure hash_datastructure,
-                       test_unordered_datastructure::key_type key,
-                       stdgpu::index_t* erased)
-            : hash_datastructure(hash_datastructure),
-              key(key),
-              erased(erased)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                bool success = static_cast<bool>(_hash_datastructure.erase(_key));
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            bool success = static_cast<bool>(hash_datastructure.erase(key));
+                _erased[i] = success ? 1 : 0;
+            }
 
-            erased[i] = success ? 1 : 0;
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type _key;
+            stdgpu::index_t* _erased;
     };
 
 
@@ -1306,81 +1337,87 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_while_excess_empty)
 
 namespace
 {
-    struct insert_keys
+    class insert_keys
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::key_type* keys;
-        stdgpu::index_t* inserted;
+        public:
+            insert_keys(test_unordered_datastructure hash_datastructure,
+                        test_unordered_datastructure::key_type* keys,
+                        stdgpu::index_t* inserted)
+                : _hash_datastructure(hash_datastructure),
+                  _keys(keys),
+                  _inserted(inserted)
+            {
 
-        insert_keys(test_unordered_datastructure hash_datastructure,
-                    test_unordered_datastructure::key_type* keys,
-                    stdgpu::index_t* inserted)
-            : hash_datastructure(hash_datastructure),
-              keys(keys),
-              inserted(inserted)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                thrust::pair<test_unordered_datastructure::iterator, bool> success = _hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(_keys[i]));
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            thrust::pair<test_unordered_datastructure::iterator, bool> success = hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(keys[i]));
+                _inserted[i] = success.second ? 1 : 0;
+            }
 
-            inserted[i] = success.second ? 1 : 0;
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type* _keys;
+            stdgpu::index_t* _inserted;
     };
 
 
-    struct emplace_keys
+    class emplace_keys
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::key_type* keys;
-        stdgpu::index_t* inserted;
+        public:
+            emplace_keys(test_unordered_datastructure hash_datastructure,
+                         test_unordered_datastructure::key_type* keys,
+                         stdgpu::index_t* inserted)
+                : _hash_datastructure(hash_datastructure),
+                  _keys(keys),
+                  _inserted(inserted)
+            {
 
-        emplace_keys(test_unordered_datastructure hash_datastructure,
-                     test_unordered_datastructure::key_type* keys,
-                     stdgpu::index_t* inserted)
-            : hash_datastructure(hash_datastructure),
-              keys(keys),
-              inserted(inserted)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                thrust::pair<test_unordered_datastructure::iterator, bool> success = _hash_datastructure.emplace(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(_keys[i]));
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            thrust::pair<test_unordered_datastructure::iterator, bool> success = hash_datastructure.emplace(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(keys[i]));
+                _inserted[i] = success.second ? 1 : 0;
+            }
 
-            inserted[i] = success.second ? 1 : 0;
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type* _keys;
+            stdgpu::index_t* _inserted;
     };
 
 
-    struct erase_keys
+    class erase_keys
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::key_type* keys;
-        stdgpu::index_t* erased;
+        public:
+            erase_keys(test_unordered_datastructure hash_datastructure,
+                       test_unordered_datastructure::key_type* keys,
+                       stdgpu::index_t* erased)
+                : _hash_datastructure(hash_datastructure),
+                  _keys(keys),
+                  _erased(erased)
+            {
 
-        erase_keys(test_unordered_datastructure hash_datastructure,
-                   test_unordered_datastructure::key_type* keys,
-                   stdgpu::index_t* erased)
-            : hash_datastructure(hash_datastructure),
-              keys(keys),
-              erased(erased)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                bool success = static_cast<bool>(_hash_datastructure.erase(_keys[i]));
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            bool success = static_cast<bool>(hash_datastructure.erase(keys[i]));
+                _erased[i] = success ? 1 : 0;
+            }
 
-            erased[i] = success ? 1 : 0;
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type* _keys;
+            stdgpu::index_t* _erased;
     };
 }
 
@@ -1685,30 +1722,32 @@ namespace
         destroyDeviceArray<stdgpu::index_t>(erased);
     }
 
-    struct Key2ValueFunctor
+    class Key2ValueFunctor
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::key_type* keys;
-        test_unordered_datastructure::value_type* values;
+        public:
+            Key2ValueFunctor(const test_unordered_datastructure& hash_datastructure,
+                             test_unordered_datastructure::key_type* keys,
+                             test_unordered_datastructure::value_type* values)
+                : _hash_datastructure(hash_datastructure),
+                  _keys(keys),
+                  _values(values)
+            {
 
-        Key2ValueFunctor(const test_unordered_datastructure& hash_datastructure,
-                         test_unordered_datastructure::key_type* keys,
-                         test_unordered_datastructure::value_type* values)
-            : hash_datastructure(hash_datastructure),
-              keys(keys),
-              values(values)
-        {
+            }
 
-        }
+            STDGPU_HOST_DEVICE void
+            operator()(const stdgpu::index_t i)
+            {
+                test_unordered_datastructure::allocator_type a = _hash_datastructure.get_allocator();
+                stdgpu::allocator_traits<test_unordered_datastructure::allocator_type>::construct(a,
+                                                                                                  &(_values[i]),
+                                                                                                  STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(_keys[i]));
+            }
 
-        STDGPU_HOST_DEVICE void
-        operator()(const stdgpu::index_t i)
-        {
-            test_unordered_datastructure::allocator_type a = hash_datastructure.get_allocator();
-            stdgpu::allocator_traits<test_unordered_datastructure::allocator_type>::construct(a,
-                                                                                              &(values[i]),
-                                                                                              STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(keys[i]));
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type* _keys;
+            test_unordered_datastructure::value_type* _values;
     };
 }
 
@@ -1867,36 +1906,38 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_const_range_unique_paral
 
 namespace
 {
-    struct insert_and_erase_keys
+    class insert_and_erase_keys
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::key_type* keys;
-        stdgpu::index_t* inserted;
-        stdgpu::index_t* erased;
+        public:
+            insert_and_erase_keys(test_unordered_datastructure hash_datastructure,
+                                  test_unordered_datastructure::key_type* keys,
+                                  stdgpu::index_t* inserted,
+                                  stdgpu::index_t* erased)
+                : _hash_datastructure(hash_datastructure),
+                  _keys(keys),
+                  _inserted(inserted),
+                  _erased(erased)
+            {
 
-        insert_and_erase_keys(test_unordered_datastructure hash_datastructure,
-                              test_unordered_datastructure::key_type* keys,
-                              stdgpu::index_t* inserted,
-                              stdgpu::index_t* erased)
-            : hash_datastructure(hash_datastructure),
-              keys(keys),
-              inserted(inserted),
-              erased(erased)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                thrust::pair<test_unordered_datastructure::iterator, bool> success_insert = _hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(_keys[i]));
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            thrust::pair<test_unordered_datastructure::iterator, bool> success_insert = hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(keys[i]));
+                _inserted[i] = success_insert.second ? 1 : 0;
 
-            inserted[i] = success_insert.second ? 1 : 0;
+                bool success_erase = static_cast<bool>(_hash_datastructure.erase(_keys[i]));
 
-            bool success_erase = static_cast<bool>(hash_datastructure.erase(keys[i]));
+                _erased[i] = success_erase ? 1 : 0;
+            }
 
-            erased[i] = success_erase ? 1 : 0;
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type* _keys;
+            stdgpu::index_t* _inserted;
+            stdgpu::index_t* _erased;
     };
 }
 
@@ -1935,48 +1976,52 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_and_erase_unique_parall
 
 namespace
 {
-    struct store_bucket_sizes
+    class store_bucket_sizes
     {
-        test_unordered_datastructure hash_datastructure;
-        stdgpu::index_t* bucket_sizes;
+        public:
+            store_bucket_sizes(test_unordered_datastructure hash_datastructure,
+                               stdgpu::index_t* bucket_sizes)
+                : _hash_datastructure(hash_datastructure),
+                  _bucket_sizes(bucket_sizes)
+            {
 
-        store_bucket_sizes(test_unordered_datastructure hash_datastructure,
-                           stdgpu::index_t* bucket_sizes)
-            : hash_datastructure(hash_datastructure),
-              bucket_sizes(bucket_sizes)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                _bucket_sizes[i] = _hash_datastructure.bucket_size(i);
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            bucket_sizes[i] = hash_datastructure.bucket_size(i);
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            stdgpu::index_t* _bucket_sizes;
     };
 
 
-    struct store_counts
+    class store_counts
     {
-        test_unordered_datastructure hash_datastructure;
-        test_unordered_datastructure::key_type* keys;
-        stdgpu::index_t* counts;
+        public:
+            store_counts(test_unordered_datastructure hash_datastructure,
+                         test_unordered_datastructure::key_type* keys,
+                         stdgpu::index_t* counts)
+                : _hash_datastructure(hash_datastructure),
+                  _keys(keys),
+                  _counts(counts)
+            {
 
-        store_counts(test_unordered_datastructure hash_datastructure,
-                     test_unordered_datastructure::key_type* keys,
-                     stdgpu::index_t* counts)
-            : hash_datastructure(hash_datastructure),
-              keys(keys),
-              counts(counts)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                _counts[i] = _hash_datastructure.count(_keys[i]);
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            counts[i] = hash_datastructure.count(keys[i]);
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type* _keys;
+            stdgpu::index_t* _counts;
     };
 }
 
@@ -2033,32 +2078,34 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, count_sum)
 
 namespace
 {
-    struct for_each_counter
+    class for_each_counter
     {
-        stdgpu::atomic<unsigned int> counter;
-        stdgpu::atomic<unsigned int> bad_counter;
-        test_unordered_datastructure hash_datastructure;
-
-        for_each_counter(stdgpu::atomic<unsigned int> counter,
-                         stdgpu::atomic<unsigned int> bad_counter,
-                        const test_unordered_datastructure& hash_datastructure)
-            : counter(counter),
-              bad_counter(bad_counter),
-              hash_datastructure(hash_datastructure)
-        {
-
-        }
-
-        STDGPU_DEVICE_ONLY void
-        operator()(const test_unordered_datastructure::value_type& value)
-        {
-            if (!hash_datastructure.contains(STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(value)))
+        public:
+            for_each_counter(stdgpu::atomic<unsigned int> counter,
+                             stdgpu::atomic<unsigned int> bad_counter,
+                             const test_unordered_datastructure& hash_datastructure)
+                : _counter(counter),
+                  _bad_counter(bad_counter),
+                  _hash_datastructure(hash_datastructure)
             {
-                ++bad_counter;
+
             }
 
-            ++counter;
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const test_unordered_datastructure::value_type& value)
+            {
+                if (!_hash_datastructure.contains(STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(value)))
+                {
+                    ++_bad_counter;
+                }
+
+                ++_counter;
+            }
+
+        private:
+            stdgpu::atomic<unsigned int> _counter;
+            stdgpu::atomic<unsigned int> _bad_counter;
+            test_unordered_datastructure _hash_datastructure;
     };
 }
 
@@ -2089,21 +2136,23 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_count)
 
 namespace
 {
-    struct insert_vector
+    class insert_vector
     {
-        stdgpu::vector<test_unordered_datastructure::key_type> keys;
+        public:
+            insert_vector(stdgpu::vector<test_unordered_datastructure::key_type> keys)
+                : _keys(keys)
+            {
 
-        insert_vector(stdgpu::vector<test_unordered_datastructure::key_type> keys)
-            : keys(keys)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const test_unordered_datastructure::value_type& value)
+            {
+                _keys.push_back(STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(value));
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const test_unordered_datastructure::value_type& value)
-        {
-            keys.push_back(STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(value));
-        }
+        private:
+            stdgpu::vector<test_unordered_datastructure::key_type> _keys;
     };
 }
 
@@ -2142,21 +2191,23 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_keys_same)
 
 namespace
 {
-    struct erase_hash
+    class erase_hash
     {
-        test_unordered_datastructure hash_datastructure;
+        public:
+            erase_hash(test_unordered_datastructure hash_datastructure)
+                : _hash_datastructure(hash_datastructure)
+            {
 
-        erase_hash(test_unordered_datastructure hash_datastructure)
-            : hash_datastructure(hash_datastructure)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const test_unordered_datastructure::value_type& value)
+            {
+                _hash_datastructure.erase(STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(value));
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const test_unordered_datastructure::value_type& value)
-        {
-            hash_datastructure.erase(STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(value));
-        }
+        private:
+            test_unordered_datastructure _hash_datastructure;
     };
 }
 

--- a/test/stdgpu/unordered_map.inc
+++ b/test/stdgpu/unordered_map.inc
@@ -49,12 +49,12 @@ struct vec3int16
     vec3int16() = default;
 
     STDGPU_HOST_DEVICE
-    vec3int16(const std::int16_t x,
-              const std::int16_t y,
-              const std::int16_t z)
-        : x(x),
-          y(y),
-          z(z)
+    vec3int16(const std::int16_t new_x,
+              const std::int16_t new_y,
+              const std::int16_t new_z)
+        : x(new_x),
+          y(new_y),
+          z(new_z)
     {
 
     }

--- a/test/stdgpu/unordered_set.inc
+++ b/test/stdgpu/unordered_set.inc
@@ -43,12 +43,12 @@ struct vec3int16
     vec3int16() = default;
 
     STDGPU_HOST_DEVICE
-    vec3int16(const std::int16_t x,
-              const std::int16_t y,
-              const std::int16_t z)
-        : x(x),
-          y(y),
-          z(z)
+    vec3int16(const std::int16_t new_x,
+              const std::int16_t new_y,
+              const std::int16_t new_z)
+        : x(new_x),
+          y(new_y),
+          z(new_z)
     {
 
     }

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -62,119 +62,131 @@ vector<int>::emplace_back<int>(int&&);
 
 
 template <typename T>
-struct pop_back_vector
+class pop_back_vector
 {
-    stdgpu::vector<T> pool;
+    public:
+        pop_back_vector(stdgpu::vector<T> pool)
+            : _pool(pool)
+        {
 
-    pop_back_vector(stdgpu::vector<T> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(STDGPU_MAYBE_UNUSED const T x)
+        {
+            _pool.pop_back();
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(STDGPU_MAYBE_UNUSED const T x)
-    {
-        pool.pop_back();
-    }
+    private:
+        stdgpu::vector<T> _pool;
 };
 
 template <typename Pair>
-struct pop_back_vector_const_type
+class pop_back_vector_const_type
 {
-    stdgpu::vector<Pair> pool;
+    public:
+        pop_back_vector_const_type(stdgpu::vector<Pair> pool)
+            : _pool(pool)
+        {
 
-    pop_back_vector_const_type(stdgpu::vector<Pair> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        inline STDGPU_HOST_DEVICE void
+        operator()(STDGPU_MAYBE_UNUSED const typename Pair::first_type& first)
+        {
+            _pool.pop_back();
+        }
 
-    inline STDGPU_HOST_DEVICE void
-    operator()(STDGPU_MAYBE_UNUSED const typename Pair::first_type& first)
-    {
-        pool.pop_back();
-    }
+    private:
+        stdgpu::vector<Pair> _pool;
 };
 
 
 template <typename T>
-struct push_back_vector
+class push_back_vector
 {
-    stdgpu::vector<T> pool;
+    public:
+        push_back_vector(stdgpu::vector<T> pool)
+            : _pool(pool)
+        {
 
-    push_back_vector(stdgpu::vector<T> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _pool.push_back(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        pool.push_back(x);
-    }
+    private:
+        stdgpu::vector<T> _pool;
 };
 
 template <typename Pair>
-struct push_back_vector_const_type
+class push_back_vector_const_type
 {
-    stdgpu::vector<Pair> pool;
-    typename Pair::second_type second;
+    public:
+        push_back_vector_const_type(stdgpu::vector<Pair> pool,
+                                    const typename Pair::second_type& second)
+            : _pool(pool),
+              _second(second)
+        {
 
-    push_back_vector_const_type(stdgpu::vector<Pair> pool,
-                                const typename Pair::second_type& second)
-        : pool(pool),
-          second(second)
-    {
+        }
 
-    }
+        inline STDGPU_HOST_DEVICE void
+        operator()(const typename Pair::first_type& first)
+        {
+            _pool.push_back(thrust::make_pair(first, _second));
+        }
 
-    inline STDGPU_HOST_DEVICE void
-    operator()(const typename Pair::first_type& first)
-    {
-        pool.push_back(thrust::make_pair(first, second));
-    }
+    private:
+        stdgpu::vector<Pair> _pool;
+        typename Pair::second_type _second;
 };
 
 
 template <typename T>
-struct emplace_back_vector
+class emplace_back_vector
 {
-    stdgpu::vector<T> pool;
+    public:
+        emplace_back_vector(stdgpu::vector<T> pool)
+            : _pool(pool)
+        {
 
-    emplace_back_vector(stdgpu::vector<T> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _pool.emplace_back(x);
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        pool.emplace_back(x);
-    }
+    private:
+        stdgpu::vector<T> _pool;
 };
 
 template <typename Pair>
-struct emplace_back_vector_const_type
+class emplace_back_vector_const_type
 {
-    stdgpu::vector<Pair> pool;
-    typename Pair::second_type second;
+    public:
+        emplace_back_vector_const_type(stdgpu::vector<Pair> pool,
+                                       const typename Pair::second_type& second)
+            : _pool(pool),
+              _second(second)
+        {
 
-    emplace_back_vector_const_type(stdgpu::vector<Pair> pool,
-                                   const typename Pair::second_type& second)
-        : pool(pool),
-          second(second)
-    {
+        }
 
-    }
+        inline STDGPU_HOST_DEVICE void
+        operator()(const typename Pair::first_type& first)
+        {
+            _pool.emplace_back(first, _second);
+        }
 
-    inline STDGPU_HOST_DEVICE void
-    operator()(const typename Pair::first_type& first)
-    {
-        pool.emplace_back(first, second);
-    }
+    private:
+        stdgpu::vector<Pair> _pool;
+        typename Pair::second_type _second;
 };
 
 
@@ -201,7 +213,7 @@ class nondefault_int_vector
 
         STDGPU_HOST_DEVICE
         nondefault_int_vector(const int x)
-            : x(x)
+            : _x(x)
         {
 
         }
@@ -209,11 +221,11 @@ class nondefault_int_vector
         STDGPU_HOST_DEVICE
         operator int() const
         {
-            return x;
+            return _x;
         }
 
     private:
-        int x;
+        int _x;
 };
 
 
@@ -698,31 +710,33 @@ TEST_F(stdgpu_vector, clear_nondefault_type)
 
 
 template <typename T>
-struct simultaneous_push_back_and_pop_back_vector
+class simultaneous_push_back_and_pop_back_vector
 {
-    stdgpu::vector<T> pool;
-    stdgpu::vector<T> pool_validation;
-
-    simultaneous_push_back_and_pop_back_vector(stdgpu::vector<T> pool,
-                                               stdgpu::vector<T> pool_validation)
-        : pool(pool),
-          pool_validation(pool_validation)
-    {
-
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const T x)
-    {
-        pool.push_back(x);
-
-        thrust::pair<T, bool> popped = pool.pop_back();
-
-        if (popped.second)
+    public:
+        simultaneous_push_back_and_pop_back_vector(stdgpu::vector<T> pool,
+                                                   stdgpu::vector<T> pool_validation)
+            : _pool(pool),
+              _pool_validation(pool_validation)
         {
-            pool_validation.push_back(popped.first);
+
         }
-    }
+
+        STDGPU_DEVICE_ONLY void
+        operator()(const T x)
+        {
+            _pool.push_back(x);
+
+            thrust::pair<T, bool> popped = _pool.pop_back();
+
+            if (popped.second)
+            {
+                _pool_validation.push_back(popped.first);
+            }
+        }
+
+    private:
+        stdgpu::vector<T> _pool;
+        stdgpu::vector<T> _pool_validation;
 };
 
 TEST_F(stdgpu_vector, simultaneous_push_back_and_pop_back)
@@ -761,21 +775,23 @@ TEST_F(stdgpu_vector, simultaneous_push_back_and_pop_back)
 }
 
 
-struct at_non_const_vector
+class at_non_const_vector
 {
-    stdgpu::vector<int> pool;
+    public:
+        at_non_const_vector(stdgpu::vector<int> pool)
+            : _pool(pool)
+        {
 
-    at_non_const_vector(stdgpu::vector<int> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const int x)
+        {
+            _pool.at(x) = x * x;
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const int x)
-    {
-        pool.at(x) = x * x;
-    }
+    private:
+        stdgpu::vector<int> _pool;
 };
 
 
@@ -801,21 +817,23 @@ TEST_F(stdgpu_vector, at_non_const)
 }
 
 
-struct access_operator_non_const_vector
+class access_operator_non_const_vector
 {
-    stdgpu::vector<int> pool;
+    public:
+        access_operator_non_const_vector(stdgpu::vector<int> pool)
+            : _pool(pool)
+        {
 
-    access_operator_non_const_vector(stdgpu::vector<int> pool)
-        : pool(pool)
-    {
+        }
 
-    }
+        STDGPU_DEVICE_ONLY void
+        operator()(const int x)
+        {
+            _pool[x] = x * x;
+        }
 
-    STDGPU_DEVICE_ONLY void
-    operator()(const int x)
-    {
-        pool[x] = x * x;
-    }
+    private:
+        stdgpu::vector<int> _pool;
 };
 
 
@@ -913,46 +931,50 @@ TEST_F(stdgpu_vector, shrink_to_fit)
 namespace
 {
     template <typename T>
-    struct non_const_front_functor
+    class non_const_front_functor
     {
-        stdgpu::vector<T> pool;
-        T* result;
+        public:
+            non_const_front_functor(const stdgpu::vector<T>& pool,
+                                    T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        non_const_front_functor(const stdgpu::vector<T>& pool,
-                                T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _pool.front();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = pool.front();
-        }
+        private:
+            stdgpu::vector<T> _pool;
+            T* _result;
     };
 
 
     template <typename T>
-    struct const_front_functor
+    class const_front_functor
     {
-        const stdgpu::vector<T> pool;
-        T* result;
+        public:
+            const_front_functor(const stdgpu::vector<T>& pool,
+                                T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        const_front_functor(const stdgpu::vector<T>& pool,
-                            T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _pool.front();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = pool.front();
-        }
+        private:
+            const stdgpu::vector<T> _pool;
+            T* _result;
     };
 
 
@@ -1005,46 +1027,50 @@ namespace
 
 
     template <typename T>
-    struct non_const_back_functor
+    class non_const_back_functor
     {
-        stdgpu::vector<T> pool;
-        T* result;
+        public:
+            non_const_back_functor(const stdgpu::vector<T>& pool,
+                                   T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        non_const_back_functor(const stdgpu::vector<T>& pool,
-                               T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _pool.back();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = pool.back();
-        }
+        private:
+            stdgpu::vector<T> _pool;
+            T* _result;
     };
 
 
     template <typename T>
-    struct const_back_functor
+    class const_back_functor
     {
-        const stdgpu::vector<T> pool;
-        T* result;
+        public:
+            const_back_functor(const stdgpu::vector<T>& pool,
+                               T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        const_back_functor(const stdgpu::vector<T>& pool,
-                           T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _pool.back();
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-        {
-            *result = pool.back();
-        }
+        private:
+            const stdgpu::vector<T> _pool;
+            T* _result;
     };
 
 
@@ -1097,46 +1123,50 @@ namespace
 
 
     template <typename T>
-    struct non_const_operator_access_functor
+    class non_const_operator_access_functor
     {
-        stdgpu::vector<T> pool;
-        T* result;
+        public:
+            non_const_operator_access_functor(const stdgpu::vector<T>& pool,
+                                              T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        non_const_operator_access_functor(const stdgpu::vector<T>& pool,
-                                          T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                *_result = _pool[i];
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            *result = pool[i];
-        }
+        private:
+            stdgpu::vector<T> _pool;
+            T* _result;
     };
 
 
     template <typename T>
-    struct const_operator_access_functor
+    class const_operator_access_functor
     {
-        const stdgpu::vector<T> pool;
-        T* result;
+        public:
+            const_operator_access_functor(const stdgpu::vector<T>& pool,
+                                          T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        const_operator_access_functor(const stdgpu::vector<T>& pool,
-                                      T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                *_result = _pool[i];
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            *result = pool[i];
-        }
+        private:
+            const stdgpu::vector<T> _pool;
+            T* _result;
     };
 
 
@@ -1192,46 +1222,50 @@ namespace
 
 
     template <typename T>
-    struct non_const_at_functor
+    class non_const_at_functor
     {
-        stdgpu::vector<T> pool;
-        T* result;
+        public:
+            non_const_at_functor(const stdgpu::vector<T>& pool,
+                                 T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        non_const_at_functor(const stdgpu::vector<T>& pool,
-                             T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                *_result = _pool.at(i);
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            *result = pool.at(i);
-        }
+        private:
+            stdgpu::vector<T> _pool;
+            T* _result;
     };
 
 
     template <typename T>
-    struct const_at_functor
+    class const_at_functor
     {
-        const stdgpu::vector<T> pool;
-        T* result;
+        public:
+            const_at_functor(const stdgpu::vector<T>& pool,
+                             T* result)
+                : _pool(pool),
+                  _result(result)
+            {
 
-        const_at_functor(const stdgpu::vector<T>& pool,
-                         T* result)
-            : pool(pool),
-              result(result)
-        {
+            }
 
-        }
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                *_result = _pool.at(i);
+            }
 
-        STDGPU_DEVICE_ONLY void
-        operator()(const stdgpu::index_t i)
-        {
-            *result = pool.at(i);
-        }
+        private:
+            const stdgpu::vector<T> _pool;
+            T* _result;
     };
 
 


### PR DESCRIPTION
In order to ensure a high usability and reliability of the library, it should build without warnings even in the presence of strict warning settings which may be imposed by user projects. Consider variable shadowing and fix related warnings. Note that this warning will be disabled by default since older supported thrust versions do not fulfill these stricter settings.