### PR TITLE
CI: Fix codecov task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,7 @@ jobs:
         targetType: 'inline'
         script: |
             set -e
-            bash <(curl -s https://codecov.io/bash) -f build/stdgpu_coverage.info
+            bash <(curl -s https://codecov.io/bash) -Z -t $(codecov_upload_token) -f build/stdgpu_coverage.info
 
 - job:
   displayName: Documentation OpenMP


### PR DESCRIPTION
Recently, the codecov task defined in the Azure Pipelines CI YAML file silently failed since something regarding the upload token seems to have changed for pull requests. Independently of being a potential regression in Azure Pipelines CI or codecov CI, this issue can be addressed on our side by explicitly passing the upload token to the upload script. This makes the CI task more robust. In addition to that, also tell the upload script to return failure (i.e. 1) if the uploading process failed.