### PR TITLE
ranges: Fix compilation error with select functor

### DIFF
--- a/src/stdgpu/impl/ranges_detail.h
+++ b/src/stdgpu/impl/ranges_detail.h
@@ -298,6 +298,8 @@ namespace detail
 template <typename T>
 struct select
 {
+    select() = default;
+
     STDGPU_HOST_DEVICE
     select(T* values)
         : _values(values)
@@ -311,7 +313,7 @@ struct select
         return _values[i];
     }
 
-    T* _values;
+    T* _values = nullptr;
 };
 
 } // namespace detail


### PR DESCRIPTION
In #122, the API of the `ranges` module has been extended. However, on older compilers such as NVCC 10.0, this causes compilation errors where the default constructor of the internal `select` functor is missing. Fix this issue by adding the respective default constructor.