### PR TITLE
deque,vector: Fix overflow in test

### DIFF
--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -1616,7 +1616,7 @@ class at_non_const_deque
 
 TEST_F(stdgpu_deque, at_non_const)
 {
-    const stdgpu::index_t N = 100000;
+    const stdgpu::index_t N = 10000;
 
     stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
 
@@ -1658,7 +1658,7 @@ class access_operator_non_const_deque
 
 TEST_F(stdgpu_deque, access_operator_non_const)
 {
-    const stdgpu::index_t N = 100000;
+    const stdgpu::index_t N = 10000;
 
     stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
 

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -797,7 +797,7 @@ class at_non_const_vector
 
 TEST_F(stdgpu_vector, at_non_const)
 {
-    const stdgpu::index_t N = 100000;
+    const stdgpu::index_t N = 10000;
 
     stdgpu::vector<int> pool = stdgpu::vector<int>::createDeviceObject(N);
 
@@ -839,7 +839,7 @@ class access_operator_non_const_vector
 
 TEST_F(stdgpu_vector, access_operator_non_const)
 {
-    const stdgpu::index_t N = 100000;
+    const stdgpu::index_t N = 10000;
 
     stdgpu::vector<int> pool = stdgpu::vector<int>::createDeviceObject(N);
 


### PR DESCRIPTION
The unit tests of the non-const `operator[]` and `at()` functions for both `deque` and `vector` fail due to an overflow which has been revealed when using 64-bit indices. Fix this issue by using a smaller container size such that the transformed values fit into an `int`.