### PR TITLE
cmake: Add option to treat warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ else()
     set(STDGPU_SETUP_COMPILER_FLAGS_DEFAULT OFF)
 endif()
 option(STDGPU_SETUP_COMPILER_FLAGS "Constructs the compiler flags, default: ON if standalone, OFF if included via add_subdirectory" ${STDGPU_SETUP_COMPILER_FLAGS_DEFAULT})
+option(STDGPU_TREAT_WARNINGS_AS_ERRORS "Treats compiler warnings as errors, default: OFF" OFF)
 
 if(STDGPU_SETUP_COMPILER_FLAGS)
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/${STDGPU_BACKEND_DIRECTORY}/set_device_flags.cmake")

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Build Option | Effect | Default
 --- | --- | ---
 `STDGPU_BACKEND` | Device system backend | `STDGPU_BACKEND_CUDA`
 `STDGPU_SETUP_COMPILER_FLAGS` | Constructs the compiler flags | `ON` if standalone, `OFF` if included via `add_subdirectory`
+`STDGPU_TREAT_WARNINGS_AS_ERRORS` | Treats compiler warnings as errors | `OFF`
 `STDGPU_BUILD_SHARED_LIBS` | Builds the project as a shared library, if set to `ON`, or as a static library, if set to `OFF` | `BUILD_SHARED_LIBS`
 `STDGPU_BUILD_EXAMPLES` | Build the examples | `ON`
 `STDGPU_BUILD_TESTS` | Build the unit tests | `ON`

--- a/cmake/config_summary.cmake
+++ b/cmake/config_summary.cmake
@@ -13,6 +13,7 @@ function(stdgpu_print_configuration_summary)
     message(STATUS "Build:")
     message(STATUS "  STDGPU_BACKEND                            :   ${STDGPU_BACKEND}")
     message(STATUS "  STDGPU_SETUP_COMPILER_FLAGS               :   ${STDGPU_SETUP_COMPILER_FLAGS} (depends on usage method)")
+    message(STATUS "  STDGPU_TREAT_WARNINGS_AS_ERRORS           :   ${STDGPU_TREAT_WARNINGS_AS_ERRORS}")
     message(STATUS "  STDGPU_BUILD_SHARED_LIBS                  :   ${STDGPU_BUILD_SHARED_LIBS} (depends on BUILD_SHARED_LIBS)")
 
     message(STATUS "")

--- a/cmake/cuda/set_device_flags.cmake
+++ b/cmake/cuda/set_device_flags.cmake
@@ -48,11 +48,20 @@ if(NOT MSVC)
     #string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wconversion")
     #string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wfloat-equal")
 
+    if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
+        string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Werror")
+    endif()
+
     if(${CMAKE_BUILD_TYPE} MATCHES "Release" OR ${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
         message(STATUS "Appended optimization flag (-O3,/O2) implicitly")
     endif()
 else()
     string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler /W2") # or /W3 or /W4 depending on how useful this is
+
+    if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
+        string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler /WX")
+    endif()
+
     #string(APPEND STDGPU_DEVICE_FLAGS " /O2")
 endif()
 

--- a/cmake/set_host_flags.cmake
+++ b/cmake/set_host_flags.cmake
@@ -8,11 +8,20 @@ if(NOT MSVC)
     string(APPEND STDGPU_HOST_FLAGS " -Wconversion")
     string(APPEND STDGPU_HOST_FLAGS " -Wfloat-equal")
 
+    if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
+        string(APPEND STDGPU_HOST_FLAGS " -Werror")
+    endif()
+
     if(${CMAKE_BUILD_TYPE} MATCHES "Release" OR ${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
         string(APPEND STDGPU_HOST_FLAGS " -O3")
     endif()
 else()
     string(APPEND STDGPU_HOST_FLAGS " /W2") # or /W3 or /W4 depending on how useful this is
+
+    if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
+        string(APPEND STDGPU_HOST_FLAGS " /WX")
+    endif()
+
     #string(APPEND STDGPU_HOST_FLAGS " /O2")
 endif()
 

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -102,6 +102,7 @@ Build Option | Effect | Default
 --- | --- | ---
 `STDGPU_BACKEND` | Device system backend | `STDGPU_BACKEND_CUDA`
 `STDGPU_SETUP_COMPILER_FLAGS` | Constructs the compiler flags | `ON` if standalone, `OFF` if included via `add_subdirectory`
+`STDGPU_TREAT_WARNINGS_AS_ERRORS` | Treats compiler warnings as errors | `OFF`
 `STDGPU_BUILD_SHARED_LIBS` | Builds the project as a shared library, if set to `ON`, or as a static library, if set to `OFF` | `BUILD_SHARED_LIBS`
 `STDGPU_BUILD_EXAMPLES` | Build the examples | `ON`
 `STDGPU_BUILD_TESTS` | Build the unit tests | `ON`

--- a/scripts/ci/configure_openmp_debug.sh
+++ b/scripts/ci/configure_openmp_debug.sh
@@ -8,4 +8,4 @@ sh scripts/utils/create_empty_directory.sh build
 sh scripts/utils/download_dependencies.sh
 
 # Configure project
-sh scripts/utils/configure_debug.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -Dthrust_ROOT=external/thrust
+sh scripts/utils/configure_debug.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_TREAT_WARNINGS_AS_ERRORS=ON -Dthrust_ROOT=external/thrust

--- a/scripts/ci/configure_openmp_release.sh
+++ b/scripts/ci/configure_openmp_release.sh
@@ -8,4 +8,4 @@ sh scripts/utils/create_empty_directory.sh build
 sh scripts/utils/download_dependencies.sh
 
 # Configure project
-sh scripts/utils/configure_release.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -Dthrust_ROOT=external/thrust
+sh scripts/utils/configure_release.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_TREAT_WARNINGS_AS_ERRORS=ON -Dthrust_ROOT=external/thrust


### PR DESCRIPTION
Many bugs in the project have been unveiled by increasing the warning level and handling all warnings in general. Add an option to tell the compiler to treat warnings as errors. This enables the CI to detect regressions and potentially unsafe changes more faithfully. By default, this option is set to `OFF` for backwards compatibility.