### PR TITLE
test: Fix conversion warning and missing namespace

### DIFF
--- a/test/stdgpu/algorithm.cpp
+++ b/test/stdgpu/algorithm.cpp
@@ -107,7 +107,7 @@ void
 thread_check_min_max_integer(const stdgpu::index_t iterations)
 {
     // Generate true random numbers
-    size_t seed = test_utils::random_thread_seed();
+    std::size_t seed = test_utils::random_thread_seed();
 
     std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_int_distribution<T> dist(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
@@ -184,7 +184,7 @@ void
 thread_check_min_max_float(const stdgpu::index_t iterations)
 {
     // Generate true random numbers
-    size_t seed = test_utils::random_thread_seed();
+    std::size_t seed = test_utils::random_thread_seed();
 
     std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_real_distribution<T> dist(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
@@ -228,7 +228,7 @@ void
 thread_check_clamp_integer(const stdgpu::index_t iterations)
 {
     // Generate true random numbers
-    size_t seed = test_utils::random_thread_seed();
+    std::size_t seed = test_utils::random_thread_seed();
 
     std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_int_distribution<T> dist(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
@@ -298,7 +298,7 @@ void
 thread_check_clamp_float(const stdgpu::index_t iterations)
 {
     // Generate true random numbers
-    size_t seed = test_utils::random_thread_seed();
+    std::size_t seed = test_utils::random_thread_seed();
 
     std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_real_distribution<T> dist(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());

--- a/test/stdgpu/cmath.cpp
+++ b/test/stdgpu/cmath.cpp
@@ -60,7 +60,7 @@ TEST_F(stdgpu_cmath, abs_infinity)
 void
 thread_positive_values(const stdgpu::index_t iterations)
 {
-    size_t seed = test_utils::random_thread_seed();
+    std::size_t seed = test_utils::random_thread_seed();
 
     std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_real_distribution<float> dist(std::numeric_limits<float>::min(), std::numeric_limits<float>::max());
@@ -86,7 +86,7 @@ TEST_F(stdgpu_cmath, abs_positive_values)
 void
 thread_negative_values(const stdgpu::index_t iterations)
 {
-    size_t seed = test_utils::random_thread_seed();
+    std::size_t seed = test_utils::random_thread_seed();
 
     std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_real_distribution<float> dist(std::numeric_limits<float>::lowest(), -std::numeric_limits<float>::min());

--- a/test/stdgpu/cuda/atomic.cu
+++ b/test/stdgpu/cuda/atomic.cu
@@ -174,7 +174,7 @@ class random_float
 {
     public:
         STDGPU_HOST_DEVICE
-        random_float(const stdgpu::index_t seed,
+        random_float(const std::size_t seed,
                      const float min,
                      const float max)
             : _seed(seed),
@@ -187,7 +187,7 @@ class random_float
         STDGPU_HOST_DEVICE float
         operator()(const stdgpu::index_t n) const
         {
-            thrust::default_random_engine rng(_seed);
+            thrust::default_random_engine rng(static_cast<thrust::default_random_engine::result_type>(_seed));
             thrust::uniform_real_distribution<float> dist(_min, _max);
             rng.discard(n);
 
@@ -195,7 +195,7 @@ class random_float
         }
 
     private:
-        stdgpu::index_t _seed;
+        std::size_t _seed;
         float _min, _max;
 };
 

--- a/test/stdgpu/cuda/bit.cu
+++ b/test/stdgpu/cuda/bit.cu
@@ -44,8 +44,8 @@ class stdgpu_cuda_bit : public ::testing::Test
 
 struct bit_width_functor
 {
-    STDGPU_DEVICE_ONLY size_t
-    operator()(const size_t i) const
+    STDGPU_DEVICE_ONLY std::size_t
+    operator()(const std::size_t i) const
     {
         return stdgpu::cuda::bit_width(static_cast<unsigned long long>(1) << i);
     }
@@ -53,29 +53,29 @@ struct bit_width_functor
 
 TEST_F(stdgpu_cuda_bit, bit_width)
 {
-    size_t* powers = createDeviceArray<size_t>(std::numeric_limits<size_t>::digits);
+    std::size_t* powers = createDeviceArray<std::size_t>(std::numeric_limits<std::size_t>::digits);
     thrust::sequence(stdgpu::device_begin(powers), stdgpu::device_end(powers));
 
     thrust::transform(stdgpu::device_begin(powers), stdgpu::device_end(powers),
                       stdgpu::device_begin(powers),
                       bit_width_functor());
 
-    size_t* host_powers = copyCreateDevice2HostArray<size_t>(powers, std::numeric_limits<size_t>::digits);
+    std::size_t* host_powers = copyCreateDevice2HostArray<std::size_t>(powers, std::numeric_limits<std::size_t>::digits);
 
-    for (size_t i = 0; i < std::numeric_limits<size_t>::digits; ++i)
+    for (std::size_t i = 0; i < std::numeric_limits<std::size_t>::digits; ++i)
     {
-        EXPECT_EQ(host_powers[i], static_cast<size_t>(i + 1));
+        EXPECT_EQ(host_powers[i], static_cast<std::size_t>(i + 1));
     }
 
-    destroyDeviceArray<size_t>(powers);
-    destroyHostArray<size_t>(host_powers);
+    destroyDeviceArray<std::size_t>(powers);
+    destroyHostArray<std::size_t>(host_powers);
 }
 
 
 struct popcount_pow2
 {
-    STDGPU_DEVICE_ONLY size_t
-    operator()(const size_t i) const
+    STDGPU_DEVICE_ONLY std::size_t
+    operator()(const std::size_t i) const
     {
         return stdgpu::cuda::popcount(static_cast<unsigned long long>(1) << i);
     }
@@ -83,51 +83,51 @@ struct popcount_pow2
 
 TEST_F(stdgpu_cuda_bit, popcount_pow2)
 {
-    size_t* powers = createDeviceArray<size_t>(std::numeric_limits<size_t>::digits);
+    std::size_t* powers = createDeviceArray<std::size_t>(std::numeric_limits<std::size_t>::digits);
     thrust::sequence(stdgpu::device_begin(powers), stdgpu::device_end(powers));
 
     thrust::transform(stdgpu::device_begin(powers), stdgpu::device_end(powers),
                       stdgpu::device_begin(powers),
                       popcount_pow2());
 
-    size_t* host_powers = copyCreateDevice2HostArray<size_t>(powers, std::numeric_limits<size_t>::digits);
+    std::size_t* host_powers = copyCreateDevice2HostArray<std::size_t>(powers, std::numeric_limits<std::size_t>::digits);
 
-    for (size_t i = 0; i < std::numeric_limits<size_t>::digits; ++i)
+    for (std::size_t i = 0; i < std::numeric_limits<std::size_t>::digits; ++i)
     {
         EXPECT_EQ(host_powers[i], 1);
     }
 
-    destroyDeviceArray<size_t>(powers);
-    destroyHostArray<size_t>(host_powers);
+    destroyDeviceArray<std::size_t>(powers);
+    destroyHostArray<std::size_t>(host_powers);
 }
 
 
 struct popcount_pow2m1
 {
-    STDGPU_DEVICE_ONLY size_t
-    operator()(const size_t i) const
+    STDGPU_DEVICE_ONLY std::size_t
+    operator()(const std::size_t i) const
     {
-        return stdgpu::popcount((static_cast<size_t>(1) << i) - 1);
+        return stdgpu::popcount((static_cast<std::size_t>(1) << i) - 1);
     }
 };
 
 TEST_F(stdgpu_cuda_bit, popcount_pow2m1)
 {
-    size_t* powers = createDeviceArray<size_t>(std::numeric_limits<size_t>::digits);
+    std::size_t* powers = createDeviceArray<std::size_t>(std::numeric_limits<std::size_t>::digits);
     thrust::sequence(stdgpu::device_begin(powers), stdgpu::device_end(powers));
 
     thrust::transform(stdgpu::device_begin(powers), stdgpu::device_end(powers),
                       stdgpu::device_begin(powers),
                       popcount_pow2m1());
 
-    size_t* host_powers = copyCreateDevice2HostArray<size_t>(powers, std::numeric_limits<size_t>::digits);
+    std::size_t* host_powers = copyCreateDevice2HostArray<std::size_t>(powers, std::numeric_limits<std::size_t>::digits);
 
-    for (size_t i = 0; i < std::numeric_limits<size_t>::digits; ++i)
+    for (std::size_t i = 0; i < std::numeric_limits<std::size_t>::digits; ++i)
     {
         EXPECT_EQ(host_powers[i], i);
     }
 
-    destroyDeviceArray<size_t>(powers);
-    destroyHostArray<size_t>(host_powers);
+    destroyDeviceArray<std::size_t>(powers);
+    destroyHostArray<std::size_t>(host_powers);
 }
 

--- a/test/stdgpu/functional.cpp
+++ b/test/stdgpu/functional.cpp
@@ -161,7 +161,7 @@ check_integer_random()
     const stdgpu::index_t N = 1000000;
 
     // Generate true random numbers
-    size_t seed = test_utils::random_seed();
+    std::size_t seed = test_utils::random_seed();
 
     std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_int_distribution<T> dist(std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
@@ -222,7 +222,7 @@ check_floating_point_random()
     const stdgpu::index_t N = 1000000;
 
     // Generate true random numbers
-    size_t seed = test_utils::random_seed();
+    std::size_t seed = test_utils::random_seed();
 
     std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
     std::uniform_real_distribution<T> dist(static_cast<T>(-1e38), static_cast<T>(1e38));

--- a/test/stdgpu/iterator.cpp
+++ b/test/stdgpu/iterator.cpp
@@ -191,7 +191,7 @@ TEST_F(stdgpu_iterator, size_host_void)
 
 TEST_F(stdgpu_iterator, size_nullptr_void)
 {
-    EXPECT_EQ(stdgpu::size((void*)nullptr), static_cast<size_t>(0));
+    EXPECT_EQ(stdgpu::size((void*)nullptr), static_cast<std::size_t>(0));
 }
 
 
@@ -199,7 +199,7 @@ TEST_F(stdgpu_iterator, size_device)
 {
     int* array = createDeviceArray<int>(42);
 
-    EXPECT_EQ(stdgpu::size(array), static_cast<size_t>(42));
+    EXPECT_EQ(stdgpu::size(array), static_cast<std::size_t>(42));
 
     destroyDeviceArray<int>(array);
 }
@@ -209,7 +209,7 @@ TEST_F(stdgpu_iterator, size_host)
 {
     int* array_result = createHostArray<int>(42);
 
-    EXPECT_EQ(stdgpu::size(array_result), static_cast<size_t>(42));
+    EXPECT_EQ(stdgpu::size(array_result), static_cast<std::size_t>(42));
 
     destroyHostArray<int>(array_result);
 }
@@ -217,7 +217,7 @@ TEST_F(stdgpu_iterator, size_host)
 
 TEST_F(stdgpu_iterator, size_nullptr)
 {
-    EXPECT_EQ(stdgpu::size((int*)nullptr), static_cast<size_t>(0));
+    EXPECT_EQ(stdgpu::size((int*)nullptr), static_cast<std::size_t>(0));
 }
 
 
@@ -225,7 +225,7 @@ TEST_F(stdgpu_iterator, size_device_shifted)
 {
     int* array = createDeviceArray<int>(42);
 
-    EXPECT_EQ(stdgpu::size(array + 24), static_cast<size_t>(0));
+    EXPECT_EQ(stdgpu::size(array + 24), static_cast<std::size_t>(0));
 
     destroyDeviceArray<int>(array);
 }
@@ -235,7 +235,7 @@ TEST_F(stdgpu_iterator, size_host_shifted)
 {
     int* array_result = createHostArray<int>(42);
 
-    EXPECT_EQ(stdgpu::size(array_result + 24), static_cast<size_t>(0));
+    EXPECT_EQ(stdgpu::size(array_result + 24), static_cast<std::size_t>(0));
 
     destroyHostArray<int>(array_result);
 }
@@ -245,7 +245,7 @@ TEST_F(stdgpu_iterator, size_device_wrong_alignment)
 {
     int* array = createDeviceArray<int>(1);
 
-    EXPECT_EQ(stdgpu::size(reinterpret_cast<size_t*>(array)), static_cast<size_t>(0));
+    EXPECT_EQ(stdgpu::size(reinterpret_cast<std::size_t*>(array)), static_cast<std::size_t>(0));
 
     destroyDeviceArray<int>(array);
 }
@@ -255,7 +255,7 @@ TEST_F(stdgpu_iterator, size_host_wrong_alignment)
 {
     int* array_result = createHostArray<int>(1);
 
-    EXPECT_EQ(stdgpu::size(reinterpret_cast<size_t*>(array_result)), static_cast<size_t>(0));
+    EXPECT_EQ(stdgpu::size(reinterpret_cast<std::size_t*>(array_result)), static_cast<std::size_t>(0));
 
     destroyHostArray<int>(array_result);
 }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -62,7 +62,7 @@ namespace test_utils
 
         }
 
-        return static_cast<size_t>(std::chrono::system_clock::now().time_since_epoch().count());
+        return static_cast<std::size_t>(std::chrono::system_clock::now().time_since_epoch().count());
     }
 
 


### PR DESCRIPTION
There are still some inconsistencies regarding the `std` namespace usage and other minor potential flaws which may be detected by the high warning level. Fix a conversion warning which has been unveiled recently. Furthermore, use the namespaced `std::size_t` rather than `size_t` consistently throughout the code and tests.