### PR TITLE
bit: Rename functions to match most recent draft of C++20

### DIFF
--- a/src/stdgpu/bit.h
+++ b/src/stdgpu/bit.h
@@ -36,7 +36,7 @@ namespace stdgpu
  */
 template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
 STDGPU_HOST_DEVICE bool
-ispow2(const T number);
+has_single_bit(const T number);
 
 /**
  * \brief Computes the smallest power of two which is larger or equal than the given number
@@ -45,7 +45,7 @@ ispow2(const T number);
  */
 template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
 STDGPU_HOST_DEVICE T
-ceil2(const T number);
+bit_ceil(const T number);
 
 /**
  * \brief Computes the largest power of two which is smaller or equal than the given number
@@ -54,31 +54,30 @@ ceil2(const T number);
  */
 template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
 STDGPU_HOST_DEVICE T
-floor2(const T number);
+bit_floor(const T number);
 
 /**
  * \brief Computes the modulus of the given number and a power of two divider
  * \param[in] number A number
  * \param[in] divider The divider with divider = 2^n
  * \return The modulos of the given number and divider
- * \pre ispow2(divider)
+ * \pre has_single_bit(divider)
  * \post result >= 0
  * \post result < divider
  */
 template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
 STDGPU_HOST_DEVICE T
-mod2(const T number,
-     const T divider);
+bit_mod(const T number,
+        const T divider);
 
 /**
- * \brief Computes the base-2 logarithm of a power of two
+ * \brief Computes the smallest number of bits to represent the given number
  * \param[in] number A number
- * \return The base-2 logarithm of the number
- * \pre ispow2(divider)
+ * \return The smallest number of bits to represent the given number
  */
 template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
 STDGPU_HOST_DEVICE T
-log2pow2(const T number);
+bit_width(const T number);
 
 /**
  * \brief Counts the number of set bits in the number
@@ -88,6 +87,47 @@ log2pow2(const T number);
 template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
 STDGPU_HOST_DEVICE int
 popcount(const T number);
+
+
+// Deprecated classes and functions
+/**
+ * \deprecated Replaced by has_single_bit
+ * \brief Determines whether the number is a power of two
+ * \param[in] number A number
+ * \return True if number is a power of two, false otherwise
+ */
+template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
+[[deprecated("Replaced by has_single_bit")]]
+STDGPU_HOST_DEVICE bool
+ispow2(const T number);
+
+/**
+ * \deprecated Replaced by bit_mod
+ * \brief Computes the modulus of the given number and a power of two divider
+ * \param[in] number A number
+ * \param[in] divider The divider with divider = 2^n
+ * \return The modulos of the given number and divider
+ * \pre ispow2(divider)
+ * \post result >= 0
+ * \post result < divider
+ */
+template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
+[[deprecated("Replaced by bit_mod")]]
+STDGPU_HOST_DEVICE T
+mod2(const T number,
+     const T divider);
+
+/**
+ * \deprecated Replaced by bit_width
+ * \brief Computes the base-2 logarithm of a power of two
+ * \param[in] number A number
+ * \return The base-2 logarithm of the number
+ * \pre ispow2(divider)
+ */
+template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
+[[deprecated("Replaced by bit_width")]]
+STDGPU_HOST_DEVICE T
+log2pow2(const T number);
 
 } // namespace stdgpu
 

--- a/src/stdgpu/cstdlib.h
+++ b/src/stdgpu/cstdlib.h
@@ -44,7 +44,7 @@ struct sizediv_t
  * \param[in] y The divider with y = 2^n
  * \return The resulting quotient and remainder
  * \pre y > 0
- * \pre ispow2(y)
+ * \pre has_single_bit(y)
  * \post result.quot * y + result.rem == x
  */
 STDGPU_HOST_DEVICE sizediv_t

