### PR TITLE
General: Increase MSVC warning level and fix related warnings

### DIFF
--- a/cmake/cuda/set_device_flags.cmake
+++ b/cmake/cuda/set_device_flags.cmake
@@ -52,7 +52,7 @@ if(NOT MSVC)
         message(STATUS "Appended optimization flag (-O3,/O2) implicitly")
     endif()
 else()
-    #string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler /W3") # or /W4 depending on how useful this is
+    string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler /W2") # or /W3 or /W4 depending on how useful this is
     #string(APPEND STDGPU_DEVICE_FLAGS " /O2")
 endif()
 

--- a/cmake/set_host_flags.cmake
+++ b/cmake/set_host_flags.cmake
@@ -12,7 +12,7 @@ if(NOT MSVC)
         string(APPEND STDGPU_HOST_FLAGS " -O3")
     endif()
 else()
-    #string(APPEND STDGPU_HOST_FLAGS " /W3") # or /W4 depending on how useful this is
+    string(APPEND STDGPU_HOST_FLAGS " /W2") # or /W3 or /W4 depending on how useful this is
     #string(APPEND STDGPU_HOST_FLAGS " /O2")
 endif()
 

--- a/test/stdgpu/algorithm.cpp
+++ b/test/stdgpu/algorithm.cpp
@@ -109,7 +109,7 @@ thread_check_min_max_integer(const stdgpu::index_t iterations)
     // Generate true random numbers
     size_t seed = test_utils::random_thread_seed();
 
