### PR TITLE
General: Fix format warnings

### DIFF
--- a/cmake/set_host_flags.cmake
+++ b/cmake/set_host_flags.cmake
@@ -11,7 +11,6 @@ if(NOT MSVC)
     if(${CMAKE_BUILD_TYPE} MATCHES "Release" OR ${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
         string(APPEND STDGPU_HOST_FLAGS " -O3")
     endif()
-    string(APPEND STDGPU_HOST_FLAGS " -Wno-format")
 else()
     #string(APPEND STDGPU_HOST_FLAGS " /W3") # or /W4 depending on how useful this is
     #string(APPEND STDGPU_HOST_FLAGS " /O2")

--- a/src/stdgpu/cstddef.h
+++ b/src/stdgpu/cstddef.h
@@ -22,6 +22,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cinttypes>
 
 #include <stdgpu/config.h>
 #include <stdgpu/platform.h>
@@ -38,6 +39,16 @@ using index64_t = std::ptrdiff_t;       /**< std::ptrdiff_t */
     using index_t = index32_t;          /**< index32_t : Use faster 32-bit indexing when STDGPU_USE_32_BIT_INDEX is set */
 #else
     using index_t = index64_t;          /**< index64_t : Use 64-bit indexing when STDGPU_USE_32_BIT_INDEX is not set */
+#endif
+
+
+#define STDGPU_PRIINDEX32 PRIdLEAST32           /**< PRIdLEAST32 */
+#define STDGPU_PRIINDEX64 "td"                  /**< td */
+
+#if STDGPU_USE_32_BIT_INDEX
+    #define STDGPU_PRIINDEX STDGPU_PRIINDEX32   /**< STDGPU_PRIINDEX32 */
+#else
+    #define STDGPU_PRIINDEX STDGPU_PRIINDEX64   /**< STDGPU_PRIINDEX32 */
 #endif
 
 

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -408,12 +408,12 @@ deque<T>::size() const
     // Check boundary cases where the push/pop caused the pointers to be overful/underful
     if (current_size < 0)
     {
-        printf("stdgpu::deque::size : Size out of bounds: %d not in [0, %d]. Clamping to 0\n", current_size, _capacity);
+        printf("stdgpu::deque::size : Size out of bounds: %" STDGPU_PRIINDEX " not in [0, %" STDGPU_PRIINDEX "]. Clamping to 0\n", current_size, _capacity);
         return 0;
     }
     else if (current_size > _capacity)
     {
-        printf("stdgpu::deque::size : Size out of bounds: %d not in [0, %d]. Clamping to %d\n", current_size, _capacity, _capacity);
+        printf("stdgpu::deque::size : Size out of bounds: %" STDGPU_PRIINDEX " not in [0, %" STDGPU_PRIINDEX "]. Clamping to %" STDGPU_PRIINDEX "\n", current_size, _capacity, _capacity);
         return _capacity;
     }
 

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -191,7 +191,7 @@ class offset_inside_range
 
             if (linked_entry < 0 || linked_entry >= _base.total_count())
             {
-                printf("stdgpu::detail::unordered_base : Linked entry out of range : %d -> %d\n", i, linked_entry);
+                printf("stdgpu::detail::unordered_base : Linked entry out of range : %" STDGPU_PRIINDEX " -> %" STDGPU_PRIINDEX "\n", i, linked_entry);
                 return false;
             }
 
@@ -238,7 +238,7 @@ class count_visits
                 // Prevent potential endless loop and print warning
                 if (_flags[linked_list] > 1)
                 {
-                    printf("stdgpu::detail::unordered_base : Linked list not unique : %d visited %d times\n", linked_list, _flags[linked_list]);
+                    printf("stdgpu::detail::unordered_base : Linked list not unique : %" STDGPU_PRIINDEX " visited %d times\n", linked_list, _flags[linked_list]);
                     return;
                 }
             }
@@ -294,7 +294,7 @@ class value_reachable
 
                 if (!_base.contains(block))
                 {
-                    printf("stdgpu::detail::unordered_base : Unreachable entry : %d\n", i);
+                    printf("stdgpu::detail::unordered_base : Unreachable entry : %" STDGPU_PRIINDEX "\n", i);
                     return false;
                 }
             }
@@ -336,7 +336,7 @@ class values_unique
 
                 if (position != i)
                 {
-                    printf("stdgpu::detail::unordered_base : Duplicate entry : Expected %d but also found at %d\n", i, position);
+                    printf("stdgpu::detail::unordered_base : Duplicate entry : Expected %" STDGPU_PRIINDEX " but also found at %" STDGPU_PRIINDEX "\n", i, position);
                     return false;
                 }
             }

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -187,7 +187,7 @@ vector<T>::push_back(const T& element)
     }
     else
     {
-        printf("stdgpu::vector::push_back : Index out of bounds: %d not in [0, %d]\n", push_position, _capacity - 1);
+        printf("stdgpu::vector::push_back : Index out of bounds: %" STDGPU_PRIINDEX " not in [0, %" STDGPU_PRIINDEX "]\n", push_position, _capacity - 1);
     }
 
     return pushed;