--- a/src/stdgpu/cuda/bit.cuh
+++ b/src/stdgpu/cuda/bit.cuh
@@ -25,22 +25,21 @@ namespace cuda
 {
 
 /**
- * \brief Computes the base-2 logarithm of a power of two
+ * \brief Computes the smallest number of bits to represent the given number
  * \param[in] number A number
- * \return The base-2 logarithm of the number
+ * \return The smallest number of bits to represent the given number
  */
 STDGPU_DEVICE_ONLY unsigned int
-log2pow2(const unsigned int number);
+bit_width(const unsigned int number);
 
 
 /**
- * \brief Computes the base-2 logarithm of a power of two
+ * \brief Computes the smallest number of bits to represent the given number
  * \param[in] number A number
- * \return The base-2 logarithm of the number
- * \pre ispow2(divider)
+ * \return The smallest number of bits to represent the given number
  */
 STDGPU_DEVICE_ONLY unsigned long long int
-log2pow2(const unsigned long long int number);
+bit_width(const unsigned long long int number);
 
 
 /**

--- a/src/stdgpu/cuda/impl/bit_detail.cuh
+++ b/src/stdgpu/cuda/impl/bit_detail.cuh
@@ -25,16 +25,16 @@ namespace cuda
 {
 
 inline STDGPU_DEVICE_ONLY unsigned int
-log2pow2(const unsigned int number)
+bit_width(const unsigned int number)
 {
-    return __ffs(number) - 1;
+    return __ffs(number);
 }
 
 
 inline STDGPU_DEVICE_ONLY unsigned long long int
-log2pow2(const unsigned long long int number)
+bit_width(const unsigned long long int number)
 {
-    return __ffsll(number) - 1;
+    return __ffsll(number);
 }
 
 

--- a/src/stdgpu/impl/cstdlib_detail.h
+++ b/src/stdgpu/impl/cstdlib_detail.h
@@ -32,7 +32,7 @@ sizedivPow2(const std::size_t x,
 
     sizediv_t result;
     result.quot = x / y;
-    result.rem  = mod2(x, y);
+    result.rem  = bit_mod(x, y);
 
     STDGPU_ENSURES(result.quot * y + result.rem == x);
 

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -338,7 +338,7 @@ unordered_map<Key, T, Hash, KeyEqual>::createDeviceObject(const index_t& bucket_
 {
     STDGPU_EXPECTS(bucket_count > 0);
     STDGPU_EXPECTS(excess_count > 0);
-    STDGPU_EXPECTS(ispow2<std::size_t>(static_cast<std::size_t>(bucket_count)));
+    STDGPU_EXPECTS(has_single_bit<std::size_t>(static_cast<std::size_t>(bucket_count)));
 
     unordered_map<Key, T, Hash, KeyEqual> result;
     result._base = detail::unordered_base<key_type, value_type, detail::select1st<value_type>, hasher, key_equal>::createDeviceObject(bucket_count, excess_count);

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -323,7 +323,7 @@ unordered_set<Key, Hash, KeyEqual>::createDeviceObject(const index_t& bucket_cou
 {
     STDGPU_EXPECTS(bucket_count > 0);
     STDGPU_EXPECTS(excess_count > 0);
-    STDGPU_EXPECTS(ispow2<std::size_t>(static_cast<std::size_t>(bucket_count)));
+    STDGPU_EXPECTS(has_single_bit<std::size_t>(static_cast<std::size_t>(bucket_count)));
 
     unordered_set<Key, Hash, KeyEqual> result;
     result._base = detail::unordered_base<key_type, value_type, thrust::identity<key_type>, hasher, key_equal>::createDeviceObject(bucket_count, excess_count);

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -105,7 +105,7 @@ class unordered_map
          * \param[in] excess_count The number of excess entries
          * \pre bucket_count > 0
          * \pre excess_count > 0
-         * \pre ispow2(bucket_count)
+         * \pre has_single_bit(bucket_count)
          * \return A newly created object of this class allocated on the GPU (device)
          */
         [[deprecated("Replaced by createDeviceObject(const index_t& capacity)")]]

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -93,7 +93,7 @@ class unordered_set
          * \param[in] excess_count The number of excess entries
          * \pre bucket_count > 0
          * \pre excess_count > 0
-         * \pre ispow2(bucket_count)
+         * \pre has_single_bit(bucket_count)
          * \return A newly created object of this class allocated on the GPU (device)
          */
         [[deprecated("Replaced by createDeviceObject(const index_t& capacity)")]]

--- a/test/stdgpu/bit.cpp
+++ b/test/stdgpu/bit.cpp
@@ -49,30 +49,30 @@ namespace stdgpu
 
 template
 STDGPU_HOST_DEVICE bool
-ispow2<unsigned int>(const unsigned int);
+has_single_bit<unsigned int>(const unsigned int);
 
 template
 STDGPU_HOST_DEVICE unsigned int
-ceil2<unsigned int>(const unsigned int);
+bit_ceil<unsigned int>(const unsigned int);
 
 template
 STDGPU_HOST_DEVICE unsigned int
-floor2<unsigned int>(const unsigned int);
+bit_floor<unsigned int>(const unsigned int);
 
 template
 STDGPU_HOST_DEVICE unsigned int
-mod2<unsigned int>(const unsigned int,
-                   const unsigned int);
+bit_mod<unsigned int>(const unsigned int,
+                      const unsigned int);
 
 // Instantiation of specialized templates emit no-effect warnings with Clang
 /*
 template
 STDGPU_HOST_DEVICE unsigned int
-log2pow2<unsigned int>(const unsigned int number);
+bit_width<unsigned int>(const unsigned int number);
 
 template
 STDGPU_HOST_DEVICE unsigned long long int
-log2pow2<unsigned long long int>(const unsigned long long int);
+bit_width<unsigned long long int>(const unsigned long long int);
 
 template
 STDGPU_HOST_DEVICE int
@@ -84,6 +84,237 @@ popcount<unsigned long long int>(const unsigned long long int);
 */
 
 } // namespace stdgpu
