### PR TITLE
General: Deprecate misleading/obsolete cmake options

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ In addition, the implementation of some functionality can be controlled via conf
 
 Configuration Option | Effect | Default
 --- | --- | ---
-`STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING` | Enable warnings when auxiliary arrays are allocated in memory API | `OFF`
+`STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING` | Enable warnings when auxiliary arrays are allocated in memory API (**deprecated**) | `OFF`
 `STDGPU_ENABLE_CONTRACT_CHECKS` | Enable contract checks | `OFF` if `CMAKE_BUILD_TYPE` equals `Release` or `MinSizeRel`, `ON` otherwise
-`STDGPU_ENABLE_MANAGED_ARRAY_WARNING` | Enable warnings when managed memory is initialized on the host side but should be on device in memory API | `OFF`
+`STDGPU_ENABLE_MANAGED_ARRAY_WARNING` | Enable warnings when managed memory is initialized on the host side but should be on device in memory API (**deprecated**) | `OFF`
 `STDGPU_USE_32_BIT_INDEX` | Use 32-bit instead of 64-bit signed integer for `index_t` | `ON`
-`STDGPU_USE_FAST_DESTROY` | Use fast destruction of allocated arrays (filled with a default value) by omitting destructor calls in memory API | `OFF`
-`STDGPU_USE_FIBONACCI_HASHING` | Use Fibonacci Hashing instead of Modulo to compute hash bucket indices | `ON`
+`STDGPU_USE_FAST_DESTROY` | Use fast destruction of allocated arrays (filled with a default value) by omitting destructor calls in memory API (**deprecated**) | `OFF`
+`STDGPU_USE_FIBONACCI_HASHING` | Use Fibonacci Hashing instead of Modulo to compute hash bucket indices (**deprecated**) | `ON`
 
 
 ### Examples

--- a/cmake/config_summary.cmake
+++ b/cmake/config_summary.cmake
@@ -18,12 +18,12 @@ function(stdgpu_print_configuration_summary)
     message(STATUS "")
 
     message(STATUS "Configuration:")
-    message(STATUS "  STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING     :   ${STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING}")
+    message(STATUS "  STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING     :   [deprecated] ${STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING}")
     message(STATUS "  STDGPU_ENABLE_CONTRACT_CHECKS             :   ${STDGPU_ENABLE_CONTRACT_CHECKS} (depends on build type)")
-    message(STATUS "  STDGPU_ENABLE_MANAGED_ARRAY_WARNING       :   ${STDGPU_ENABLE_MANAGED_ARRAY_WARNING}")
+    message(STATUS "  STDGPU_ENABLE_MANAGED_ARRAY_WARNING       :   [deprecated] ${STDGPU_ENABLE_MANAGED_ARRAY_WARNING}")
     message(STATUS "  STDGPU_USE_32_BIT_INDEX                   :   ${STDGPU_USE_32_BIT_INDEX}")
-    message(STATUS "  STDGPU_USE_FAST_DESTROY                   :   ${STDGPU_USE_FAST_DESTROY}")
-    message(STATUS "  STDGPU_USE_FIBONACCI_HASHING              :   ${STDGPU_USE_FIBONACCI_HASHING}")
+    message(STATUS "  STDGPU_USE_FAST_DESTROY                   :   [deprecated] ${STDGPU_USE_FAST_DESTROY}")
+    message(STATUS "  STDGPU_USE_FIBONACCI_HASHING              :   [deprecated] ${STDGPU_USE_FIBONACCI_HASHING}")
 
     message(STATUS "")
 

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -111,12 +111,12 @@ In addition, the implementation of some functionality can be controlled via conf
 
 Configuration Option | Effect | Default
 --- | --- | ---
-`STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING` | Enable warnings when auxiliary arrays are allocated in memory API | `OFF`
+`STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING` | Enable warnings when auxiliary arrays are allocated in memory API (**deprecated**) | `OFF`
 `STDGPU_ENABLE_CONTRACT_CHECKS` | Enable contract checks | `OFF` if `CMAKE_BUILD_TYPE` equals `Release` or `MinSizeRel`, `ON` otherwise
