### PR TITLE
bit,bitset: Fix missing post-conditions and remove unnecessary dependency

### DIFF
--- a/src/stdgpu/bit.h
+++ b/src/stdgpu/bit.h
@@ -74,6 +74,8 @@ bit_mod(const T number,
  * \brief Computes the smallest number of bits to represent the given number
  * \param[in] number A number
  * \return The smallest number of bits to represent the given number
+ * \post result >= 0
+ * \post result <= numeric_limits<T>::digits
  */
 template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
 STDGPU_HOST_DEVICE T
@@ -83,6 +85,8 @@ bit_width(const T number);
  * \brief Counts the number of set bits in the number
  * \param[in] number A number
  * \return The number of set bits
+ * \post result >= 0
+ * \post result <= numeric_limits<T>::digits
  */
 template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
 STDGPU_HOST_DEVICE int

--- a/src/stdgpu/impl/bit_detail.h
+++ b/src/stdgpu/impl/bit_detail.h
@@ -45,6 +45,9 @@ bit_width(T number)
     {
         ++result;
     }
+
+    STDGPU_ENSURES(result <= static_cast<T>(numeric_limits<T>::digits));
+
     return result;
 }
 
@@ -58,6 +61,10 @@ popcount(T number)
         // Clear the least significant bit set
         number &= number - 1;
     }
+
+    STDGPU_ENSURES(0 <= result);
+    STDGPU_ENSURES(result <= numeric_limits<T>::digits);
+
     return result;
 }
 
@@ -82,7 +89,7 @@ bit_ceil(const T number)
     result += (result == 0);
 
     result--;
-    for (index_t i = 0; i < stdgpu::numeric_limits<T>::digits; ++i)
+    for (index_t i = 0; i < numeric_limits<T>::digits; ++i)
     {
         result |= result >> i;
     }
@@ -104,7 +111,7 @@ bit_floor(const T number)
     if (number == 0) return 0;
 
     T result = number;
-    for (index_t i = 0; i < stdgpu::numeric_limits<T>::digits; ++i)
+    for (index_t i = 0; i < numeric_limits<T>::digits; ++i)
     {
         result |= result >> i;
     }

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -19,7 +19,6 @@
 #include <stdgpu/atomic.cuh>
 #include <stdgpu/contract.h>
 #include <stdgpu/cstdlib.h>
-#include <stdgpu/limits.h>
 
 
 
@@ -40,7 +39,7 @@ inline STDGPU_DEVICE_ONLY bool
 bitset::reference::operator=(bool x)
 {
     block_type set_pattern = static_cast<block_type>(1) << _bit_n;
-    block_type reset_pattern = numeric_limits<block_type>::max() - set_pattern;
+    block_type reset_pattern = ~set_pattern;
 
     block_type old;
     stdgpu::atomic_ref<block_type> bit_block(*_bit_block);


### PR DESCRIPTION
Some functions in the `bit` module do not specify relevant post conditions. Fix this issue and cleanup an unnecessary dependency of `bitset` to `limits`. 