+
+
+void
+thread_has_single_bit_random(const stdgpu::index_t iterations,
+                             const std::unordered_set<std::size_t>& pow2_list)
+{
+    // Generate true random numbers
+    std::size_t seed = test_utils::random_thread_seed();
+
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
+    std::uniform_int_distribution<std::size_t> dist(std::numeric_limits<std::size_t>::lowest(), std::numeric_limits<std::size_t>::max());
+
+    for (stdgpu::index_t i = 0; i < iterations; ++i)
+    {
+        std::size_t number = dist(rng);
+
+        if (pow2_list.find(number) == pow2_list.end())
+        {
+            EXPECT_FALSE(stdgpu::has_single_bit(number));
+        }
+    }
+}
+
+
+TEST_F(stdgpu_bit, has_single_bit)
+{
+    std::unordered_set<std::size_t> pow2_list;
+    for (std::size_t i = 0; i < std::numeric_limits<std::size_t>::digits; ++i)
+    {
+        std::size_t pow2_i = static_cast<std::size_t>(1) << i;
+
+        ASSERT_TRUE(stdgpu::has_single_bit(pow2_i));
+
+        pow2_list.insert(pow2_i);
+    }
+
+
+    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+
+    test_utils::for_each_concurrent_thread(&thread_has_single_bit_random,
+                                           iterations_per_thread,
+                                           pow2_list);
+}
+
+
+void
+thread_bit_ceil_random(const stdgpu::index_t iterations)
+{
+    // Generate true random numbers
+    std::size_t seed = test_utils::random_thread_seed();
+
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
+    std::uniform_int_distribution<std::size_t> dist(std::numeric_limits<std::size_t>::lowest(), static_cast<std::size_t>(1) << (std::numeric_limits<std::size_t>::digits - 1));
+
+    for (stdgpu::index_t i = 0; i < iterations; ++i)
+    {
+        std::size_t number = dist(rng);
+
+        std::size_t result = stdgpu::bit_ceil(number);
+
+        EXPECT_TRUE(stdgpu::has_single_bit(result));
+        EXPECT_GE(result, number);
+        EXPECT_LT(result / 2, number);
+    }
+}
+
+
+TEST_F(stdgpu_bit, bit_ceil_random)
+{
+    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+
+    test_utils::for_each_concurrent_thread(&thread_bit_ceil_random,
+                                           iterations_per_thread);
+}
+
+
+TEST_F(stdgpu_bit, bit_ceil_zero)
+{
+    EXPECT_EQ(stdgpu::bit_ceil(static_cast<std::size_t>(0)), static_cast<std::size_t>(1));
+}
+
+
+void
+thread_bit_floor_random(const stdgpu::index_t iterations)
+{
+    // Generate true random numbers
+    std::size_t seed = test_utils::random_thread_seed();
+
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
+    std::uniform_int_distribution<std::size_t> dist(std::numeric_limits<std::size_t>::lowest(), std::numeric_limits<std::size_t>::max());
+
+    for (stdgpu::index_t i = 0; i < iterations; ++i)
+    {
+        std::size_t number = dist(rng);
+
+        std::size_t result = stdgpu::bit_floor(number);
+
+        EXPECT_TRUE(stdgpu::has_single_bit(result));
+        EXPECT_LE(result, number);
+        EXPECT_GT(result, number / 2);
+    }
+}
+
+
+TEST_F(stdgpu_bit, bit_floor_random)
+{
+    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+
+    test_utils::for_each_concurrent_thread(&thread_bit_floor_random,
+                                           iterations_per_thread);
+}
+
+
+TEST_F(stdgpu_bit, bit_floor_zero)
+{
+    EXPECT_EQ(stdgpu::bit_floor(static_cast<std::size_t>(0)), static_cast<std::size_t>(0));
+}
+
+
+void
+thread_bit_mod_random(const stdgpu::index_t iterations,
+                      const std::size_t divider)
+{
+    // Generate true random numbers
+    std::size_t seed = test_utils::random_thread_seed();
+
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
+    std::uniform_int_distribution<std::size_t> dist(std::numeric_limits<std::size_t>::lowest(), std::numeric_limits<std::size_t>::max());
+
+    for (stdgpu::index_t i = 0; i < iterations; ++i)
+    {
+        std::size_t number = dist(rng);
+        EXPECT_EQ(stdgpu::bit_mod(number, divider), number % divider);
+    }
+}
+
+
+TEST_F(stdgpu_bit, bit_mod_random)
+{
+    const std::size_t divider = static_cast<std::size_t>(pow(2, 21));
+    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+
+    test_utils::for_each_concurrent_thread(&thread_bit_mod_random,
+                                           iterations_per_thread,
+                                           divider);
+}
+
+
+TEST_F(stdgpu_bit, bit_mod_one_positive)
+{
+    std::size_t number       = 42;
+    std::size_t divider      = 1;
+    EXPECT_EQ(stdgpu::bit_mod(number, divider), static_cast<std::size_t>(0));
+}
+
+
+TEST_F(stdgpu_bit, bit_mod_one_zero)
+{
+    std::size_t number       = 0;
+    std::size_t divider      = 1;
+    EXPECT_EQ(stdgpu::bit_mod(number, divider), static_cast<std::size_t>(0));
+}
+
+
+void
+thread_bit_width_random(const stdgpu::index_t iterations)
+{
+    // Generate true random numbers
+    std::size_t seed = test_utils::random_thread_seed();
+
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
+    std::uniform_int_distribution<std::size_t> dist(static_cast<std::size_t>(1), std::numeric_limits<std::size_t>::max());
+
+    for (stdgpu::index_t i = 0; i < iterations; ++i)
+    {
+        std::size_t number = dist(rng);
+
+        std::size_t result = stdgpu::bit_width(number);
+
+        EXPECT_GT(result, static_cast<std::size_t>(0));
+        EXPECT_LE(result, static_cast<std::size_t>(std::numeric_limits<std::size_t>::digits));
+
+        std::size_t number_lower_bound = static_cast<std::size_t>(1) << (result - 1);
+        EXPECT_GE(number, number_lower_bound);
+
+        if (number < static_cast<std::size_t>(1) << (std::numeric_limits<std::size_t>::digits - 1))
+        {
+            std::size_t number_upper_bound = static_cast<std::size_t>(1) << result;
+            EXPECT_LT(number, number_upper_bound);
+        }
+    }
+}
+
+
+TEST_F(stdgpu_bit, bit_width_random)
+{
+    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+
+    test_utils::for_each_concurrent_thread(&thread_bit_width_random,
+                                           iterations_per_thread);
+}
+
+
+TEST_F(stdgpu_bit, bit_width_zero)
+{
+    EXPECT_EQ(stdgpu::bit_width(static_cast<std::size_t>(0)), static_cast<std::size_t>(0));
+}
+
+
+TEST_F(stdgpu_bit, popcount_zero)
+{
+    EXPECT_EQ(stdgpu::popcount(static_cast<std::size_t>(0)), 0);
+}
+
+
+TEST_F(stdgpu_bit, popcount_pow2)
+{
+    for (std::size_t i = 0; i < std::numeric_limits<std::size_t>::digits; ++i)
+    {
+        EXPECT_EQ(stdgpu::popcount(static_cast<std::size_t>(1) << i), 1);
+    }
+}
+
+
+TEST_F(stdgpu_bit, popcount_pow2m1)
+{
+    for (std::size_t i = 0; i < std::numeric_limits<std::size_t>::digits; ++i)
+    {
+        EXPECT_EQ(stdgpu::popcount((static_cast<std::size_t>(1) << i) - 1), i);
+    }
+}
 
 
 void
