### PR TITLE
cmake: Fix selection of header files for installation

### DIFF
--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -60,6 +60,7 @@ install(DIRECTORY "${STDGPU_CONFIG_BUILD_DIR}/"
 install(DIRECTORY "${STDGPU_INCLUDE_LOCAL_DIR}/"
         DESTINATION ${CMAKE_INSTALL_PREFIX}/${STDGPU_INCLUDE_INSTALL_DIR}
         COMPONENT stdgpu
-        PATTERN "*.cpp" EXCLUDE
-        PATTERN "*.cu" EXCLUDE
-        PATTERN "*.txt" EXCLUDE)
+        FILES_MATCHING
+        PATTERN "*.h"
+        PATTERN "*.cuh"
+        PATTERN "*_fwd")


### PR DESCRIPTION
To install header files, a blacklist approach is currently employed. However, as the internal structure of the project evolved over time, this list should have been updated as well but actually was not. Therefore, some auxiliary and source files will be accidentally installed. Use a whitelist approach which is easier to maintain, especially once #38 has been addressed.