### PR TITLE
memory: Add construct_at function

### DIFF
--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -66,7 +66,7 @@ class construct_value
         STDGPU_HOST_DEVICE void
         operator()(T& t) const
         {
-            ::new (static_cast<void*>(&t)) T(_value);
+            construct_at(&t, _value);
         }
 
     private:
@@ -530,7 +530,7 @@ allocator_traits<Allocator>::construct(STDGPU_MAYBE_UNUSED Allocator& a,
                                        T* p,
                                        Args&&... args)
 {
-    ::new (static_cast<void*>(p)) T(forward<Args>(args)...);
+    construct_at(p, forward<Args>(args)...);
 }
 
 
@@ -557,6 +557,15 @@ Allocator
 allocator_traits<Allocator>::select_on_container_copy_construction(STDGPU_MAYBE_UNUSED const Allocator& a)
 {
     return a;
+}
+
+
+template <typename T, typename... Args>
+STDGPU_HOST_DEVICE T*
+construct_at(T* p,
+             Args&&... args)
+{
+    return ::new (static_cast<void*>(p)) T(forward<Args>(args)...);
 }
 
 
@@ -646,7 +655,7 @@ struct [[deprecated("Replaced by stdgpu::allocator_traits<Allocator>")]] default
     construct(T* p,
               Args&&... args)
     {
-        ::new (static_cast<void*>(p)) T(forward<Args>(args)...);
+        construct_at(p, forward<Args>(args)...);
     }
 
     template <typename T>

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -478,6 +478,20 @@ struct allocator_traits
 /**
  * \brief Destroys the value at the given pointer
  * \tparam T The value type
+ * \tparam Args The argument types
+ * \param[in] p A pointer to the value to construct
+ * \param[in] args The arguments to construct the value
+ * \return A pointer to the constructed value
+ */
+template <typename T, typename... Args>
+STDGPU_HOST_DEVICE T*
+construct_at(T* p,
+             Args&&... args);
+
+
+/**
+ * \brief Destroys the value at the given pointer
+ * \tparam T The value type
  * \param[in] p A pointer to the value to destroy
  */
 template <typename T>

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -176,6 +176,10 @@ allocator_traits<safe_device_allocator<int>>::destroy<int>(safe_device_allocator
                                                            int*);
 
 template
+STDGPU_HOST_DEVICE int*
+construct_at<int>(int*);
+
+template
 STDGPU_HOST_DEVICE void
 destroy_at<int>(int*);
 
@@ -1442,6 +1446,32 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_max_size_and_select)
     Allocator b = stdgpu::allocator_traits<Allocator>::select_on_container_copy_construction(a);
 
     EXPECT_EQ(stdgpu::allocator_traits<Allocator>::max_size(a), stdgpu::allocator_traits<Allocator>::max_size(b));
+}
+
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, construct_at)
+{
+    using Allocator = stdgpu::safe_host_allocator<Counter>;
+    Allocator a;
+
+    stdgpu::index64_t size = 42;
+
+    typename Allocator::value_type* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
+
+    Counter::constructor_calls = 0;
+    Counter::destructor_calls = 0;
+    ASSERT_EQ(Counter::constructor_calls, 0);
+    ASSERT_EQ(Counter::destructor_calls, 0);
+
+    for (stdgpu::index_t i = 0; i < size; ++i)
+    {
+        stdgpu::construct_at(array + i);
+    }
+
+    EXPECT_EQ(Counter::constructor_calls, size);
+    EXPECT_EQ(Counter::destructor_calls, 0);
+
+    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
 }
 
 


### PR DESCRIPTION
Similar to `destroy_at` which got introduced in C++17, we are now getting a `construct_at` function in C++20. Add a respective GPU-callable version of `construct_at` to simplify the implementation of related classes in the `memory` module and extend the support of the latter.