### PR TITLE
General: Fix Clang warnings

### DIFF
--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -52,7 +52,7 @@ namespace detail
 {
 
 template <typename T>
-struct deque_collect_positions;
+class deque_collect_positions;
 
 } // namespace detail
 

--- a/test/stdgpu/bit.cpp
+++ b/test/stdgpu/bit.cpp
@@ -56,6 +56,8 @@ STDGPU_HOST_DEVICE unsigned int
 mod2<unsigned int>(const unsigned int,
                    const unsigned int);
 
+// Instantiation of specialized templates emit no-effect warnings with Clang
+/*
 template
 STDGPU_HOST_DEVICE unsigned int
 log2pow2<unsigned int>(const unsigned int number);
@@ -71,6 +73,7 @@ popcount<unsigned int>(const unsigned int number);
 template
 STDGPU_HOST_DEVICE int
 popcount<unsigned long long int>(const unsigned long long int);
+*/
 
 } // namespace stdgpu
 

--- a/test/stdgpu/functional.cpp
+++ b/test/stdgpu/functional.cpp
@@ -45,59 +45,62 @@ class stdgpu_functional : public ::testing::Test
 namespace stdgpu
 {
 
+// Instantiation of specialized templates emit no-effect warnings with Clang
+/*
 template
-class hash<bool>;
+struct hash<bool>;
 
 template
-class hash<char>;
+struct hash<char>;
 
 template
-class hash<signed char>;
+struct hash<signed char>;
 
 template
-class hash<unsigned char>;
+struct hash<unsigned char>;
 
 template
-class hash<wchar_t>;
+struct hash<wchar_t>;
 
 template
-class hash<char16_t>;
+struct hash<char16_t>;
 
 template
-class hash<char32_t>;
+struct hash<char32_t>;
 
 template
-class hash<short>;
+struct hash<short>;
 
 template
-class hash<unsigned short>;
+struct hash<unsigned short>;
 
 template
-class hash<int>;
+struct hash<int>;
 
 template
-class hash<unsigned int>;
+struct hash<unsigned int>;
 
 template
-class hash<long>;
+struct hash<long>;
 
 template
-class hash<unsigned long>;
+struct hash<unsigned long>;
 
 template
-class hash<long long>;
+struct hash<long long>;
 
 template
-class hash<unsigned long long>;
+struct hash<unsigned long long>;
 
 template
-class hash<float>;
+struct hash<float>;
 
 template
-class hash<double>;
+struct hash<double>;
 
 template
-class hash<long double>;
+struct hash<long double>;
+*/
 
 } // namespace stdgpu
 

--- a/test/stdgpu/limits.cpp
+++ b/test/stdgpu/limits.cpp
@@ -43,59 +43,62 @@ class stdgpu_limits : public ::testing::Test
 namespace stdgpu
 {
 
+// Instantiation of specialized templates emit no-effect warnings with Clang
+/*
 template
-class numeric_limits<bool>;
+struct numeric_limits<bool>;
 
 template
-class numeric_limits<char>;
+struct numeric_limits<char>;
 
 template
-class numeric_limits<signed char>;
+struct numeric_limits<signed char>;
 
 template
-class numeric_limits<unsigned char>;
+struct numeric_limits<unsigned char>;
 
 template
-class numeric_limits<wchar_t>;
+struct numeric_limits<wchar_t>;
 
 template
-class numeric_limits<char16_t>;
+struct numeric_limits<char16_t>;
 
 template
-class numeric_limits<char32_t>;
+struct numeric_limits<char32_t>;
 
 template
-class numeric_limits<short>;
+struct numeric_limits<short>;
 
 template
-class numeric_limits<unsigned short>;
+struct numeric_limits<unsigned short>;
 
 template
-class numeric_limits<int>;
+struct numeric_limits<int>;
 
 template
-class numeric_limits<unsigned int>;
+struct numeric_limits<unsigned int>;
 
 template
-class numeric_limits<long>;
+struct numeric_limits<long>;
 
 template
-class numeric_limits<unsigned long>;
+struct numeric_limits<unsigned long>;
 
 template
-class numeric_limits<long long>;
+struct numeric_limits<long long>;
 
 template
-class numeric_limits<unsigned long long>;
+struct numeric_limits<unsigned long long>;
 
 template
-class numeric_limits<float>;
+struct numeric_limits<float>;
 
 template
-class numeric_limits<double>;
+struct numeric_limits<double>;
 
 template
-class numeric_limits<long double>;
+struct numeric_limits<long double>;
+*/
 
 } // namespace stdgpu
 

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -1348,6 +1348,9 @@ namespace
                 #if STDGPU_CODE == STDGPU_CODE_HOST
                     Counter::constructor_calls++;
                 #endif
+
+                // Suppress unused member warning
+                x = 0;
             }
 
             STDGPU_HOST_DEVICE
@@ -1356,6 +1359,9 @@ namespace
                 #if STDGPU_CODE == STDGPU_CODE_HOST
                     Counter::destructor_calls++;
                 #endif
+
+                // Suppress unused member warning
+                x = 0;
             }
 
         private:

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -154,16 +154,16 @@ namespace stdgpu
 {
 
 template
-class safe_device_allocator<int>;
+struct safe_device_allocator<int>;
 
 template
-class safe_host_allocator<int>;
+struct safe_host_allocator<int>;
 
 template
-class safe_managed_allocator<int>;
+struct safe_managed_allocator<int>;
 
 template
-class allocator_traits<safe_device_allocator<int>>;
+struct allocator_traits<safe_device_allocator<int>>;
 
 template
 STDGPU_HOST_DEVICE void


### PR DESCRIPTION
Some of the recent test coverage improvements result in warnings emitted by the Clang compiler. Although none of them causes potential harm, they still need to be addressed. Fix them to allow for clean Clang builds.