### PR TITLE
ranges: Add size() and empty() functions as well as additional constructors

### DIFF
--- a/src/stdgpu/impl/ranges_detail.h
+++ b/src/stdgpu/impl/ranges_detail.h
@@ -17,6 +17,9 @@
 #define STDGPU_RANGES_DETAIL_H
 
 
+#include <thrust/distance.h>
+
+
 
 namespace stdgpu
 {
@@ -52,6 +55,28 @@ device_range<T>::device_range(T* p,
 
 
 template <typename T>
+STDGPU_HOST_DEVICE
+device_range<T>::device_range(typename device_range<T>::iterator begin,
+                              index64_t n)
+    : _begin(begin),
+      _end(begin + n)
+{
+
+}
+
+
+template <typename T>
+STDGPU_HOST_DEVICE
+device_range<T>::device_range(typename device_range<T>::iterator begin,
+                              typename device_range<T>::iterator end)
+    : _begin(begin),
+      _end(end)
+{
+
+}
+
+
+template <typename T>
 STDGPU_HOST_DEVICE typename device_range<T>::iterator
 device_range<T>::begin()
 {
@@ -64,6 +89,38 @@ STDGPU_HOST_DEVICE typename device_range<T>::iterator
 device_range<T>::end()
 {
     return _end;
+}
+
+
+template <typename T>
+STDGPU_HOST_DEVICE typename device_range<T>::iterator
+device_range<T>::begin() const
+{
+    return _begin;
+}
+
+
+template <typename T>
+STDGPU_HOST_DEVICE typename device_range<T>::iterator
+device_range<T>::end() const
+{
+    return _end;
+}
+
+
+template <typename T>
+STDGPU_HOST_DEVICE index64_t
+device_range<T>::size() const
+{
+    return thrust::distance(begin(), end());
+}
+
+
+template <typename T>
+STDGPU_HOST_DEVICE bool
+device_range<T>::empty() const
+{
+    return size() == 0;
 }
 
 
@@ -98,6 +155,28 @@ host_range<T>::host_range(T* p,
 
 
 template <typename T>
+STDGPU_HOST_DEVICE
+host_range<T>::host_range(typename host_range<T>::iterator begin,
+                          index64_t n)
+    : _begin(begin),
+      _end(begin + n)
+{
+
+}
+
+
+template <typename T>
+STDGPU_HOST_DEVICE
+host_range<T>::host_range(typename host_range<T>::iterator begin,
+                          typename host_range<T>::iterator end)
+    : _begin(begin),
+      _end(end)
+{
+
+}
+
+
+template <typename T>
 STDGPU_HOST_DEVICE typename host_range<T>::iterator
 host_range<T>::begin()
 {
@@ -110,6 +189,47 @@ STDGPU_HOST_DEVICE typename host_range<T>::iterator
 host_range<T>::end()
 {
     return _end;
+}
+
+
+template <typename T>
+STDGPU_HOST_DEVICE typename host_range<T>::iterator
+host_range<T>::begin() const
+{
+    return _begin;
+}
+
+
+template <typename T>
+STDGPU_HOST_DEVICE typename host_range<T>::iterator
+host_range<T>::end() const
+{
+    return _end;
+}
+
+
+template <typename T>
+STDGPU_HOST_DEVICE index64_t
+host_range<T>::size() const
+{
+    return thrust::distance(begin(), end());
+}
+
+
+template <typename T>
+STDGPU_HOST_DEVICE bool
+host_range<T>::empty() const
+{
+    return size() == 0;
+}
+
+
+template <typename R, typename UnaryFunction>
+STDGPU_HOST_DEVICE
+transform_range<R, UnaryFunction>::transform_range(R r)
+    : transform_range(r, UnaryFunction())
+{
+
 }
 
 
@@ -137,6 +257,38 @@ STDGPU_HOST_DEVICE typename transform_range<R, UnaryFunction>::iterator
 transform_range<R, UnaryFunction>::end()
 {
     return _end;
+}
+
+
+template <typename R, typename UnaryFunction>
+STDGPU_HOST_DEVICE typename transform_range<R, UnaryFunction>::iterator
+transform_range<R, UnaryFunction>::begin() const
+{
+    return _begin;
+}
+
+
+template <typename R, typename UnaryFunction>
+STDGPU_HOST_DEVICE typename transform_range<R, UnaryFunction>::iterator
+transform_range<R, UnaryFunction>::end() const
+{
+    return _end;
+}
+
+
+template <typename R, typename UnaryFunction>
+STDGPU_HOST_DEVICE index64_t
+transform_range<R, UnaryFunction>::size() const
+{
+    return thrust::distance(begin(), end());
+}
+
+
+template <typename R, typename UnaryFunction>
+STDGPU_HOST_DEVICE bool
+transform_range<R, UnaryFunction>::empty() const
+{
+    return size() == 0;
 }
 
 

--- a/src/stdgpu/ranges.h
+++ b/src/stdgpu/ranges.h
@@ -22,6 +22,7 @@
 
 #include <thrust/iterator/transform_iterator.h>
 
+#include <stdgpu/attribute.h>
 #include <stdgpu/cstddef.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/platform.h>
@@ -39,14 +40,21 @@ template <typename T>
 class device_range
 {
     public:
-        using iterator      = device_ptr<T>;                    /**< device_ptr<T> */
-        using value_type    = typename iterator::value_type;    /**< typename iterator::value_type */
+        using iterator          = device_ptr<T>;                        /**< device_ptr<T> */
+        using value_type        = typename iterator::value_type;        /**< typename iterator::value_type */
+        using difference_type   = typename iterator::difference_type;   /**< typename iterator::difference_type */
+        using reference         = typename iterator::reference;         /**< typename iterator::reference */
+
+        /**
+         * \brief Empty constructor
+         */
+        device_range() = default;
 
         /**
          * \brief Constructor with automatic size inference from the given pointer
          * \param[in] p A pointer to the array
          */
-        device_range(T* p);
+        explicit device_range(T* p);
 
         /**
          * \brief Constructor
@@ -69,18 +77,68 @@ class device_range
                      index_t n);
 
         /**
+         * \brief Constructor
+         * \param[in] begin An iterator to the begin of an array
+         * \param[in] n The number of array elements
+         */
+        STDGPU_HOST_DEVICE
+        device_range(iterator begin,
+                     index64_t n);
+
+        /**
+         * \brief Constructor
+         * \param[in] begin An iterator to the begin of an array
+         * \param[in] end An iterator to the end of an array
+         */
+        STDGPU_HOST_DEVICE
+        device_range(iterator begin,
+                     iterator end);
+
+        /**
+         * \deprecated Replaced by begin() const
+         * \brief An iterator to the begin of the range
+         * \return An iterator to the begin of the range
+         */
+        //[[deprecated("Replaced by begin() const]]
+        STDGPU_HOST_DEVICE iterator
+        begin();
+
+        /**
+         * \deprecated Replaced by end() const
+         * \brief An iterator to the end of the range
+         * \return An iterator to the end of the range
+         */
+        //[[deprecated("Replaced by end() const]]
+        STDGPU_HOST_DEVICE iterator
+        end();
+
+        /**
          * \brief An iterator to the begin of the range
          * \return An iterator to the begin of the range
          */
         STDGPU_HOST_DEVICE iterator
-        begin();
+        begin() const;
 
         /**
          * \brief An iterator to the end of the range
          * \return An iterator to the end of the range
          */
         STDGPU_HOST_DEVICE iterator
-        end();
+        end() const;
+
+        /**
+         * \brief The size
+         * \return The size of the range
+         */
+        STDGPU_HOST_DEVICE index64_t
+        size() const;
+
+        /**
+         * \brief Checks if the range is empty
+         * \return True if the range is empty, false otherwise
+         */
+        STDGPU_NODISCARD STDGPU_HOST_DEVICE bool
+        empty() const;
 
     private:
         iterator _begin = {};
@@ -96,14 +154,21 @@ template <typename T>
 class host_range
 {
     public:
-        using iterator      = host_ptr<T>;                      /**< host_ptr<T> */
-        using value_type    = typename iterator::value_type;    /**< typename iterator::value_type */
+        using iterator          = host_ptr<T>;                          /**< host_ptr<T> */
+        using value_type        = typename iterator::value_type;        /**< typename iterator::value_type */
+        using difference_type   = typename iterator::difference_type;   /**< typename iterator::difference_type */
+        using reference         = typename iterator::reference;         /**< typename iterator::reference */
+
+        /**
+         * \brief Empty constructor
+         */
+        host_range() = default;
 
         /**
          * \brief Constructor with automatic size inference from the given pointer
          * \param[in] p A pointer to the array
          */
-        host_range(T* p);
+        explicit host_range(T* p);
 
         /**
          * \brief Constructor
@@ -126,18 +191,68 @@ class host_range
                    index_t n);
 
         /**
+         * \brief Constructor
+         * \param[in] begin An iterator to the begin of an array
+         * \param[in] n The number of array elements
+         */
+        STDGPU_HOST_DEVICE
+        host_range(iterator begin,
+                   index64_t n);
+
+        /**
+         * \brief Constructor
+         * \param[in] begin An iterator to the begin of an array
+         * \param[in] end An iterator to the end of an array
+         */
+        STDGPU_HOST_DEVICE
+        host_range(iterator begin,
+                   iterator end);
+
+        /**
+         * \deprecated Replaced by begin() const
+         * \brief An iterator to the begin of the range
+         * \return An iterator to the begin of the range
+         */
+        //[[deprecated("Replaced by begin() const]]
+        STDGPU_HOST_DEVICE iterator
+        begin();
+
+        /**
+         * \deprecated Replaced by end() const
+         * \brief An iterator to the end of the range
+         * \return An iterator to the end of the range
+         */
+        //[[deprecated("Replaced by end() const]]
+        STDGPU_HOST_DEVICE iterator
+        end();
+
+        /**
          * \brief An iterator to the begin of the range
          * \return An iterator to the begin of the range
          */
         STDGPU_HOST_DEVICE iterator
-        begin();
+        begin() const;
 
         /**
          * \brief An iterator to the end of the range
          * \return An iterator to the end of the range
          */
         STDGPU_HOST_DEVICE iterator
-        end();
+        end() const;
+
+        /**
+         * \brief The size
+         * \return The size of the range
+         */
+        STDGPU_HOST_DEVICE index64_t
+        size() const;
+
+        /**
+         * \brief Checks if the range is empty
+         * \return True if the range is empty, false otherwise
+         */
+        STDGPU_NODISCARD STDGPU_HOST_DEVICE bool
+        empty() const;
 
     private:
         iterator _begin = {};
@@ -154,8 +269,22 @@ template <typename R, typename UnaryFunction>
 class transform_range
 {
     public:
-        using iterator      = thrust::transform_iterator<UnaryFunction, typename R::iterator>;      /**< thrust::transform_iterator<UnaryFunction, typename R::iterator> */
-        using value_type    = typename iterator::value_type;                                        /**< typename iterator::value_type */
+        using iterator          = thrust::transform_iterator<UnaryFunction, typename R::iterator>;      /**< thrust::transform_iterator<UnaryFunction, typename R::iterator> */
+        using value_type        = typename iterator::value_type;                                        /**< typename iterator::value_type */
+        using difference_type   = typename iterator::difference_type;                                   /**< typename iterator::difference_type */
+        using reference         = typename iterator::reference;                                         /**< typename iterator::reference */
+
+        /**
+         * \brief Empty constructor
+         */
+        transform_range() = default;
+
+        /**
+         * \brief Constructor
+         * \param[in] r The input range
+         */
+        STDGPU_HOST_DEVICE
+        explicit transform_range(R r);
 
         /**
          * \brief Constructor
@@ -167,18 +296,50 @@ class transform_range
                         UnaryFunction f);
 
         /**
+         * \deprecated Replaced by begin() const
+         * \brief An iterator to the begin of the range
+         * \return An iterator to the begin of the range
+         */
+        //[[deprecated("Replaced by begin() const]]
+        STDGPU_HOST_DEVICE iterator
+        begin();
+
+        /**
+         * \deprecated Replaced by end() const
+         * \brief An iterator to the end of the range
+         * \return An iterator to the end of the range
+         */
+        //[[deprecated("Replaced by end() const]]
+        STDGPU_HOST_DEVICE iterator
+        end();
+
+        /**
          * \brief An iterator to the begin of the range
          * \return An iterator to the begin of the range
          */
         STDGPU_HOST_DEVICE iterator
-        begin();
+        begin() const;
 
         /**
          * \brief An iterator to the end of the range
          * \return An iterator to the end of the range
          */
         STDGPU_HOST_DEVICE iterator
-        end();
+        end() const;
+
+        /**
+         * \brief The size
+         * \return The size of the range
+         */
+        STDGPU_HOST_DEVICE index64_t
+        size() const;
+
+        /**
+         * \brief Checks if the range is empty
+         * \return True if the range is empty, false otherwise
+         */
+        STDGPU_NODISCARD STDGPU_HOST_DEVICE bool
+        empty() const;
 
     private:
         iterator _begin = {};

--- a/test/stdgpu/ranges.cpp
+++ b/test/stdgpu/ranges.cpp
@@ -60,7 +60,103 @@ class transform_range<device_range<int>, thrust::identity<int>>;
 } // namespace stdgpu
 
 
-TEST_F(stdgpu_ranges, device_range_with_size)
+TEST_F(stdgpu_ranges, device_range_default)
+{
+    const stdgpu::device_range<int> array_range;
+    int* array_begin   = array_range.begin().get();
+    int* array_end     = array_range.end().get();
+
+    EXPECT_EQ(array_begin, nullptr);
+    EXPECT_EQ(array_end,   nullptr);
+    EXPECT_EQ(array_range.size(), 0);
+    EXPECT_TRUE(array_range.empty());
+}
+
+
+TEST_F(stdgpu_ranges, device_range_pointer_with_size)
+{
+    const stdgpu::index64_t size = 42;
+    int* array = createDeviceArray<int>(size);
+
+    const stdgpu::device_range<int> array_range(array, size);
+    int* array_begin   = array_range.begin().get();
+    int* array_end     = array_range.end().get();
+
+    EXPECT_EQ(array_begin, array);
+    EXPECT_EQ(array_end,   array + size);
+
+    destroyDeviceArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, device_range_pointer_with_size_deprecated)
+{
+    const stdgpu::index_t size = 42;
+    int* array = createDeviceArray<int>(size);
+
+    const stdgpu::device_range<int> array_range(array, size);
+    int* array_begin   = array_range.begin().get();
+    int* array_end     = array_range.end().get();
+
+    EXPECT_EQ(array_begin, array);
+    EXPECT_EQ(array_end,   array + size);
+
+    destroyDeviceArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, device_range_pointer_automatic_size)
+{
+    const stdgpu::index64_t size = 42;
+    int* array = createDeviceArray<int>(size);
+
+    const stdgpu::device_range<int> array_range(array);
+    int* array_begin   = array_range.begin().get();
+    int* array_end     = array_range.end().get();
+
+    EXPECT_EQ(array_begin, array);
+    EXPECT_EQ(array_end,   array + size);
+
+    destroyDeviceArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, device_range_iterator_with_size)
+{
+    const stdgpu::index64_t size = 42;
+    int* array = createDeviceArray<int>(size);
+    stdgpu::device_ptr<int> begin_iterator = stdgpu::make_device(array);
+
+    const stdgpu::device_range<int> array_range(begin_iterator, size);
+    int* array_begin   = array_range.begin().get();
+    int* array_end     = array_range.end().get();
+
+    EXPECT_EQ(array_begin, array);
+    EXPECT_EQ(array_end,   array + size);
+
+    destroyDeviceArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, device_range_iterator_pair)
+{
+    const stdgpu::index64_t size = 42;
+    int* array = createDeviceArray<int>(size);
+    stdgpu::device_ptr<int> begin_iterator = stdgpu::make_device(array);
+    stdgpu::device_ptr<int> end_iterator   = stdgpu::make_device(array + size);
+
+    const stdgpu::device_range<int> array_range(begin_iterator, end_iterator);
+    int* array_begin   = array_range.begin().get();
+    int* array_end     = array_range.end().get();
+
+    EXPECT_EQ(array_begin, array);
+    EXPECT_EQ(array_end,   array + size);
+
+    destroyDeviceArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, device_range_deprecated_nonconst_begin_end)
 {
     const stdgpu::index64_t size = 42;
     int* array = createDeviceArray<int>(size);
@@ -76,39 +172,129 @@ TEST_F(stdgpu_ranges, device_range_with_size)
 }
 
 
-TEST_F(stdgpu_ranges, device_range_with_size_deprecated)
-{
-    const stdgpu::index_t size = 42;
-    int* array = createDeviceArray<int>(size);
-
-    stdgpu::device_range<int> array_range(array, size);
-    int* array_begin   = array_range.begin().get();
-    int* array_end     = array_range.end().get();
-
-    EXPECT_EQ(array_begin, array);
-    EXPECT_EQ(array_end,   array + size);
-
-    destroyDeviceArray<int>(array);
-}
-
-
-TEST_F(stdgpu_ranges, device_range_automatic_size)
+TEST_F(stdgpu_ranges, device_range_size)
 {
     const stdgpu::index64_t size = 42;
     int* array = createDeviceArray<int>(size);
 
-    stdgpu::device_range<int> array_range(array);
+    const stdgpu::device_range<int> array_range(array, size);
+
+    EXPECT_EQ(array_range.size(), size);
+
+    destroyDeviceArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, device_range_empty)
+{
+    const stdgpu::index64_t size = 42;
+    int* array = createDeviceArray<int>(size);
+
+    const stdgpu::device_range<int> array_range(array, size);
+
+    EXPECT_FALSE(array_range.empty());
+
+    destroyDeviceArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, host_range_default)
+{
+    const stdgpu::host_range<int> array_range;
+    int* array_begin   = array_range.begin().get();
+    int* array_end     = array_range.end().get();
+
+    EXPECT_EQ(array_begin, nullptr);
+    EXPECT_EQ(array_end,   nullptr);
+    EXPECT_EQ(array_range.size(), 0);
+    EXPECT_TRUE(array_range.empty());
+}
+
+
+TEST_F(stdgpu_ranges, host_range_pointer_with_size)
+{
+    const stdgpu::index64_t size = 42;
+    int* array = createHostArray<int>(size);
+
+    const stdgpu::host_range<int> array_range(array, size);
     int* array_begin   = array_range.begin().get();
     int* array_end     = array_range.end().get();
 
     EXPECT_EQ(array_begin, array);
     EXPECT_EQ(array_end,   array + size);
 
-    destroyDeviceArray<int>(array);
+    destroyHostArray<int>(array);
 }
 
 
-TEST_F(stdgpu_ranges, host_range_with_size)
+TEST_F(stdgpu_ranges, host_range_pointer_with_size_deprecated)
+{
+    const stdgpu::index_t size = 42;
+    int* array = createHostArray<int>(size);
+
+    const stdgpu::host_range<int> array_range(array, size);
+    int* array_begin   = array_range.begin().get();
+    int* array_end     = array_range.end().get();
+
+    EXPECT_EQ(array_begin, array);
+    EXPECT_EQ(array_end,   array + size);
+
+    destroyHostArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, host_range_pointer_automatic_size)
+{
+    const stdgpu::index64_t size = 42;
+    int* array = createHostArray<int>(size);
+
+    const stdgpu::host_range<int> array_range(array);
+    int* array_begin   = array_range.begin().get();
+    int* array_end     = array_range.end().get();
+
+    EXPECT_EQ(array_begin, array);
+    EXPECT_EQ(array_end,   array + size);
+
+    destroyHostArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, host_range_iterator_with_size)
+{
+    const stdgpu::index64_t size = 42;
+    int* array = createHostArray<int>(size);
+    stdgpu::host_ptr<int> begin_iterator = stdgpu::make_host(array);
+
+    const stdgpu::host_range<int> array_range(begin_iterator, size);
+    int* array_begin   = array_range.begin().get();
+    int* array_end     = array_range.end().get();
+
+    EXPECT_EQ(array_begin, array);
+    EXPECT_EQ(array_end,   array + size);
+
+    destroyHostArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, host_range_iterator_pair)
+{
+    const stdgpu::index64_t size = 42;
+    int* array = createHostArray<int>(size);
+    stdgpu::host_ptr<int> begin_iterator = stdgpu::make_host(array);
+    stdgpu::host_ptr<int> end_iterator   = stdgpu::make_host(array + size);
+
+    const stdgpu::host_range<int> array_range(begin_iterator, end_iterator);
+    int* array_begin   = array_range.begin().get();
+    int* array_end     = array_range.end().get();
+
+    EXPECT_EQ(array_begin, array);
+    EXPECT_EQ(array_end,   array + size);
+
+    destroyHostArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, host_range_deprecated_nonconst_begin_end)
 {
     const stdgpu::index64_t size = 42;
     int* array = createHostArray<int>(size);
@@ -124,33 +310,27 @@ TEST_F(stdgpu_ranges, host_range_with_size)
 }
 
 
-TEST_F(stdgpu_ranges, host_range_with_size_deprecated)
+TEST_F(stdgpu_ranges, host_range_size)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array = createHostArray<int>(size);
 
-    stdgpu::host_range<int> array_range(array, size);
-    int* array_begin   = array_range.begin().get();
-    int* array_end     = array_range.end().get();
+    const stdgpu::host_range<int> array_range(array, size);
 
-    EXPECT_EQ(array_begin, array);
-    EXPECT_EQ(array_end,   array + size);
+    EXPECT_EQ(array_range.size(), size);
 
     destroyHostArray<int>(array);
 }
 
 
-TEST_F(stdgpu_ranges, host_range_automatic_size)
+TEST_F(stdgpu_ranges, host_range_empty)
 {
     const stdgpu::index64_t size = 42;
     int* array = createHostArray<int>(size);
 
-    stdgpu::host_range<int> array_range(array);
-    int* array_begin   = array_range.begin().get();
-    int* array_end     = array_range.end().get();
+    const stdgpu::host_range<int> array_range(array, size);
 
-    EXPECT_EQ(array_begin, array);
-    EXPECT_EQ(array_end,   array + size);
+    EXPECT_FALSE(array_range.empty());
 
     destroyHostArray<int>(array);
 }
@@ -167,14 +347,28 @@ struct square
 };
 
 
-TEST_F(stdgpu_ranges, transform_range)
+TEST_F(stdgpu_ranges, transform_range_default)
+{
+    const stdgpu::transform_range<stdgpu::host_range<int>, square<int>> square_range;
+    int* array_begin   = square_range.begin().base().get();
+    int* array_end     = square_range.end().base().get();
+
+    EXPECT_EQ(array_begin, nullptr);
+    EXPECT_EQ(array_end,   nullptr);
+    EXPECT_EQ(square_range.size(), 0);
+    EXPECT_TRUE(square_range.empty());
+
+}
+
+
+TEST_F(stdgpu_ranges, transform_range_with_range)
 {
     const stdgpu::index64_t size = 42;
     int* array          = createHostArray<int>(size);
     int* array_result   = createHostArray<int>(size);
 
-    stdgpu::host_range<int> array_range(array);
-    stdgpu::transform_range<stdgpu::host_range<int>, square<int>> square_range(array_range, square<int>());
+    const stdgpu::host_range<int> array_range(array);
+    const stdgpu::transform_range<stdgpu::host_range<int>, square<int>> square_range(array_range);
 
     // Setup array
     thrust::tabulate(array_range.begin(), array_range.end(),
@@ -192,6 +386,79 @@ TEST_F(stdgpu_ranges, transform_range)
 
     destroyHostArray<int>(array);
     destroyHostArray<int>(array_result);
+}
+
+
+TEST_F(stdgpu_ranges, transform_range_with_range_and_function)
+{
+    const stdgpu::index64_t size = 42;
+    int* array          = createHostArray<int>(size);
+    int* array_result   = createHostArray<int>(size);
+
+    const stdgpu::host_range<int> array_range(array);
+    const stdgpu::transform_range<stdgpu::host_range<int>, square<int>> square_range(array_range, square<int>());
+
+    // Setup array
+    thrust::tabulate(array_range.begin(), array_range.end(),
+                     thrust::identity<int>());
+
+    // Execute transformation and write into array_result
+    thrust::copy(square_range.begin(), square_range.end(),
+                 stdgpu::host_begin(array_result));
+
+    for (stdgpu::index_t i = 0; i < size; ++i)
+    {
+        EXPECT_EQ(array[i], i);
+        EXPECT_EQ(array_result[i], i * i);
+    }
+
+    destroyHostArray<int>(array);
+    destroyHostArray<int>(array_result);
+}
+
+
+TEST_F(stdgpu_ranges, transform_range_deprecated_nonconst_begin_end)
+{
+    const stdgpu::index64_t size = 42;
+    int* array = createHostArray<int>(size);
+
+    const stdgpu::host_range<int> array_range(array);
+    stdgpu::transform_range<stdgpu::host_range<int>, square<int>> square_range(array_range, square<int>());
+    int* array_begin   = square_range.begin().base().get();
+    int* array_end     = square_range.end().base().get();
+
+    EXPECT_EQ(array_begin, array);
+    EXPECT_EQ(array_end,   array + size);
+
+    destroyHostArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, transform_range_size)
+{
+    const stdgpu::index64_t size = 42;
+    int* array = createHostArray<int>(size);
+
+    const stdgpu::host_range<int> array_range(array);
+    const stdgpu::transform_range<stdgpu::host_range<int>, square<int>> square_range(array_range, square<int>());
+
+    EXPECT_EQ(square_range.size(), size);
+
+    destroyHostArray<int>(array);
+}
+
+
+TEST_F(stdgpu_ranges, transform_range_empty)
+{
+    const stdgpu::index64_t size = 42;
+    int* array = createHostArray<int>(size);
+
+    const stdgpu::host_range<int> array_range(array);
+    const stdgpu::transform_range<stdgpu::host_range<int>, square<int>> square_range(array_range, square<int>());
+
+    EXPECT_FALSE(square_range.empty());
+
+    destroyHostArray<int>(array);
 }
 
 


### PR DESCRIPTION
The API of the `ranges` module, which aims to model the C++20 ranges library in a significantly simplified yet still useful manner, is still rather limited. Add additional constructors to `host_range`, `device_range` and `transform_range` as well as `size()` and `empty()` functions and some typedefs. Furthermore, replace the non-const `begin()` and `end()` functions with equivalent const versions and implicitly deprecate the non-const ones. This is a small step towards a more useful `ranges` module.