### PR TITLE
General: Fix sign-conversion warnings

### DIFF
--- a/src/stdgpu/cuda/impl/memory.cpp
+++ b/src/stdgpu/cuda/impl/memory.cpp
@@ -68,19 +68,19 @@ dispatch_malloc(const dynamic_memory_type type,
     {
         case dynamic_memory_type::device :
         {
-            STDGPU_DETAIL_SAFE_CALL(cudaMalloc(array, bytes));
+            STDGPU_DETAIL_SAFE_CALL(cudaMalloc(array, static_cast<std::size_t>(bytes)));
         }
         break;
 
         case dynamic_memory_type::host :
         {
-            STDGPU_DETAIL_SAFE_CALL(cudaMallocHost(array, bytes));
+            STDGPU_DETAIL_SAFE_CALL(cudaMallocHost(array, static_cast<std::size_t>(bytes)));
         }
         break;
 
         case dynamic_memory_type::managed :
         {
-            STDGPU_DETAIL_SAFE_CALL(cudaMallocManaged(array, bytes));
+            STDGPU_DETAIL_SAFE_CALL(cudaMallocManaged(array, static_cast<std::size_t>(bytes)));
         }
         break;
 
@@ -160,7 +160,7 @@ dispatch_memcpy(void* destination,
         return;
     }
 
-    STDGPU_DETAIL_SAFE_CALL(cudaMemcpy(destination, source, bytes, kind));
+    STDGPU_DETAIL_SAFE_CALL(cudaMemcpy(destination, source, static_cast<std::size_t>(bytes), kind));
 }
 
 

--- a/src/stdgpu/impl/bitset.inc
+++ b/src/stdgpu/impl/bitset.inc
@@ -158,10 +158,10 @@ bitset::count() const
         return 0;
     }
 
-    return thrust::transform_reduce(device_begin(_bit_blocks), device_end(_bit_blocks),
-                                    detail::count_bits<block_type>(),
-                                    block_type(0),
-                                    thrust::plus<block_type>());
+    return static_cast<index_t>(thrust::transform_reduce(device_begin(_bit_blocks), device_end(_bit_blocks),
+                                                         detail::count_bits<block_type>(),
+                                                         block_type(0),
+                                                         thrust::plus<block_type>()));
 }
 
 

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -138,7 +138,7 @@ bitset::operator[](const index_t n) const
     STDGPU_EXPECTS(0 <= n);
     STDGPU_EXPECTS(n < size());
 
-    const sizediv_t positions = sizedivPow2(n, _bits_per_block);
+    const sizediv_t positions = sizedivPow2(static_cast<std::size_t>(n), static_cast<std::size_t>(_bits_per_block));
 
     return reference(_bit_blocks + positions.quot, static_cast<index_t>(positions.rem));
 }
@@ -150,7 +150,7 @@ bitset::operator[](const index_t n)
     STDGPU_EXPECTS(0 <= n);
     STDGPU_EXPECTS(n < size());
 
-    const sizediv_t positions = sizedivPow2(n, _bits_per_block);
+    const sizediv_t positions = sizedivPow2(static_cast<std::size_t>(n), static_cast<std::size_t>(_bits_per_block));
 
     return reference(_bit_blocks + positions.quot, static_cast<index_t>(positions.rem));
 }

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -93,7 +93,7 @@ deque<T>::at(const deque<T>::index_type n) const
     STDGPU_EXPECTS(n < size());
     STDGPU_EXPECTS(occupied(n));
 
-    index_t index_to_wrap = _begin.load() + n;
+    index_t index_to_wrap = static_cast<index_t>(_begin.load()) + n;
 
     STDGPU_ASSERT(0 <= index_to_wrap);
 
@@ -171,12 +171,12 @@ deque<T>::push_back(const T& element)
         return pushed;
     }
 