-    std::default_random_engine rng(seed);
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_int_distribution<T> dist(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
 
     for (stdgpu::index_t i = 0; i < iterations; ++i)
@@ -186,7 +186,7 @@ thread_check_min_max_float(const stdgpu::index_t iterations)
     // Generate true random numbers
     size_t seed = test_utils::random_thread_seed();
 
-    std::default_random_engine rng(seed);
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_real_distribution<T> dist(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
 
     std::uniform_real_distribution<T> flip(T(0), T(1));
@@ -230,7 +230,7 @@ thread_check_clamp_integer(const stdgpu::index_t iterations)
     // Generate true random numbers
     size_t seed = test_utils::random_thread_seed();
 
-    std::default_random_engine rng(seed);
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_int_distribution<T> dist(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
 
     for (stdgpu::index_t i = 0; i < iterations; ++i)
@@ -300,7 +300,7 @@ thread_check_clamp_float(const stdgpu::index_t iterations)
     // Generate true random numbers
     size_t seed = test_utils::random_thread_seed();
 
-    std::default_random_engine rng(seed);
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_real_distribution<T> dist(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
 
     std::uniform_real_distribution<T> flip(T(0), T(1));

--- a/test/stdgpu/bit.cpp
+++ b/test/stdgpu/bit.cpp
@@ -93,7 +93,7 @@ thread_ispow2_random(const stdgpu::index_t iterations,
     // Generate true random numbers
     std::size_t seed = test_utils::random_thread_seed();
 
-    std::default_random_engine rng(seed);
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_int_distribution<std::size_t> dist(std::numeric_limits<std::size_t>::lowest(), std::numeric_limits<std::size_t>::max());
 
     for (stdgpu::index_t i = 0; i < iterations; ++i)
@@ -135,7 +135,7 @@ thread_ceil2_random(const stdgpu::index_t iterations)
     // Generate true random numbers
     std::size_t seed = test_utils::random_thread_seed();
 
-    std::default_random_engine rng(seed);
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_int_distribution<std::size_t> dist(std::numeric_limits<std::size_t>::lowest(), std::numeric_limits<std::size_t>::max());
 
     for (stdgpu::index_t i = 0; i < iterations; ++i)
@@ -175,7 +175,7 @@ thread_floor2_random(const stdgpu::index_t iterations)
     // Generate true random numbers
     std::size_t seed = test_utils::random_thread_seed();
 
-    std::default_random_engine rng(seed);
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_int_distribution<std::size_t> dist(std::numeric_limits<std::size_t>::lowest(), std::numeric_limits<std::size_t>::max());
 
     for (stdgpu::index_t i = 0; i < iterations; ++i)
@@ -213,7 +213,7 @@ thread_mod2_random(const stdgpu::index_t iterations,
     // Generate true random numbers
     std::size_t seed = test_utils::random_thread_seed();
 
-    std::default_random_engine rng(seed);
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_int_distribution<std::size_t> dist(std::numeric_limits<std::size_t>::lowest(), std::numeric_limits<std::size_t>::max());
 
     for (stdgpu::index_t i = 0; i < iterations; ++i)

--- a/test/stdgpu/cmath.cpp
+++ b/test/stdgpu/cmath.cpp
@@ -62,7 +62,7 @@ thread_positive_values(const stdgpu::index_t iterations)
 {
     size_t seed = test_utils::random_thread_seed();
 
-    std::default_random_engine rng(seed);
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_real_distribution<float> dist(std::numeric_limits<float>::min(), std::numeric_limits<float>::max());
 
     for (stdgpu::index_t i = 0; i < iterations; ++i)
@@ -88,7 +88,7 @@ thread_negative_values(const stdgpu::index_t iterations)
 {
     size_t seed = test_utils::random_thread_seed();
 
-    std::default_random_engine rng(seed);
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_real_distribution<float> dist(std::numeric_limits<float>::lowest(), -std::numeric_limits<float>::min());
 
     for (stdgpu::index_t i = 0; i < iterations; ++i)

--- a/test/stdgpu/cstdlib.cpp
+++ b/test/stdgpu/cstdlib.cpp
@@ -54,7 +54,7 @@ thread_values(const stdgpu::index_t iterations)
 {
     std::size_t seed = test_utils::random_thread_seed();
 
-    std::default_random_engine rng(seed);
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_int_distribution<std::size_t> dist_x(1, std::numeric_limits<long long int>::max());
     std::uniform_int_distribution<int> dist_y(1, std::numeric_limits<std::size_t>::digits);
 

--- a/test/stdgpu/functional.cpp
+++ b/test/stdgpu/functional.cpp
@@ -160,7 +160,10 @@ check_integer_random()
 {
     const stdgpu::index_t N = 1000000;
 
-    std::default_random_engine rng(test_utils::random_seed());
+    // Generate true random numbers
+    size_t seed = test_utils::random_seed();
+
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_int_distribution<T> dist(std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
 
     std::unordered_set<std::size_t> hashes;
@@ -218,7 +221,10 @@ check_floating_point_random()
 {
     const stdgpu::index_t N = 1000000;
 
-    std::default_random_engine rng(test_utils::random_seed());
+    // Generate true random numbers
+    size_t seed = test_utils::random_seed();
+
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_real_distribution<T> dist(static_cast<T>(-1e38), static_cast<T>(1e38));
 
     std::unordered_set<std::size_t> hashes;

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -81,7 +81,7 @@ namespace
         // Generate true random numbers
         size_t seed = test_utils::random_thread_seed();
 
-        std::default_random_engine rng(seed);
+        std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
         std::uniform_int_distribution<std::int16_t> dist(std::numeric_limits<std::int16_t>::lowest(), std::numeric_limits<std::int16_t>::max());
 
         for (stdgpu::index_t i = 0; i < iterations; ++i)
@@ -1441,7 +1441,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_one_free
     // Generate true random numbers
     size_t seed = test_utils::random_seed();
 
-    std::default_random_engine rng(seed);
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_int_distribution<std::int16_t> dist(std::numeric_limits<std::int16_t>::lowest(), std::numeric_limits<std::int16_t>::max());
 
     test_unordered_datastructure::key_type* host_positions = createHostArray<test_unordered_datastructure::key_type>(N);
@@ -1537,7 +1537,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, emplace_parallel_while_one_fre
     // Generate true random numbers
     size_t seed = test_utils::random_seed();
 
-    std::default_random_engine rng(seed);
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_int_distribution<std::int16_t> dist(std::numeric_limits<std::int16_t>::lowest(), std::numeric_limits<std::int16_t>::max());
 
     test_unordered_datastructure::key_type* host_positions = createHostArray<test_unordered_datastructure::key_type>(N);
@@ -1622,7 +1622,7 @@ namespace
         // Generate true random numbers
         size_t seed = test_utils::random_seed();
 
-        std::default_random_engine rng(seed);
+        std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
         std::uniform_int_distribution<std::int16_t> dist(std::numeric_limits<std::int16_t>::lowest(), std::numeric_limits<std::int16_t>::max());
 
         test_unordered_datastructure::key_type* host_positions = createHostArray<test_unordered_datastructure::key_type>(N);

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -27,6 +27,7 @@
 #include <utility>
 #include <vector>
 
+#include <stdgpu/attribute.h>
 #include <stdgpu/cstddef.h>
 
 
@@ -54,7 +55,9 @@ namespace test_utils
                 throw std::runtime_error("Entropy is 0.0");
             }
         }
-        catch (const std::exception& e)
+        // For some reason, this code fails to compile with NVCC+MSVC using the CUDA backend: STDGPU_MAYBE_UNUSED const std::exception& e
+        // Thus, use the version below to fix unused paramater warnings
+        catch (const std::exception&)
         {
 
         }


### PR DESCRIPTION
In contrast to GCC and Clang, the used warning level for MSVC was rather low. Enable more warnings for MSVC and fix the newly appearing ones in the unit tests.