### PR TITLE
test: Fix missing include in device_info cpp files

### DIFF
--- a/test/stdgpu/cuda/device_info.cpp
+++ b/test/stdgpu/cuda/device_info.cpp
@@ -13,6 +13,8 @@
  *  limitations under the License.
  */
 
+#include <stdgpu/cuda/device_info.h>
+
 #include <algorithm>
 #include <cstdio>
 #include <cstddef>

--- a/test/stdgpu/openmp/device_info.cpp
+++ b/test/stdgpu/openmp/device_info.cpp
@@ -13,6 +13,8 @@
  *  limitations under the License.
  */
 
+#include <stdgpu/openmp/device_info.h>
+
 #include <algorithm>
 #include <cstdio>
 #include <string>


### PR DESCRIPTION
In #118, the includes were cleaned up. During this cleanup, the `device_info.cpp` files were not checked properly, so the lack of a proper include to their respective header files was not discovered there. Add the respective includes such that these files also follow common conventions.