### PR TITLE
CI: Fix potentially missing OpenMP runtime package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,14 @@ jobs:
 
   steps:
     - task: Bash@3
+      displayName: Install OpenMP
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/install_openmp_ubuntu1804.sh
+
+    - task: Bash@3
       displayName: Install CMake 3.15+
       inputs:
         targetType: 'inline'
@@ -110,6 +118,14 @@ jobs:
     vmImage: 'ubuntu-18.04'
 
   steps:
+    - task: Bash@3
+      displayName: Install OpenMP
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/install_openmp_ubuntu1804.sh
+
     - task: Bash@3
       displayName: Install CMake 3.15+
       inputs:

--- a/scripts/utils/install_openmp_ubuntu1804.sh
+++ b/scripts/utils/install_openmp_ubuntu1804.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# GCC: Already installed
+# Clang: Install libomp-dev and remove conflicting packages
+sudo apt-get update
+sudo apt-get remove libomp*
+sudo apt-get install -f libomp-dev


### PR DESCRIPTION
Up to now, we assumed that the OpenMP runtime package is also installed in the Ubuntu 18.04 image of Azure Pipelines. Since Ubuntu itself does not strictly impose a hard dependency when installing Clang but rather only a suggestion, this assumption is not always valid. In particular, the last update of the image seems to break it. Fix the problem by explicitly installing the required package.