### PR TITLE
ranges: Add index64_t constructor and deprecate index_t version

### DIFF
--- a/src/stdgpu/impl/ranges_detail.h
+++ b/src/stdgpu/impl/ranges_detail.h
@@ -23,7 +23,18 @@ namespace stdgpu
 
 template <typename T>
 device_range<T>::device_range(T* p)
-    : device_range(p, static_cast<index_t>(stdgpu::size(p)))
+    : device_range(p, stdgpu::size(p))
+{
+
+}
+
+
+template <typename T>
+STDGPU_HOST_DEVICE
+device_range<T>::device_range(T* p,
+                              index64_t n)
+    : _begin(p),
+      _end(p + n)
 {
 
 }
@@ -57,9 +68,17 @@ device_range<T>::end()
 
 
 template <typename T>
+host_range<T>::host_range(T* p)
+    : host_range(p, stdgpu::size(p))
+{
+
+}
+
+
+template <typename T>
 STDGPU_HOST_DEVICE
 host_range<T>::host_range(T* p,
-                          index_t n)
+                          index64_t n)
     : _begin(p),
       _end(p + n)
 {
@@ -68,8 +87,11 @@ host_range<T>::host_range(T* p,
 
 
 template <typename T>
-host_range<T>::host_range(T* p)
-    : host_range(p, static_cast<index_t>(stdgpu::size(p)))
+STDGPU_HOST_DEVICE
+host_range<T>::host_range(T* p,
+                          index_t n)
+    : _begin(p),
+      _end(p + n)
 {
 
 }

--- a/src/stdgpu/ranges.h
+++ b/src/stdgpu/ranges.h
@@ -55,6 +55,17 @@ class device_range
          */
         STDGPU_HOST_DEVICE
         device_range(T* p,
+                     index64_t n);
+
+        /**
+         * \deprecated Replaced by device_range(T*, index64_t)
+         * \brief Constructor
+         * \param[in] p A pointer to the array
+         * \param[in] n The number of array elements
+         */
+        //[[deprecated("Replaced by device_range(T*, index64_t")]]
+        STDGPU_HOST_DEVICE
+        device_range(T* p,
                      index_t n);
 
         /**
@@ -99,6 +110,17 @@ class host_range
          * \param[in] p A pointer to the array
          * \param[in] n The number of array elements
          */
+        STDGPU_HOST_DEVICE
+        host_range(T* p,
+                   index64_t n);
+
+        /**
+         * \deprecated Replaced by host_range(T*, index64_t)
+         * \brief Constructor
+         * \param[in] p A pointer to the array
+         * \param[in] n The number of array elements
+         */
+        //[[deprecated("Replaced by host_range(T*, index64_t")]]
         STDGPU_HOST_DEVICE
         host_range(T* p,
                    index_t n);

--- a/test/stdgpu/ranges.cpp
+++ b/test/stdgpu/ranges.cpp
@@ -62,6 +62,22 @@ class transform_range<device_range<int>, thrust::identity<int>>;
 
 TEST_F(stdgpu_ranges, device_range_with_size)
 {
+    const stdgpu::index64_t size = 42;
+    int* array = createDeviceArray<int>(size);
+
+    stdgpu::device_range<int> array_range(array, size);
+    int* array_begin   = array_range.begin().get();
+    int* array_end     = array_range.end().get();
+
+    EXPECT_EQ(array_begin, array);
+    EXPECT_EQ(array_end,   array + size);
+
+    destroyDeviceArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, device_range_with_size_deprecated)
+{
     const stdgpu::index_t size = 42;
     int* array = createDeviceArray<int>(size);
 
@@ -78,7 +94,7 @@ TEST_F(stdgpu_ranges, device_range_with_size)
 
 TEST_F(stdgpu_ranges, device_range_automatic_size)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array = createDeviceArray<int>(size);
 
     stdgpu::device_range<int> array_range(array);
@@ -93,6 +109,22 @@ TEST_F(stdgpu_ranges, device_range_automatic_size)
 
 
 TEST_F(stdgpu_ranges, host_range_with_size)
+{
+    const stdgpu::index64_t size = 42;
+    int* array = createHostArray<int>(size);
+
+    stdgpu::host_range<int> array_range(array, size);
+    int* array_begin   = array_range.begin().get();
+    int* array_end     = array_range.end().get();
+
+    EXPECT_EQ(array_begin, array);
+    EXPECT_EQ(array_end,   array + size);
+
+    destroyHostArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, host_range_with_size_deprecated)
 {
     const stdgpu::index_t size = 42;
     int* array = createHostArray<int>(size);
@@ -110,7 +142,7 @@ TEST_F(stdgpu_ranges, host_range_with_size)
 
 TEST_F(stdgpu_ranges, host_range_automatic_size)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array = createHostArray<int>(size);
 
     stdgpu::host_range<int> array_range(array);
@@ -137,7 +169,7 @@ struct square
 
 TEST_F(stdgpu_ranges, transform_range)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array          = createHostArray<int>(size);
     int* array_result   = createHostArray<int>(size);
 


### PR DESCRIPTION
The `memory` and `iterator` modules consistently use `index64_t` to specify sizes. However, `ranges` uses the configurable `index_t` type which may be different from `index64_t`. Add a corresponding `index64_t` constructor version to both `device_range` and `host_range` and deprecate the `index_t` version (only implicitly to avoid unnecessary noise).