### PR TITLE
src,test: Improve consistency and cleanup includes

### DIFF
--- a/src/stdgpu/cuda/impl/memory.cpp
+++ b/src/stdgpu/cuda/impl/memory.cpp
@@ -31,7 +31,7 @@ namespace cuda
  * \brief A macro that automatically sets information about the caller
  * \param[in] error A CUDA error object
  */
-#define STDGPU_DETAIL_SAFE_CALL(error) stdgpu::cuda::safe_call(error, __FILE__, __LINE__, STDGPU_FUNC)
+#define STDGPU_CUDA_SAFE_CALL(error) stdgpu::cuda::safe_call(error, __FILE__, __LINE__, STDGPU_FUNC)
 
 
 /**
@@ -68,19 +68,19 @@ dispatch_malloc(const dynamic_memory_type type,
     {
         case dynamic_memory_type::device :
         {
-            STDGPU_DETAIL_SAFE_CALL(cudaMalloc(array, static_cast<std::size_t>(bytes)));
+            STDGPU_CUDA_SAFE_CALL(cudaMalloc(array, static_cast<std::size_t>(bytes)));
         }
         break;
 
         case dynamic_memory_type::host :
         {
-            STDGPU_DETAIL_SAFE_CALL(cudaMallocHost(array, static_cast<std::size_t>(bytes)));
+            STDGPU_CUDA_SAFE_CALL(cudaMallocHost(array, static_cast<std::size_t>(bytes)));
         }
         break;
 
         case dynamic_memory_type::managed :
         {
-            STDGPU_DETAIL_SAFE_CALL(cudaMallocManaged(array, static_cast<std::size_t>(bytes)));
+            STDGPU_CUDA_SAFE_CALL(cudaMallocManaged(array, static_cast<std::size_t>(bytes)));
         }
         break;
 
@@ -100,19 +100,19 @@ dispatch_free(const dynamic_memory_type type,
     {
         case dynamic_memory_type::device :
         {
-            STDGPU_DETAIL_SAFE_CALL(cudaFree(array));
+            STDGPU_CUDA_SAFE_CALL(cudaFree(array));
         }
         break;
 
         case dynamic_memory_type::host :
         {
-            STDGPU_DETAIL_SAFE_CALL(cudaFreeHost(array));
+            STDGPU_CUDA_SAFE_CALL(cudaFreeHost(array));
         }
         break;
 
         case dynamic_memory_type::managed :
         {
-            STDGPU_DETAIL_SAFE_CALL(cudaFree(array));
+            STDGPU_CUDA_SAFE_CALL(cudaFree(array));
         }
         break;
 
@@ -160,7 +160,7 @@ dispatch_memcpy(void* destination,
         return;
     }
 
-    STDGPU_DETAIL_SAFE_CALL(cudaMemcpy(destination, source, static_cast<std::size_t>(bytes), kind));
+    STDGPU_CUDA_SAFE_CALL(cudaMemcpy(destination, source, static_cast<std::size_t>(bytes), kind));
 }
 
 
@@ -169,7 +169,7 @@ workaround_synchronize_device_thrust()
 {
     // We need to synchronize the device before exiting the calling function
     #if THRUST_VERSION <= 100903    // CUDA 10.0 and below
-        STDGPU_DETAIL_SAFE_CALL(cudaDeviceSynchronize());
+        STDGPU_CUDA_SAFE_CALL(cudaDeviceSynchronize());
     #endif
 }
 
@@ -180,12 +180,12 @@ workaround_synchronize_managed_memory()
     // We need to synchronize the whole device before accessing managed memory on pre-Pascal GPUs
     int current_device;
     int hash_concurrent_managed_access;
-    STDGPU_DETAIL_SAFE_CALL( cudaGetDevice(&current_device) );
-    STDGPU_DETAIL_SAFE_CALL( cudaDeviceGetAttribute( &hash_concurrent_managed_access, cudaDevAttrConcurrentManagedAccess, current_device ) );
+    STDGPU_CUDA_SAFE_CALL( cudaGetDevice(&current_device) );
+    STDGPU_CUDA_SAFE_CALL( cudaDeviceGetAttribute( &hash_concurrent_managed_access, cudaDevAttrConcurrentManagedAccess, current_device ) );
     if(hash_concurrent_managed_access == 0)
     {
         printf("stdgpu::cuda::workaround_synchronize_managed_memory : Synchronizing the whole GPU in order to access the data on the host ...\n");
-        STDGPU_DETAIL_SAFE_CALL(cudaDeviceSynchronize());
+        STDGPU_CUDA_SAFE_CALL(cudaDeviceSynchronize());
     }
 }
 

--- a/src/stdgpu/impl/iterator_detail.h
+++ b/src/stdgpu/impl/iterator_detail.h
@@ -18,6 +18,8 @@
 
 #include <cstdio>
 #include <type_traits>
+#include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/iterator_adaptor.h>
 
 
 

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -315,18 +315,14 @@ allocation_manager::valid() const
 void
 workaround_synchronize_device_thrust()
 {
-    #if STDGPU_BACKEND == STDGPU_BACKEND_CUDA
-        stdgpu::STDGPU_BACKEND_NAMESPACE::workaround_synchronize_device_thrust();
-    #endif
+    stdgpu::STDGPU_BACKEND_NAMESPACE::workaround_synchronize_device_thrust();
 }
 
 
 void
 workaround_synchronize_managed_memory()
 {
-    #if STDGPU_BACKEND == STDGPU_BACKEND_CUDA
-        stdgpu::STDGPU_BACKEND_NAMESPACE::workaround_synchronize_managed_memory();
-    #endif
+    stdgpu::STDGPU_BACKEND_NAMESPACE::workaround_synchronize_managed_memory();
 }
 
 

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -15,8 +15,6 @@
 
 #include <stdgpu/memory.h>
 
-#include <atomic>
-#include <condition_variable>
 #include <cstdio>
 #include <map>
 #include <mutex>

--- a/src/stdgpu/iterator.h
+++ b/src/stdgpu/iterator.h
@@ -22,8 +22,6 @@
 
 #include <thrust/detail/pointer.h>
 #include <thrust/detail/reference.h> // Only forward declaration included by thrust/detail/pointer.h
-#include <thrust/iterator/discard_iterator.h>
-#include <thrust/iterator/iterator_adaptor.h>
 
 #include <stdgpu/cstddef.h>
 #include <stdgpu/platform.h>

--- a/src/stdgpu/openmp/impl/memory.cpp
+++ b/src/stdgpu/openmp/impl/memory.cpp
@@ -90,6 +90,20 @@ dispatch_memcpy(void* destination,
 }
 
 
+void
+workaround_synchronize_device_thrust()
+{
+    // No synchronization workaround required for OpenMP backend
+}
+
+
+void
+workaround_synchronize_managed_memory()
+{
+    // No synchronization workaround required for OpenMP backend
+}
+
+
 } // namespace openmp
 
 } // namespace stdgpu

--- a/src/stdgpu/openmp/impl/memory.cpp
+++ b/src/stdgpu/openmp/impl/memory.cpp
@@ -16,9 +16,8 @@
 #include <stdgpu/openmp/memory.h>
 
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
-#include <exception>
-#include <memory>
 
 
 

--- a/src/stdgpu/openmp/memory.h
+++ b/src/stdgpu/openmp/memory.h
@@ -64,6 +64,21 @@ dispatch_memcpy(void* destination,
                 dynamic_memory_type destination_type,
                 dynamic_memory_type source_type);
 
+
+/**
+ * \brief Workarounds a synchronization issue with older versions of thrust
+ */
+void
+workaround_synchronize_device_thrust();
+
+
+/**
+ * \brief Workarounds a synchronization issue with older GPUs
+ */
+void
+workaround_synchronize_managed_memory();
+
+
 } // namespace openmp
 
 } // namespace stdgpu

