### PR TITLE
General: Increase warning level and fix conversion and float-equal warnings

### DIFF
--- a/cmake/cuda/set_device_flags.cmake
+++ b/cmake/cuda/set_device_flags.cmake
@@ -42,7 +42,11 @@ endif()
 if(NOT MSVC)
     string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wall")
     string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wextra")
-    #string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wshadow") # Currently disabled due to thrust
+    # Currently disabled due to thrust and a bug in CMake (fixed in 3.17)
+    #string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wshadow")
+    #string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wsign-compare")
+    #string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wconversion")
+    #string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wfloat-equal")
 
     if(${CMAKE_BUILD_TYPE} MATCHES "Release" OR ${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
         message(STATUS "Appended optimization flag (-O3,/O2) implicitly")

--- a/cmake/set_host_flags.cmake
+++ b/cmake/set_host_flags.cmake
@@ -3,7 +3,10 @@ if(NOT MSVC)
     string(APPEND STDGPU_HOST_FLAGS " -Wall")
     string(APPEND STDGPU_HOST_FLAGS " -pedantic")
     string(APPEND STDGPU_HOST_FLAGS " -Wextra")
-    #string(APPEND STDGPU_HOST_FLAGS " -Wshadow") # Currently disabled due to thrust
+    string(APPEND STDGPU_HOST_FLAGS " -Wshadow")
+    string(APPEND STDGPU_HOST_FLAGS " -Wsign-compare")
+    string(APPEND STDGPU_HOST_FLAGS " -Wconversion")
+    string(APPEND STDGPU_HOST_FLAGS " -Wfloat-equal")
 
     if(${CMAKE_BUILD_TYPE} MATCHES "Release" OR ${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
         string(APPEND STDGPU_HOST_FLAGS " -O3")

--- a/examples/createAndDestroyDeviceObject.cpp
+++ b/examples/createAndDestroyDeviceObject.cpp
@@ -100,7 +100,7 @@ fill_image(Image image)
     {
         for (stdgpu::index_t j = 0; j < image.height(); ++j)
         {
-            std::uint8_t value = (i * i + j * j) % (1 << 8);
+            std::uint8_t value = static_cast<std::uint8_t>((i * i + j * j) % (1 << 8));
 
             image(i, j) = value;
         }

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -140,7 +140,7 @@ bitset::operator[](const index_t n) const
 
     const sizediv_t positions = sizedivPow2(n, _bits_per_block);
 
-    return reference(_bit_blocks + positions.quot, positions.rem);
+    return reference(_bit_blocks + positions.quot, static_cast<index_t>(positions.rem));
 }
 
 
@@ -152,7 +152,7 @@ bitset::operator[](const index_t n)
 
     const sizediv_t positions = sizedivPow2(n, _bits_per_block);
 
-    return reference(_bit_blocks + positions.quot, positions.rem);
+    return reference(_bit_blocks + positions.quot, static_cast<index_t>(positions.rem));
 }
 
 

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -176,7 +176,7 @@ deque<T>::push_back(const T& element)
     // Check size
     if (current_size < _capacity)
     {
-        unsigned int push_position = _end.fetch_inc_mod(_capacity);
+        unsigned int push_position = _end.fetch_inc_mod(static_cast<unsigned int>(_capacity));
 
         while (!pushed)
         {
@@ -230,8 +230,8 @@ deque<T>::pop_back()
     // Check size
     if (current_size > 0)
     {
-        unsigned int pop_position = _end.fetch_dec_mod(_capacity);
-        pop_position = (pop_position == 0) ? _capacity - 1 : pop_position - 1;  // Manually reconstruct stored value
+        unsigned int pop_position = _end.fetch_dec_mod(static_cast<unsigned int>(_capacity));
+        pop_position = (pop_position == 0) ? static_cast<unsigned int>(_capacity) - 1 : pop_position - 1;  // Manually reconstruct stored value
 
         while (!popped.second)
         {
@@ -293,8 +293,8 @@ deque<T>::push_front(const T& element)
     // Check size
     if (current_size < _capacity)
     {
-        unsigned int push_position = _begin.fetch_dec_mod(_capacity);
-        push_position = (push_position == 0) ? _capacity - 1 : push_position - 1;  // Manually reconstruct stored value
+        unsigned int push_position = _begin.fetch_dec_mod(static_cast<unsigned int>(_capacity));
+        push_position = (push_position == 0) ? static_cast<unsigned int>(_capacity) - 1 : push_position - 1;  // Manually reconstruct stored value
 
         while (!pushed)
         {
@@ -348,7 +348,7 @@ deque<T>::pop_front()
     // Check size
     if (current_size > 0)
     {
-        unsigned int pop_position = _begin.fetch_inc_mod(_capacity);
+        unsigned int pop_position = _begin.fetch_inc_mod(static_cast<unsigned int>(_capacity));
 
         while (!popped.second)
         {

--- a/src/stdgpu/impl/ranges_detail.h
+++ b/src/stdgpu/impl/ranges_detail.h
@@ -23,7 +23,7 @@ namespace stdgpu
 
 template <typename T>
 device_range<T>::device_range(T* p)
-    : device_range(p, stdgpu::size(p))
+    : device_range(p, static_cast<index_t>(stdgpu::size(p)))
 {
 
 }
@@ -69,7 +69,7 @@ host_range<T>::host_range(T* p,
 
 template <typename T>
 host_range<T>::host_range(T* p)
-    : host_range(p, stdgpu::size(p))
+    : host_range(p, static_cast<index_t>(stdgpu::size(p)))
 {
 
 }

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -332,7 +332,7 @@ class values_unique
                 auto block = _base._key_from_value(_base._values[i]);
 
                 auto it = _base.find(block);
-                index_t position = thrust::distance(_base.begin(), it);
+                index_t position = static_cast<index_t>(thrust::distance(_base.begin(), it));
 
                 if (position != i)
                 {
@@ -436,13 +436,13 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::bucket(const key_type&
 {
     #if STDGPU_USE_FIBONACCI_HASHING
         // If bucket_count() == 1, then the result will be shifted by the width of std::size_t which leads to undefined/unreliable behavior
-        std::size_t result = (bucket_count() == 1) ? 0 : (_hash(key) * 11400714819323198485llu) >> (numeric_limits<std::size_t>::digits - log2pow2<std::size_t>(bucket_count()));
+        index_t result = (bucket_count() == 1) ? 0 : static_cast<index_t>((_hash(key) * 11400714819323198485llu) >> (numeric_limits<std::size_t>::digits - log2pow2<std::size_t>(bucket_count())));
     #else
-        std::size_t result = mod2<std::size_t>(_hash(key), bucket_count());
+        index_t result = static_cast<index_t>(mod2<std::size_t>(_hash(key), bucket_count()));
     #endif
 
-    STDGPU_ENSURES(0 <= static_cast<index_t>(result));
-    STDGPU_ENSURES(static_cast<index_t>(result) < bucket_count());
+    STDGPU_ENSURES(0 <= result);
+    STDGPU_ENSURES(result < bucket_count());
     return result;
 }
 
@@ -665,7 +665,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_erase(const unorde
     bool erased = false;
 
     const_iterator it = find(key);
-    index_t position = thrust::distance(cbegin(), it);
+    index_t position = static_cast<index_t>(thrust::distance(cbegin(), it));
 
     bool contains_block = (it != end());
     if (contains_block)
@@ -1038,7 +1038,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::createDeviceObject(con
     STDGPU_EXPECTS(capacity > 0);
 
     // bucket count depends on default max load factor
-    index_t bucket_count = next_pow2(std::ceil(static_cast<float>(capacity) / default_max_load_factor()));
+    index_t bucket_count = next_pow2(static_cast<index_t>(std::ceil(static_cast<float>(capacity) / default_max_load_factor())));
 
     // excess count is estimated by the expected collision count and conservatively lowered since entries falling into regular buckets are already included here
     index_t excess_count = std::max<index_t>(1, expected_collisions(bucket_count, capacity) * 2 / 3);

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -700,7 +700,7 @@ TEST_F(stdgpu_atomic, operator_sub_equals_unsigned_long_long_int)
 template <typename T>
 bool
 bit_set(const T value,
-        const int bit_position)
+        const stdgpu::index_t bit_position)
 {
     return (1 == ( (value >> bit_position) & 1));
 }

--- a/test/stdgpu/cuda/atomic.cu
+++ b/test/stdgpu/cuda/atomic.cu
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <limits>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
@@ -274,7 +275,8 @@ TEST_F(stdgpu_cuda_atomic, float_min)
         EXPECT_LE(*host_min, host_numbers[i]);
 
         // min in numbers
-        if (*host_min == host_numbers[i])
+        // *host_min == host_numbers[i]
+        if (std::abs(*host_min - host_numbers[i]) < std::numeric_limits<float>::min())
         {
             min_found = true;
         }
@@ -324,7 +326,8 @@ TEST_F(stdgpu_cuda_atomic, float_max)
         EXPECT_GE(*host_max, host_numbers[i]);
 
         // max in numbers
-        if (*host_max == host_numbers[i])
+        // *host_max == host_numbers[i]
+        if (std::abs(*host_max - host_numbers[i]) < std::numeric_limits<float>::min())
         {
             max_found = true;
         }

--- a/test/stdgpu/cuda/device_info.cpp
+++ b/test/stdgpu/cuda/device_info.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstddef>
 #include <cuda_runtime_api.h>
 #include <string>
 
@@ -52,10 +53,10 @@ void
 print_device_information()
 {
     cudaDeviceProp properties;
-    cudaGetDeviceProperties( &properties, 0 );
+    cudaGetDeviceProperties(&properties, 0);
 
-    size_t free_memory  = 0;
-    size_t total_memory = 0;
+    std::size_t free_memory  = 0;
+    std::size_t total_memory = 0;
     cudaMemGetInfo(&free_memory, &total_memory);
 
     std::string gpu_name = properties.name;
@@ -67,16 +68,16 @@ print_device_information()
     printf( "+---------------------------------------------------------+\n" );
     printf( "|%*s%*s%*s|\n", gpu_name_space_left, " ", gpu_name_size, gpu_name.c_str(), gpu_name_space_right, " ");
     printf( "+---------------------------------------------------------+\n" );
-    printf( "| Compute Capability        :   %1d.%1d                       |\n", properties.major, properties.minor );
-    printf( "| Clock rate                :   %-6.0f MHz                |\n", detail::kilo_to_mega_hertz(properties.clockRate));
-    printf( "| Global Memory             :   %-6.3f GiB / %-6.3f GiB   |\n", detail::byte_to_gibi_byte(free_memory), detail::byte_to_gibi_byte(total_memory));
-    printf( "| Memory Bus Width          :   %-6d Bit                |\n", properties.memoryBusWidth );
-    printf( "| Multiprocessor (SM) count :   %-6d                    |\n", properties.multiProcessorCount );
-    printf( "| Warp size                 :   %-6d Threads            |\n", properties.warpSize );
-    printf( "| L2 Cache                  :   %-6.0f KiB                |\n", detail::byte_to_kibi_byte(properties.l2CacheSize));
-    printf( "| Total Constant Memory     :   %-6.0f KiB                |\n", detail::byte_to_kibi_byte(properties.totalConstMem));
-    printf( "| Shared Memory per SM      :   %-6.0f KiB                |\n", detail::byte_to_kibi_byte(properties.sharedMemPerMultiprocessor));
-    printf( "| Total Shared Memory       :   %-6.0f KiB                |\n", detail::byte_to_kibi_byte(properties.sharedMemPerMultiprocessor * static_cast<size_t>(properties.multiProcessorCount)));
+    printf( "| Compute Capability        :   %1d.%1d                       |\n", properties.major, properties.minor);
+    printf( "| Clock rate                :   %-6.0f MHz                |\n", detail::kilo_to_mega_hertz(static_cast<float>(properties.clockRate)));
+    printf( "| Global Memory             :   %-6.3f GiB / %-6.3f GiB   |\n", detail::byte_to_gibi_byte(static_cast<float>(free_memory)), detail::byte_to_gibi_byte(static_cast<float>(total_memory)));
+    printf( "| Memory Bus Width          :   %-6d Bit                |\n", properties.memoryBusWidth);
+    printf( "| Multiprocessor (SM) count :   %-6d                    |\n", properties.multiProcessorCount);
+    printf( "| Warp size                 :   %-6d Threads            |\n", properties.warpSize);
+    printf( "| L2 Cache                  :   %-6.0f KiB                |\n", detail::byte_to_kibi_byte(static_cast<float>(properties.l2CacheSize)));
+    printf( "| Total Constant Memory     :   %-6.0f KiB                |\n", detail::byte_to_kibi_byte(static_cast<float>(properties.totalConstMem)));
+    printf( "| Shared Memory per SM      :   %-6.0f KiB                |\n", detail::byte_to_kibi_byte(static_cast<float>(properties.sharedMemPerMultiprocessor)));
+    printf( "| Total Shared Memory       :   %-6.0f KiB                |\n", detail::byte_to_kibi_byte(static_cast<float>(properties.sharedMemPerMultiprocessor * static_cast<std::size_t>(properties.multiProcessorCount))));
     printf( "+---------------------------------------------------------+\n\n" );
 }
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -197,7 +197,7 @@ void
 fill_deque(stdgpu::deque<int> pool)
 {
     const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(pool.capacity() + init),
+    thrust::for_each(thrust::counting_iterator<int>(static_cast<int>(init)), thrust::counting_iterator<int>(static_cast<int>(pool.capacity() + init)),
                      push_back_deque<int>(pool));
 
     thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
@@ -1996,7 +1996,7 @@ namespace
     {
         T* result = createDeviceArray<T>(1);
 
-        thrust::for_each(thrust::counting_iterator<int>(i), thrust::counting_iterator<int>(i + 1),
+        thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i), thrust::counting_iterator<stdgpu::index_t>(i + 1),
                          non_const_operator_access_functor<T>(pool, result));
 
         T host_result;
@@ -2015,7 +2015,7 @@ namespace
     {
         T* result = createDeviceArray<T>(1);
 
-        thrust::for_each(thrust::counting_iterator<int>(i), thrust::counting_iterator<int>(i + 1),
+        thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i), thrust::counting_iterator<stdgpu::index_t>(i + 1),
                          const_operator_access_functor<T>(pool, result));
 
         T host_result;
@@ -2095,7 +2095,7 @@ namespace
     {
         T* result = createDeviceArray<T>(1);
 
-        thrust::for_each(thrust::counting_iterator<int>(i), thrust::counting_iterator<int>(i + 1),
+        thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i), thrust::counting_iterator<stdgpu::index_t>(i + 1),
                          non_const_at_functor<T>(pool, result));
 
         T host_result;
@@ -2114,7 +2114,7 @@ namespace
     {
         T* result = createDeviceArray<T>(1);
 
-        thrust::for_each(thrust::counting_iterator<int>(i), thrust::counting_iterator<int>(i + 1),
+        thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i), thrust::counting_iterator<stdgpu::index_t>(i + 1),
                          const_at_functor<T>(pool, result));
 
         T host_result;

--- a/test/stdgpu/functional.cpp
+++ b/test/stdgpu/functional.cpp
@@ -219,7 +219,7 @@ check_floating_point_random()
     const stdgpu::index_t N = 1000000;
 
     std::default_random_engine rng(test_utils::random_seed());
-    std::uniform_real_distribution<T> dist(-1e38, 1e38);
+    std::uniform_real_distribution<T> dist(static_cast<T>(-1e38), static_cast<T>(1e38));
 
     std::unordered_set<std::size_t> hashes;
     hashes.reserve(N);

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -1155,7 +1155,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyDeviceArray_double_free)
     int default_value = 10;
     stdgpu::index64_t size = 42;
 
-    int* array_device   = createDeviceArray<int>(default_value, size);
+    int* array_device   = createDeviceArray<int>(size, default_value);
     int* array_device_2 = array_device;
 
     destroyDeviceArray<int>(array_device);

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -97,7 +97,7 @@ class lock_and_unlock
 
 TEST_F(stdgpu_mutex, parallel_lock_and_unlock)
 {
-    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(locks.size()),
+    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0), thrust::counting_iterator<stdgpu::index_t>(locks.size()),
                      lock_and_unlock(locks));
 
     EXPECT_TRUE(locks.valid());

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -110,7 +110,7 @@ namespace
     {
         public:
             STDGPU_HOST_DEVICE
-            random_key(const stdgpu::index_t seed)
+            random_key(const std::size_t seed)
                 : _seed(seed)
             {
 
@@ -119,7 +119,7 @@ namespace
             STDGPU_HOST_DEVICE test_unordered_datastructure::key_type
             operator()(const stdgpu::index_t n) const
             {
-                thrust::default_random_engine rng(_seed);
+                thrust::default_random_engine rng(static_cast<thrust::default_random_engine::result_type>(_seed));
                 thrust::uniform_real_distribution<std::int16_t> dist(stdgpu::numeric_limits<std::int16_t>::min(), stdgpu::numeric_limits<std::int16_t>::max());
                 rng.discard(3 * n);
 
@@ -127,7 +127,7 @@ namespace
             }
 
         private:
-            stdgpu::index_t _seed;
+            std::size_t _seed;
     };
 
 
@@ -193,11 +193,11 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, hash_number_collisions)
 
 
     // Number of collisions (buckets with > 1 elements)
-    stdgpu::index_t number_collisions = thrust::count_if(stdgpu::device_cbegin(bucket_hits), stdgpu::device_cend(bucket_hits),
-                                                         greater_value<1>());
+    stdgpu::index_t number_collisions = static_cast<stdgpu::index_t>(thrust::count_if(stdgpu::device_cbegin(bucket_hits), stdgpu::device_cend(bucket_hits),
+                                                                     greater_value<1>()));
 
     float percent_collisions = 40.0f;
-    EXPECT_LT(number_collisions, N * percent_collisions / 100);
+    EXPECT_LT(number_collisions, static_cast<stdgpu::index_t>(static_cast<float>(N) * percent_collisions / 100.0f));
 
     destroyDeviceArray<int>(bucket_hits);
     destroyDeviceArray<test_unordered_datastructure::key_type>(keys);
@@ -1652,7 +1652,7 @@ namespace
         stdgpu::index_t* inserted                           = createDeviceArray<stdgpu::index_t>(N);
         test_unordered_datastructure::key_type* positions   = copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+        thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0), thrust::counting_iterator<stdgpu::index_t>(N),
                          insert_keys(hash_datastructure, positions, inserted));
 
 
@@ -1680,7 +1680,7 @@ namespace
         stdgpu::index_t* inserted                           = createDeviceArray<stdgpu::index_t>(N);
         test_unordered_datastructure::key_type* positions   = copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+        thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0), thrust::counting_iterator<stdgpu::index_t>(N),
                          emplace_keys(hash_datastructure, positions, inserted));
 
 
@@ -1707,7 +1707,7 @@ namespace
         stdgpu::index_t* erased                             = createDeviceArray<stdgpu::index_t>(N);
         test_unordered_datastructure::key_type* positions   = copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+        thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0), thrust::counting_iterator<stdgpu::index_t>(N),
                          erase_keys(hash_datastructure, positions, erased));
 
 
@@ -2035,7 +2035,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_size_sum)
 
     stdgpu::index_t* bucket_sizes = createDeviceArray<stdgpu::index_t>(hash_datastructure.bucket_count());
 
-    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(hash_datastructure.bucket_count()),
+    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0), thrust::counting_iterator<stdgpu::index_t>(hash_datastructure.bucket_count()),
                      store_bucket_sizes(hash_datastructure, bucket_sizes));
 
     stdgpu::index_t bucket_size_sum = thrust::reduce(stdgpu::device_cbegin(bucket_sizes), stdgpu::device_cend(bucket_sizes));

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -194,7 +194,7 @@ void
 fill_vector(stdgpu::vector<int> pool)
 {
     const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(pool.capacity() + init),
+    thrust::for_each(thrust::counting_iterator<int>(static_cast<int>(init)), thrust::counting_iterator<int>(static_cast<int>(pool.capacity() + init)),
                      push_back_vector<int>(pool));
 
     thrust::sort(stdgpu::device_begin(pool), stdgpu::device_end(pool));
@@ -1080,7 +1080,7 @@ namespace
     {
         T* result = createDeviceArray<T>(1);
 
-        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
+        thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0), thrust::counting_iterator<stdgpu::index_t>(1),
                          non_const_back_functor<T>(pool, result));
 
         T host_result;
@@ -1098,7 +1098,7 @@ namespace
     {
         T* result = createDeviceArray<T>(1);
 
-        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
+        thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0), thrust::counting_iterator<stdgpu::index_t>(1),
                          const_back_functor<T>(pool, result));
 
         T host_result;
@@ -1177,7 +1177,7 @@ namespace
     {
         T* result = createDeviceArray<T>(1);
 
-        thrust::for_each(thrust::counting_iterator<int>(i), thrust::counting_iterator<int>(i + 1),
+        thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i), thrust::counting_iterator<stdgpu::index_t>(i + 1),
                          non_const_operator_access_functor<T>(pool, result));
 
         T host_result;
@@ -1196,7 +1196,7 @@ namespace
     {
         T* result = createDeviceArray<T>(1);
 
-        thrust::for_each(thrust::counting_iterator<int>(i), thrust::counting_iterator<int>(i + 1),
+        thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i), thrust::counting_iterator<stdgpu::index_t>(i + 1),
                          const_operator_access_functor<T>(pool, result));
 
         T host_result;
@@ -1276,7 +1276,7 @@ namespace
     {
         T* result = createDeviceArray<T>(1);
 
-        thrust::for_each(thrust::counting_iterator<int>(i), thrust::counting_iterator<int>(i + 1),
+        thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i), thrust::counting_iterator<stdgpu::index_t>(i + 1),
                          non_const_at_functor<T>(pool, result));
 
         T host_result;
@@ -1295,7 +1295,7 @@ namespace
     {
         T* result = createDeviceArray<T>(1);
 
-        thrust::for_each(thrust::counting_iterator<int>(i), thrust::counting_iterator<int>(i + 1),
+        thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i), thrust::counting_iterator<stdgpu::index_t>(i + 1),
                          const_at_functor<T>(pool, result));
 
         T host_result;

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -17,7 +17,9 @@
 #define TEST_UTILS_H
 
 #include <chrono>
+#include <cmath>
 #include <cstddef>
+#include <limits>
 #include <random>
 #include <string>
 #include <stdexcept>
@@ -42,7 +44,8 @@ namespace test_utils
         {
             std::random_device rd("/dev/urandom");
 
-            if (rd.entropy() != 0.0)
+            // rd.entropy() != 0.0
+            if (std::abs(rd.entropy()) >= std::numeric_limits<double>::min())
             {
                 return rd();
             }


### PR DESCRIPTION
In order to improve the reliability and reduce the likelihood of introducing regressions, higher warning standards are required. Increase the warning level by further accounting for conversion, sign comparison, float equality, and shadowing. Furthermore, fix the occurring warnings.