### PR TITLE
cmake: Workaround bug in imported rocthrust target name

### DIFF
--- a/cmake/rocm/Findthrust.cmake
+++ b/cmake/rocm/Findthrust.cmake
@@ -43,7 +43,12 @@ find_package_handle_standard_args(thrust
 
 if(thrust_FOUND)
     add_library(thrust::thrust INTERFACE IMPORTED)
-    set_target_properties(thrust::thrust PROPERTIES INTERFACE_LINK_LIBRARIES rocthrust)
+    # WORKAROUND: ROCm 3.1 forgot to export the namespace, so workaround this bug
+    if(TARGET roc::rocthrust)
+        set_target_properties(thrust::thrust PROPERTIES INTERFACE_LINK_LIBRARIES roc::rocthrust)
+    elseif(TARGET rocthrust)
+        set_target_properties(thrust::thrust PROPERTIES INTERFACE_LINK_LIBRARIES rocthrust)
+    endif()
 
     mark_as_advanced(THRUST_INCLUDE_DIR
                      THRUST_VERSION


### PR DESCRIPTION
ROCm 3.1 and below exported rocthrust without the `roc::` namespace which has been fixed in ROCm 3.3. However, this now causes errors on our side. Workaround this issue by supporting both versions. This workaround can be dropped once ROCm 3.3 becomes the minimum required version.