--- a/test/stdgpu/cuda/device_info.h
+++ b/test/stdgpu/cuda/device_info.h
@@ -13,19 +13,8 @@
  *  limitations under the License.
  */
 
-#ifndef DEVICE_INFO_H
-#define DEVICE_INFO_H
-
-#include <chrono>
-#include <cstddef>
-#include <random>
-#include <string>
-#include <stdexcept>
-#include <thread>
-#include <utility>
-#include <vector>
-
-#include <stdgpu/cstddef.h>
+#ifndef STDGPU_CUDA_DEVICE_INFO_H
+#define STDGPU_CUDA_DEVICE_INFO_H
 
 
 
@@ -47,4 +36,4 @@ print_device_information();
 
 
 
-#endif // DEVICE_INFO_H
+#endif // STDGPU_CUDA_DEVICE_INFO_H

--- a/test/stdgpu/openmp/device_info.h
+++ b/test/stdgpu/openmp/device_info.h
@@ -13,19 +13,8 @@
  *  limitations under the License.
  */
 
-#ifndef DEVICE_INFO_H
-#define DEVICE_INFO_H
-
-#include <chrono>
-#include <cstddef>
-#include <random>
-#include <string>
-#include <stdexcept>
-#include <thread>
-#include <utility>
-#include <vector>
-
-#include <stdgpu/cstddef.h>
+#ifndef STDGPU_OPENMP_DEVICE_INFO_H
+#define STDGPU_OPENMP_DEVICE_INFO_H
 
 
 
@@ -47,4 +36,4 @@ print_device_information();
 
 
 
-#endif // DEVICE_INFO_H
+#endif // STDGPU_OPENMP_DEVICE_INFO_H


### PR DESCRIPTION
Over time, some files were heavily refactored to improve their reliability. However, there is often some leftovers of this process including header includes. Cleanup these includes. Furthermore, make the internal `workaround_*` functions in the `memory` module mandatory to be defined by the backend modules. This improves the consistency of the required interfaces to implement a backend and clearly expresses the intent that this is not considered an optional feature.