### PR TITLE
General: Add CI job for documentation creation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,3 +173,49 @@ jobs:
         script: |
             set -e
             bash <(curl -s https://codecov.io/bash) -f build/stdgpu_coverage.info
+
+- job:
+  displayName: Documentation OpenMP
+  pool:
+    vmImage: 'ubuntu-18.04'
+
+  steps:
+    - task: Bash@3
+      displayName: Install OpenMP
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/install_openmp_ubuntu1804.sh
+
+    - task: Bash@3
+      displayName: Install CMake 3.15+
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/install_cmake_ubuntu1804.sh
+
+    - task: Bash@3
+      displayName: Install doxygen
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/install_doxygen_ubuntu1804.sh
+
+    - task: Bash@3
+      displayName: Configure project
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/ci/configure_openmp_release.sh
+
+    - task: Bash@3
+      displayName: Build documentation
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/create_documentation.sh

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -10,6 +10,12 @@ find_package(Doxygen 1.8.13)
 if(Doxygen_FOUND)
     set(STDGPU_HAVE_DOXYGEN ON CACHE BOOL "Support for documentation generation using Doxygen" FORCE)
 
+    if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
+        set(STDGPU_DOXYGEN_WARN_AS_ERROR YES)
+    else()
+        set(STDGPU_DOXYGEN_WARN_AS_ERROR NO)
+    endif()
+
     set(STDGPU_DOXYFILE_IN "${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in")
     set(STDGPU_DOXYFILE "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile")
     set(STDGPU_DOC_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}")

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -754,7 +754,7 @@ WARN_NO_PARAMDOC       = YES
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = @STDGPU_DOXYGEN_WARN_AS_ERROR@
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/scripts/utils/install_doxygen_ubuntu1804.sh
+++ b/scripts/utils/install_doxygen_ubuntu1804.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+# Install doxygen
+sudo apt-get update
+sudo apt-get install doxygen


### PR DESCRIPTION
In #108, an option was added to treat warnings as errors. Since doxygen has a similar option, namely `WARN_AS_ERROR`, bugs in the documentation such as missing documentation or spelling errors can now also be detected. Add a respective CI job to catch any documentation-related compilation warnings.