@@ -126,83 +357,6 @@ TEST_F(stdgpu_bit, ispow2)
     test_utils::for_each_concurrent_thread(&thread_ispow2_random,
                                            iterations_per_thread,
                                            pow2_list);
-}
-
-
-void
-thread_ceil2_random(const stdgpu::index_t iterations)
-{
-    // Generate true random numbers
-    std::size_t seed = test_utils::random_thread_seed();
-
-    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
-    std::uniform_int_distribution<std::size_t> dist(std::numeric_limits<std::size_t>::lowest(), std::numeric_limits<std::size_t>::max());
-
-    for (stdgpu::index_t i = 0; i < iterations; ++i)
-    {
-        std::size_t number = dist(rng);
-
-        // result will not be representable, so skip this sample
-        if (number > static_cast<std::size_t>(1) << (std::numeric_limits<std::size_t>::digits - 1)) continue;
-
-        std::size_t result = stdgpu::ceil2(number);
-
-        EXPECT_TRUE(stdgpu::ispow2(result));
-        EXPECT_GE(result, number);
-        EXPECT_LT(result / 2, number);
-    }
-}
-
-
-TEST_F(stdgpu_bit, ceil2_random)
-{
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
-
-    test_utils::for_each_concurrent_thread(&thread_ceil2_random,
-                                           iterations_per_thread);
-}
-
-
-TEST_F(stdgpu_bit, ceil2_zero)
-{
-    EXPECT_EQ(stdgpu::ceil2(static_cast<std::size_t>(0)), static_cast<std::size_t>(1));
-}
-
-
-void
-thread_floor2_random(const stdgpu::index_t iterations)
-{
-    // Generate true random numbers
-    std::size_t seed = test_utils::random_thread_seed();
-
-    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
-    std::uniform_int_distribution<std::size_t> dist(std::numeric_limits<std::size_t>::lowest(), std::numeric_limits<std::size_t>::max());
-
-    for (stdgpu::index_t i = 0; i < iterations; ++i)
-    {
-        std::size_t number = dist(rng);
-
-        std::size_t result = stdgpu::floor2(number);
-
-        EXPECT_TRUE(stdgpu::ispow2(result));
-        EXPECT_LE(result, number);
-        EXPECT_GT(result, number / 2);
-    }
-}
-
-
-TEST_F(stdgpu_bit, floor2_random)
-{
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
-
-    test_utils::for_each_concurrent_thread(&thread_floor2_random,
-                                           iterations_per_thread);
-}
-
-
-TEST_F(stdgpu_bit, floor2_zero)
-{
-    EXPECT_EQ(stdgpu::floor2(static_cast<std::size_t>(0)), static_cast<std::size_t>(0));
 }
 
 
