### PR TITLE
scripts: Use released thrust version

### DIFF
--- a/scripts/utils/download_thrust.sh
+++ b/scripts/utils/download_thrust.sh
@@ -3,3 +3,6 @@ set -e
 
 cmake -E cmake_echo_color --blue ">>>>> Download thrust"
 cmake -E chdir external git clone https://github.com/thrust/thrust
+
+# Latest release version
+cmake -E chdir external/thrust git checkout 1.9.8


### PR DESCRIPTION
Recently, the master/development branch of thrust regressed which causes failures in our CI (see [this issue](https://github.com/thrust/thrust/issues/1093)). Use a fixed version, i.e. the currently latest released/tagged version, rather than the latest development commit.