@@ -239,7 +239,7 @@ vector<T>::pop_back()
     }
     else
     {
-        printf("stdgpu::vector::pop_back : Index out of bounds: %d not in [0, %d]\n", pop_position, _capacity - 1);
+        printf("stdgpu::vector::pop_back : Index out of bounds: %" STDGPU_PRIINDEX " not in [0, %" STDGPU_PRIINDEX "]\n", pop_position, _capacity - 1);
     }
 
     return popped;
@@ -271,12 +271,12 @@ vector<T>::size() const
     // Check boundary cases where the push/pop caused the pointers to be overful/underful
     if (current_size < 0)
     {
-        printf("stdgpu::vector::size : Size out of bounds: %d not in [0, %d]. Clamping to 0\n", current_size, _capacity);
+        printf("stdgpu::vector::size : Size out of bounds: %" STDGPU_PRIINDEX " not in [0, %" STDGPU_PRIINDEX "]. Clamping to 0\n", current_size, _capacity);
         return 0;
     }
     else if (current_size > _capacity)
     {
-        printf("stdgpu::vector::size : Size out of bounds: %d not in [0, %d]. Clamping to %d\n", current_size, _capacity, _capacity);
+        printf("stdgpu::vector::size : Size out of bounds: %" STDGPU_PRIINDEX " not in [0, %" STDGPU_PRIINDEX "]. Clamping to %" STDGPU_PRIINDEX "\n", current_size, _capacity, _capacity);
         return _capacity;
     }
 

--- a/test/stdgpu/main.cpp
+++ b/test/stdgpu/main.cpp
@@ -67,13 +67,13 @@ main(int argc, char* argv[])
     printf("\n");
     printf( "+---------------------------------------------------------+\n" );
     printf( "| Memory Usage : #Created / #Destroyed (#Leaks)           |\n");
-    printf( "|   Device     %6ld / %6ld (%6ld)                   |\n", stdgpu::get_allocation_count(stdgpu::dynamic_memory_type::device),
+    printf( "|   Device     %6" STDGPU_PRIINDEX64 " / %6" STDGPU_PRIINDEX64 " (%6" STDGPU_PRIINDEX64 ")                   |\n", stdgpu::get_allocation_count(stdgpu::dynamic_memory_type::device),
                                                                        stdgpu::get_deallocation_count(stdgpu::dynamic_memory_type::device),
                                                                        stdgpu::get_allocation_count(stdgpu::dynamic_memory_type::device) - stdgpu::get_deallocation_count(stdgpu::dynamic_memory_type::device));
-    printf( "|   Host       %6ld / %6ld (%6ld)                   |\n", stdgpu::get_allocation_count(stdgpu::dynamic_memory_type::host),
+    printf( "|   Host       %6" STDGPU_PRIINDEX64 " / %6" STDGPU_PRIINDEX64 " (%6" STDGPU_PRIINDEX64 ")                   |\n", stdgpu::get_allocation_count(stdgpu::dynamic_memory_type::host),
                                                                        stdgpu::get_deallocation_count(stdgpu::dynamic_memory_type::host),
                                                                        stdgpu::get_allocation_count(stdgpu::dynamic_memory_type::host) - stdgpu::get_deallocation_count(stdgpu::dynamic_memory_type::host));
-    printf( "|   Managed    %6ld / %6ld (%6ld)                   |\n", stdgpu::get_allocation_count(stdgpu::dynamic_memory_type::managed),
+    printf( "|   Managed    %6" STDGPU_PRIINDEX64 " / %6" STDGPU_PRIINDEX64 " (%6" STDGPU_PRIINDEX64 ")                   |\n", stdgpu::get_allocation_count(stdgpu::dynamic_memory_type::managed),
                                                                        stdgpu::get_deallocation_count(stdgpu::dynamic_memory_type::managed),
                                                                        stdgpu::get_allocation_count(stdgpu::dynamic_memory_type::managed) - stdgpu::get_deallocation_count(stdgpu::dynamic_memory_type::managed));
     printf( "+---------------------------------------------------------+\n" );


### PR DESCRIPTION
A long standing issue were the inconsistent format specifiers when using the `index_t` type. Since it can be either 32-bit or 64-bit and the respective specifiers even differ between platforms, using a single fixed specifier such as `%d` causes several warnings and may also be unsafe. Fix this issue by introducing a `STDGPU_PRIINDEX` specifier macro similar to the ones defined in `<cinttypes>` which adapts to the platform and provides the correct native specifier.