@@ -256,30 +410,6 @@ TEST_F(stdgpu_bit, log2pow2)
     for (std::size_t i = 0; i < std::numeric_limits<std::size_t>::digits; ++i)
     {
         EXPECT_EQ(stdgpu::log2pow2(static_cast<std::size_t>(1) << i), static_cast<std::size_t>(i));
-    }
-}
-
-
-TEST_F(stdgpu_bit, popcount_zero)
-{
-    EXPECT_EQ(stdgpu::popcount(static_cast<std::size_t>(0)), 0);
-}
-
-
-TEST_F(stdgpu_bit, popcount_pow2)
-{
-    for (std::size_t i = 0; i < std::numeric_limits<std::size_t>::digits; ++i)
-    {
-        EXPECT_EQ(stdgpu::popcount(static_cast<std::size_t>(1) << i), 1);
-    }
-}
-
-
-TEST_F(stdgpu_bit, popcount_pow2m1)
-{
-    for (std::size_t i = 0; i < std::numeric_limits<std::size_t>::digits; ++i)
-    {
-        EXPECT_EQ(stdgpu::popcount((static_cast<std::size_t>(1) << i) - 1), i);
     }
 }
 

--- a/test/stdgpu/cuda/bit.cu
+++ b/test/stdgpu/cuda/bit.cu
@@ -42,29 +42,29 @@ class stdgpu_cuda_bit : public ::testing::Test
 };
 
 