-`STDGPU_ENABLE_MANAGED_ARRAY_WARNING` | Enable warnings when managed memory is initialized on the host side but should be on device in memory API | `OFF`
+`STDGPU_ENABLE_MANAGED_ARRAY_WARNING` | Enable warnings when managed memory is initialized on the host side but should be on device in memory API (**deprecated**) | `OFF`
 `STDGPU_USE_32_BIT_INDEX` | Use 32-bit instead of 64-bit signed integer for `index_t` | `ON`
-`STDGPU_USE_FAST_DESTROY` | Use fast destruction of allocated arrays (filled with a default value) by omitting destructor calls in memory API | `OFF`
-`STDGPU_USE_FIBONACCI_HASHING` | Use Fibonacci Hashing instead of Modulo to compute hash bucket indices | `ON`
+`STDGPU_USE_FAST_DESTROY` | Use fast destruction of allocated arrays (filled with a default value) by omitting destructor calls in memory API (**deprecated**) | `OFF`
+`STDGPU_USE_FIBONACCI_HASHING` | Use Fibonacci Hashing instead of Modulo to compute hash bucket indices (**deprecated**) | `ON`
 
 
 \subsection examples Examples

--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -20,12 +20,12 @@ else()
     set(STDGPU_ENABLE_CONTRACT_CHECKS_DEFAULT ON)
 endif()
 
-option(STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING "Enable warnings when auxiliary arrays are allocated in memory API, default: OFF" OFF)
+option(STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING "Enable warnings when auxiliary arrays are allocated in memory API (deprecated), default: OFF" OFF)
 option(STDGPU_ENABLE_CONTRACT_CHECKS "Enable contract checks, default: OFF if CMAKE_BUILD_TYPE is Release or MinSizeRel, ON otherwise" ${STDGPU_ENABLE_CONTRACT_CHECKS_DEFAULT})
-option(STDGPU_ENABLE_MANAGED_ARRAY_WARNING "Enable warnings when managed memory is initialized on the host side but should be on device in memory API, default: OFF" OFF)
+option(STDGPU_ENABLE_MANAGED_ARRAY_WARNING "Enable warnings when managed memory is initialized on the host side but should be on device in memory API (deprecated), default: OFF" OFF)
 option(STDGPU_USE_32_BIT_INDEX "Use 32-bit instead of 64-bit signed integer for index_t, default: ON" ON)
-option(STDGPU_USE_FAST_DESTROY "Use fast destruction of allocated arrays (filled with a default value) by omitting destructor calls in memory API, default: OFF" OFF)
-option(STDGPU_USE_FIBONACCI_HASHING "Use Fibonacci Hashing instead of Modulo to compute hash bucket indices, default: ON" ON)
+option(STDGPU_USE_FAST_DESTROY "Use fast destruction of allocated arrays (filled with a default value) by omitting destructor calls in memory API (deprecated), default: OFF" OFF)
+option(STDGPU_USE_FIBONACCI_HASHING "Use Fibonacci Hashing instead of Modulo to compute hash bucket indices (deprecated), default: ON" ON)
 
 configure_file("${STDGPU_INCLUDE_LOCAL_DIR}/stdgpu/config.h.in"
                "${STDGPU_BUILD_INCLUDE_DIR}/stdgpu/config.h")


### PR DESCRIPTION
Some library options merely expose implementation details and, hence, may not provide any value to users or even lead to confusion:

- `STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING` and `STDGPU_ENABLE_MANAGED_ARRAY_WARNING` both just print a warning if a certain code path to extend support to host-only (.cpp) files is chosen.
- `STDGPU_USE_FAST_DESTROY` disables proper safe destruction of arrays by skipping the destructor calls which lead to unexpected  behavior if the destructor is not trivial.
- `STDGPU_USE_FIBONACCI_HASHING` exposes an implementation detail regarding the mapping from hashes to buckets in  `unordered_map` and `unordered_set`.

Deprecate these options to encourage users to stick with the current, safe default values.