-    int current_size = _size++;
+    index_t current_size = _size++;
 
     // Check size
     if (current_size < _capacity)
     {
-        unsigned int push_position = _end.fetch_inc_mod(static_cast<unsigned int>(_capacity));
+        index_t push_position = static_cast<index_t>(_end.fetch_inc_mod(static_cast<unsigned int>(_capacity)));
 
         while (!pushed)
         {
@@ -225,13 +225,13 @@ deque<T>::pop_back()
         return popped;
     }
 
-    int current_size =  _size--;
+    index_t current_size =  _size--;
 
     // Check size
     if (current_size > 0)
     {
-        unsigned int pop_position = _end.fetch_dec_mod(static_cast<unsigned int>(_capacity));
-        pop_position = (pop_position == 0) ? static_cast<unsigned int>(_capacity) - 1 : pop_position - 1;  // Manually reconstruct stored value
+        index_t pop_position = static_cast<index_t>(_end.fetch_dec_mod(static_cast<unsigned int>(_capacity)));
+        pop_position = (pop_position == 0) ? _capacity - 1 : pop_position - 1;  // Manually reconstruct stored value
 
         while (!popped.second)
         {
@@ -288,13 +288,13 @@ deque<T>::push_front(const T& element)
         return pushed;
     }
 
-    int current_size = _size++;
+    index_t current_size = _size++;
 
     // Check size
     if (current_size < _capacity)
     {
-        unsigned int push_position = _begin.fetch_dec_mod(static_cast<unsigned int>(_capacity));
-        push_position = (push_position == 0) ? static_cast<unsigned int>(_capacity) - 1 : push_position - 1;  // Manually reconstruct stored value
+        index_t push_position = static_cast<index_t>(_begin.fetch_dec_mod(static_cast<unsigned int>(_capacity)));
+        push_position = (push_position == 0) ? _capacity - 1 : push_position - 1;  // Manually reconstruct stored value
 
         while (!pushed)
         {
@@ -343,12 +343,12 @@ deque<T>::pop_front()
         return popped;
     }
 
-    int current_size =  _size--;
+    index_t current_size =  _size--;
 
     // Check size
     if (current_size > 0)
     {
-        unsigned int pop_position = _begin.fetch_inc_mod(static_cast<unsigned int>(_capacity));
+        index_t pop_position = static_cast<index_t>(_begin.fetch_inc_mod(static_cast<unsigned int>(_capacity)));
 
         while (!popped.second)
         {
@@ -468,8 +468,8 @@ deque<T>::clear()
 {
     if (empty()) return;
 
-    const index_t begin = _begin.load();
-    const index_t end = _end.load();
+    const index_t begin = static_cast<index_t>(_begin.load());
+    const index_t end   = static_cast<index_t>(_end.load());
 
     // One large block
     if (begin <= end)

--- a/src/stdgpu/impl/functional_detail.h
+++ b/src/stdgpu/impl/functional_detail.h
@@ -29,7 +29,7 @@ namespace stdgpu
 inline STDGPU_HOST_DEVICE std::size_t \
 hash<T>::operator()(const T& key) const \
 { \
-    return key; \
+    return static_cast<std::size_t>(key); \
 }
 
 STDGPU_DETAIL_COMPOUND_HASH_BASIC_INTEGER_TYPE(bool)

--- a/src/stdgpu/impl/iterator_detail.h
+++ b/src/stdgpu/impl/iterator_detail.h
@@ -46,13 +46,13 @@ size(T* array)
 {
     index64_t size_bytes = size<void>(static_cast<void*>(const_cast<std::remove_cv_t<T>*>(array)));
 
-    if (size_bytes % sizeof(T) != 0)
+    if (size_bytes % static_cast<index64_t>(sizeof(T)) != 0)
     {
         printf("stdgpu::size : Array type not matching the memory alignment. Returning 0 ...\n");
         return 0;
     }
 
-    return size_bytes / sizeof(T);
+    return size_bytes / static_cast<index64_t>(sizeof(T));
 }
 
 

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -314,7 +314,7 @@ allocation_manager::size() const
 {
     std::lock_guard<std::recursive_mutex> lock(_mutex);
 
-    return _pointers.size();
+    return static_cast<index64_t>(_pointers.size());
 }
 
 index64_t

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -384,7 +384,7 @@ copyDevice2HostArray(const T* source_device_array,
 {
     stdgpu::detail::memcpy(destination_host_array,
                            source_device_array,
-                           count * sizeof(T),
+                           count * static_cast<stdgpu::index64_t>(sizeof(T)),
                            stdgpu::dynamic_memory_type::host,
                            stdgpu::dynamic_memory_type::device,
                            check_safety != MemoryCopy::RANGE_CHECK);
@@ -400,7 +400,7 @@ copyHost2DeviceArray(const T* source_host_array,
 {
     stdgpu::detail::memcpy(destination_device_array,
                            source_host_array,
-                           count * sizeof(T),
+                           count * static_cast<stdgpu::index64_t>(sizeof(T)),
                            stdgpu::dynamic_memory_type::device,
                            stdgpu::dynamic_memory_type::host,
                            check_safety != MemoryCopy::RANGE_CHECK);
@@ -416,7 +416,7 @@ copyHost2HostArray(const T* source_host_array,
 {
     stdgpu::detail::memcpy(destination_host_array,
                            source_host_array,
-                           count * sizeof(T),
+                           count * static_cast<stdgpu::index64_t>(sizeof(T)),
                            stdgpu::dynamic_memory_type::host,
                            stdgpu::dynamic_memory_type::host,
                            check_safety != MemoryCopy::RANGE_CHECK);
@@ -432,7 +432,7 @@ copyDevice2DeviceArray(const T* source_device_array,
 {
     stdgpu::detail::memcpy(destination_device_array,
                            source_device_array,
-                           count * sizeof(T),
+                           count * static_cast<stdgpu::index64_t>(sizeof(T)),
                            stdgpu::dynamic_memory_type::device,
                            stdgpu::dynamic_memory_type::device,
                            check_safety != MemoryCopy::RANGE_CHECK);
@@ -447,7 +447,7 @@ template <typename T>
 STDGPU_NODISCARD T*
 safe_device_allocator<T>::allocate(index64_t n)
 {
-    return static_cast<T*>(detail::allocate(n * sizeof(T), memory_type));
+    return static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type));
 }
 
 
@@ -456,7 +456,7 @@ void
 safe_device_allocator<T>::deallocate(T* p,
                                      index64_t n)
 {
-    detail::deallocate(static_cast<void*>(p), n * sizeof(T), memory_type);
+    detail::deallocate(static_cast<void*>(p), n * static_cast<index64_t>(sizeof(T)), memory_type);
 }
 
 
@@ -464,7 +464,7 @@ template <typename T>
 STDGPU_NODISCARD T*
 safe_host_allocator<T>::allocate(index64_t n)
 {
-    return static_cast<T*>(detail::allocate(n * sizeof(T), memory_type));
+    return static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type));
 }
 
 
@@ -473,7 +473,7 @@ void
 safe_host_allocator<T>::deallocate(T* p,
                                    index64_t n)
 {
-    detail::deallocate(static_cast<void*>(p), n * sizeof(T), memory_type);
+    detail::deallocate(static_cast<void*>(p), n * static_cast<index64_t>(sizeof(T)), memory_type);
 }
 
 
@@ -481,7 +481,7 @@ template <typename T>
 STDGPU_NODISCARD T*
 safe_managed_allocator<T>::allocate(index64_t n)
 {
-    return static_cast<T*>(detail::allocate(n * sizeof(T), memory_type));
+    return static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type));
 }
 
 
@@ -490,7 +490,7 @@ void
 safe_managed_allocator<T>::deallocate(T* p,
                                       index64_t n)
 {
-    detail::deallocate(static_cast<void*>(p), n * sizeof(T), memory_type);
+    detail::deallocate(static_cast<void*>(p), n * static_cast<index64_t>(sizeof(T)), memory_type);
 }
 
 
@@ -637,14 +637,14 @@ struct [[deprecated("Replaced by stdgpu::safe_host_allocator<T>")]] safe_pinned_
     STDGPU_NODISCARD T*
     allocate(index64_t n)
     {
-        return static_cast<T*>(detail::allocate(n * sizeof(T), memory_type));
+        return static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type));
     }
 
     void
     deallocate(T* p,
                index64_t n)
     {
-        detail::deallocate(static_cast<void*>(p), n * sizeof(T), memory_type);
+        detail::deallocate(static_cast<void*>(p), n * static_cast<index64_t>(sizeof(T)), memory_type);
     }
 };
 

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -51,7 +51,7 @@ next_pow2(const index_t capacity)
     index_t result = static_cast<index_t>(1) << static_cast<index_t>(std::ceil(std::log2(capacity)));
 
     STDGPU_ENSURES(result >= capacity);
-    STDGPU_ENSURES(ispow2<std::size_t>(result));
+    STDGPU_ENSURES(ispow2<std::size_t>(static_cast<std::size_t>(result)));
 
     return result;
 }
@@ -436,9 +436,9 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::bucket(const key_type&
 {
     #if STDGPU_USE_FIBONACCI_HASHING
         // If bucket_count() == 1, then the result will be shifted by the width of std::size_t which leads to undefined/unreliable behavior
-        index_t result = (bucket_count() == 1) ? 0 : static_cast<index_t>((_hash(key) * 11400714819323198485llu) >> (numeric_limits<std::size_t>::digits - log2pow2<std::size_t>(bucket_count())));
+        index_t result = (bucket_count() == 1) ? 0 : static_cast<index_t>((_hash(key) * 11400714819323198485llu) >> (numeric_limits<std::size_t>::digits - log2pow2<std::size_t>(static_cast<std::size_t>(bucket_count()))));
     #else
-        index_t result = static_cast<index_t>(mod2<std::size_t>(_hash(key), bucket_count()));
+        index_t result = static_cast<index_t>(mod2<std::size_t>(_hash(key), static_cast<std::size_t>(bucket_count())));
     #endif
 
     STDGPU_ENSURES(0 <= result);
@@ -1078,7 +1078,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::createDeviceObject(con
 {
     STDGPU_EXPECTS(bucket_count > 0);
     STDGPU_EXPECTS(excess_count > 0);
-    STDGPU_EXPECTS(ispow2<std::size_t>(bucket_count));
+    STDGPU_EXPECTS(ispow2<std::size_t>(static_cast<std::size_t>(bucket_count)));
 
     index_t total_count = bucket_count + excess_count;
 

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -338,7 +338,7 @@ unordered_map<Key, T, Hash, KeyEqual>::createDeviceObject(const index_t& bucket_
 {
     STDGPU_EXPECTS(bucket_count > 0);
     STDGPU_EXPECTS(excess_count > 0);
-    STDGPU_EXPECTS(ispow2<std::size_t>(bucket_count));
+    STDGPU_EXPECTS(ispow2<std::size_t>(static_cast<std::size_t>(bucket_count)));
 
     unordered_map<Key, T, Hash, KeyEqual> result;
     result._base = detail::unordered_base<key_type, value_type, detail::select1st<value_type>, hasher, key_equal>::createDeviceObject(bucket_count, excess_count);

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -323,7 +323,7 @@ unordered_set<Key, Hash, KeyEqual>::createDeviceObject(const index_t& bucket_cou
 {
     STDGPU_EXPECTS(bucket_count > 0);
     STDGPU_EXPECTS(excess_count > 0);
-    STDGPU_EXPECTS(ispow2<std::size_t>(bucket_count));
+    STDGPU_EXPECTS(ispow2<std::size_t>(static_cast<std::size_t>(bucket_count)));
 
     unordered_set<Key, Hash, KeyEqual> result;
     result._base = detail::unordered_base<key_type, value_type, thrust::identity<key_type>, hasher, key_equal>::createDeviceObject(bucket_count, excess_count);

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -156,7 +156,7 @@ vector<T>::push_back(const T& element)
         return pushed;
     }
 
-    int push_position = _size++;
+    index_t push_position = _size++;
 
     // Check position
     if (0 <= push_position && push_position < _capacity)
@@ -208,7 +208,7 @@ vector<T>::pop_back()
         return popped;
     }
 
-    int pop_position = --_size;
+    index_t pop_position = --_size;
 
     // Check position
     if (0 <= pop_position && pop_position < _capacity)

--- a/src/stdgpu/openmp/impl/memory.cpp
+++ b/src/stdgpu/openmp/impl/memory.cpp
@@ -38,7 +38,7 @@ dispatch_malloc(const dynamic_memory_type type,
         case dynamic_memory_type::host :
         case dynamic_memory_type::managed :
         {
-            *array = std::malloc(bytes);
+            *array = std::malloc(static_cast<std::size_t>(bytes));
         }
         break;
 
@@ -87,7 +87,7 @@ dispatch_memcpy(void* destination,
         return;
     }
 
-    std::memcpy(destination, source, bytes);
+    std::memcpy(destination, source, static_cast<std::size_t>(bytes));
 }
 
 

--- a/test/stdgpu/cstdlib.cpp
+++ b/test/stdgpu/cstdlib.cpp
@@ -44,27 +44,30 @@ TEST_F(stdgpu_cstdlib, sizedivPow2_zero)
 {
     stdgpu::sizediv_t result = stdgpu::sizedivPow2(0, 2);
 
-    EXPECT_EQ(result.quot, 0);
-    EXPECT_EQ(result.rem,  0);
+    EXPECT_EQ(result.quot, static_cast<std::size_t>(0));
+    EXPECT_EQ(result.rem,  static_cast<std::size_t>(0));
 }
 
 
 void
 thread_values(const stdgpu::index_t iterations)
 {
-    size_t seed = test_utils::random_thread_seed();
+    std::size_t seed = test_utils::random_thread_seed();
 
     std::default_random_engine rng(seed);
-    std::uniform_int_distribution<size_t> dist_x(1, std::numeric_limits<long long int>::max());
-    std::uniform_int_distribution<int> dist_y(1, std::numeric_limits<size_t>::digits);
+    std::uniform_int_distribution<std::size_t> dist_x(1, std::numeric_limits<long long int>::max());
+    std::uniform_int_distribution<int> dist_y(1, std::numeric_limits<std::size_t>::digits);
 
     for (stdgpu::index_t i = 0; i < iterations; ++i)
     {
-        size_t x = dist_x(rng);
-        size_t y = (static_cast<size_t>(1) << dist_y(rng));
+        std::size_t x = dist_x(rng);
+        std::size_t y = (static_cast<std::size_t>(1) << dist_y(rng));
 
-        EXPECT_EQ(std::lldiv(x, y).quot, stdgpu::sizedivPow2(x, y).quot);
-        EXPECT_EQ(std::lldiv(x, y).rem , stdgpu::sizedivPow2(x, y).rem);
+        std::lldiv_t div_ll         = std::lldiv(static_cast<long long int>(x), static_cast<long long int>(y));
+        stdgpu::sizediv_t div_size  = stdgpu::sizedivPow2(x, y);
+
+        EXPECT_EQ(static_cast<std::size_t>(div_ll.quot), div_size.quot);
+        EXPECT_EQ(static_cast<std::size_t>(div_ll.rem) , div_size.rem);
     }
 }
 

--- a/test/stdgpu/functional.cpp
+++ b/test/stdgpu/functional.cpp
@@ -112,7 +112,7 @@ check_integer()
     stdgpu::index_t N = static_cast<stdgpu::index_t>(std::numeric_limits<T>::max()) - static_cast<stdgpu::index_t>(std::numeric_limits<T>::lowest());
 
     std::unordered_set<std::size_t> hashes;
-    hashes.reserve(N);
+    hashes.reserve(static_cast<std::size_t>(N));
 
     stdgpu::hash<T> hasher;
     for (T i = std::numeric_limits<T>::lowest(); i < std::numeric_limits<T>::max(); ++i)
@@ -164,7 +164,7 @@ check_integer_random()
     std::uniform_int_distribution<T> dist(std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
 
     std::unordered_set<std::size_t> hashes;
-    hashes.reserve(N);
+    hashes.reserve(static_cast<std::size_t>(N));
 
     stdgpu::hash<T> hasher;
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -222,7 +222,7 @@ check_floating_point_random()
     std::uniform_real_distribution<T> dist(static_cast<T>(-1e38), static_cast<T>(1e38));
 
     std::unordered_set<std::size_t> hashes;
-    hashes.reserve(N);
+    hashes.reserve(static_cast<std::size_t>(N));
 
     stdgpu::hash<T> hasher;
     for (stdgpu::index_t i = 0; i < N; ++i)

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -688,7 +688,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2DeviceArray_no_check)
     stdgpu::index64_t size = 42;
 
     int* array = createDeviceArray<int>(size, default_value);
-    int* array_host = new int[size];
+    int* array_host = new int[static_cast<std::size_t>(size)];
     for (stdgpu::index64_t i = 0; i < size; ++i)
     {
         array_host[i] = default_value;
@@ -790,7 +790,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2HostArray_no_check)
     int default_value = 10;
     stdgpu::index64_t size = 42;
 
-    int* array_host = new int[size];
+    int* array_host = new int[static_cast<std::size_t>(size)];
     for (stdgpu::index64_t i = 0; i < size; ++i)
     {
         array_host[i] = default_value;
@@ -967,7 +967,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2DeviceArray_no_check)
     stdgpu::index64_t size = 42;
 
     int* array = createDeviceArray<int>(size, default_value);
-    int* array_host = new int[size];
+    int* array_host = new int[static_cast<std::size_t>(size)];
     for (stdgpu::index64_t i = 0; i < size; ++i)
     {
         array_host[i] = default_value;
@@ -1035,7 +1035,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2HostArray_no_check)
 
     int* array = createDeviceArray<int>(size, default_value);
     int* array_host = createHostArray<int>(size, default_value);
-    int* array_copy = new int[size];
+    int* array_copy = new int[static_cast<std::size_t>(size)];
     copyDevice2HostArray<int>(array, size, array_copy, MemoryCopy::NO_CHECK);
 
     EXPECT_TRUE( thrust::equal(thrust::host,
@@ -1093,12 +1093,12 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_no_check)
     int default_value = 10;
     stdgpu::index64_t size = 42;
 
-    int* array_host = new int[size];
+    int* array_host = new int[static_cast<std::size_t>(size)];
     for (stdgpu::index64_t i = 0; i < size; ++i)
     {
         array_host[i] = default_value;
     }
-    int* array_copy = new int[size];
+    int* array_copy = new int[static_cast<std::size_t>(size)];
     copyHost2HostArray<int>(array_host, size, array_copy, MemoryCopy::NO_CHECK);
 
     EXPECT_TRUE( thrust::equal(thrust::host,
@@ -1133,7 +1133,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_self_no_check)
     int default_value = 10;
     stdgpu::index64_t size = 42;
 
-    int* array_host = new int[size];
+    int* array_host = new int[static_cast<std::size_t>(size)];
     for (stdgpu::index64_t i = 0; i < size; ++i)
     {
         array_host[i] = default_value;

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -121,7 +121,7 @@ namespace
             {
                 thrust::default_random_engine rng(static_cast<thrust::default_random_engine::result_type>(_seed));
                 thrust::uniform_real_distribution<std::int16_t> dist(stdgpu::numeric_limits<std::int16_t>::min(), stdgpu::numeric_limits<std::int16_t>::max());
-                rng.discard(3 * n);
+                rng.discard(static_cast<std::size_t>(3 * n));
 
                 return test_unordered_datastructure::key_type(dist(rng), dist(rng), dist(rng));
             }
@@ -1628,7 +1628,7 @@ namespace
         test_unordered_datastructure::key_type* host_positions = createHostArray<test_unordered_datastructure::key_type>(N);
 
         std::unordered_set<test_unordered_datastructure::key_type, test_unordered_datastructure::hasher> set;
-        set.reserve(N);
+        set.reserve(static_cast<std::size_t>(N));
         while (static_cast<stdgpu::index_t>(set.size()) < N)
         {
             test_unordered_datastructure::key_type random(dist(rng), dist(rng), dist(rng));

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -85,7 +85,7 @@ namespace test_utils
     {
         const stdgpu::index_t concurrent_threads = std::max<stdgpu::index_t>(1, static_cast<stdgpu::index_t>(std::thread::hardware_concurrency()));
         std::vector<std::thread> threads;
-        threads.reserve(concurrent_threads);
+        threads.reserve(static_cast<std::size_t>(concurrent_threads));
 
         for (stdgpu::index_t i = 0; i < concurrent_threads; ++i)
         {
@@ -94,9 +94,9 @@ namespace test_utils
 
         for (stdgpu::index_t i = 0; i < concurrent_threads; ++i)
         {
-            if (threads[i].joinable())
+            if (threads[static_cast<std::size_t>(i)].joinable())
             {
-                threads[i].join();
+                threads[static_cast<std::size_t>(i)].join();
             }
         }
     }


### PR DESCRIPTION
In #98, the warning level has been increased. This caused several sign-conversion warnings to appear when building with Clang. Fix them to suppress this noise.