-struct log2pow2_functor
+struct bit_width_functor
 {
     STDGPU_DEVICE_ONLY size_t
     operator()(const size_t i) const
     {
-        return stdgpu::cuda::log2pow2(static_cast<unsigned long long>(1) << i);
+        return stdgpu::cuda::bit_width(static_cast<unsigned long long>(1) << i);
     }
 };
 
-TEST_F(stdgpu_cuda_bit, log2pow2)
+TEST_F(stdgpu_cuda_bit, bit_width)
 {
     size_t* powers = createDeviceArray<size_t>(std::numeric_limits<size_t>::digits);
     thrust::sequence(stdgpu::device_begin(powers), stdgpu::device_end(powers));
 
     thrust::transform(stdgpu::device_begin(powers), stdgpu::device_end(powers),
                       stdgpu::device_begin(powers),
-                      log2pow2_functor());
+                      bit_width_functor());
 
     size_t* host_powers = copyCreateDevice2HostArray<size_t>(powers, std::numeric_limits<size_t>::digits);
 
     for (size_t i = 0; i < std::numeric_limits<size_t>::digits; ++i)
     {
-        EXPECT_EQ(host_powers[i], static_cast<size_t>(i));
+        EXPECT_EQ(host_powers[i], static_cast<size_t>(i + 1));
     }
 
     destroyDeviceArray<size_t>(powers);


### PR DESCRIPTION
In the most recent draft of the upcoming C++20 standard, the functions in `<bit>` have been renamed to better highlight their intention. Apply these changes also to our GPU-capable `bit.h` header and deprecate the old versions. For the recently introduced `floor2` and `ceil2` functions, we can simply rename them since they are not contained in any released version yet.