### PR TITLE
cmake: Generate compile flags more robustly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ list(APPEND STDGPU_BACKEND_OPTIONS ${STDGPU_BACKEND_CUDA} ${STDGPU_BACKEND_OPENM
 
 # STDGPU_BACKEND
 set(STDGPU_BACKEND ${STDGPU_BACKEND_CUDA} CACHE STRING "Device system backend, default: STDGPU_BACKEND_CUDA")
-if (NOT STDGPU_BACKEND IN_LIST STDGPU_BACKEND_OPTIONS)
+if(NOT STDGPU_BACKEND IN_LIST STDGPU_BACKEND_OPTIONS)
     message(FATAL_ERROR "STDGPU_BACKEND is set to \"${STDGPU_BACKEND}\", but must be one of \"${STDGPU_BACKEND_OPTIONS}\"")
 endif()
 
@@ -28,6 +28,12 @@ set(STDGPU_BACKEND_NAMESPACE ${STDGPU_BACKEND_DIRECTORY})
 # STDGPU_BACKEND_MACRO_NAMESPACE
 set(STDGPU_BACKEND_MACRO_NAMESPACE ${STDGPU_BACKEND_NAMESPACE})
 string(TOUPPER ${STDGPU_BACKEND_MACRO_NAMESPACE} STDGPU_BACKEND_MACRO_NAMESPACE)
+
+
+# Enable backend-specific languages
+if(STDGPU_BACKEND STREQUAL STDGPU_BACKEND_CUDA)
+    enable_language(CUDA)
+endif()
 
 
 # Backend-specific modules have higher priority than generic modules
@@ -45,7 +51,23 @@ option(STDGPU_TREAT_WARNINGS_AS_ERRORS "Treats compiler warnings as errors, defa
 
 if(STDGPU_SETUP_COMPILER_FLAGS)
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/${STDGPU_BACKEND_DIRECTORY}/set_device_flags.cmake")
+    stdgpu_set_device_flags(STDGPU_DEVICE_FLAGS)
+    stdgpu_set_test_device_flags(STDGPU_TEST_DEVICE_FLAGS)
+    message(STATUS "Created device flags : ${STDGPU_DEVICE_FLAGS}")
+    message(STATUS "Created test device flags : ${STDGPU_TEST_DEVICE_FLAGS}")
+
+    if(STDGPU_BACKEND STREQUAL STDGPU_BACKEND_CUDA)
+        # FIXME Use the architecture flags for both device compiling and device linking until there is a proper abstraction
+        stdgpu_cuda_set_architecture_flags(STDGPU_DEVICE_COMPILE_AND_LINK_FLAGS)
+        string(APPEND CMAKE_CUDA_FLAGS "${STDGPU_DEVICE_COMPILE_AND_LINK_FLAGS}")
+        message(STATUS "Building with modified CMAKE_CUDA_FLAGS : ${CMAKE_CUDA_FLAGS}")
+    endif()
+
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/set_host_flags.cmake")
+    stdgpu_set_host_flags(STDGPU_HOST_FLAGS)
+    stdgpu_set_test_host_flags(STDGPU_TEST_HOST_FLAGS)
+    message(STATUS "Created host flags : ${STDGPU_HOST_FLAGS}")
+    message(STATUS "Created test host flags : ${STDGPU_TEST_HOST_FLAGS}")
 endif()
 
 

--- a/cmake/cuda/set_device_flags.cmake
+++ b/cmake/cuda/set_device_flags.cmake
@@ -1,79 +1,96 @@
+function(stdgpu_set_device_flags STDGPU_OUTPUT_DEVICE_FLAGS)
+    # Clear list before appending flags
+    unset(${STDGPU_OUTPUT_DEVICE_FLAGS})
 
-enable_language(CUDA)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        list(APPEND ${STDGPU_OUTPUT_DEVICE_FLAGS} "-Wall")
+        list(APPEND ${STDGPU_OUTPUT_DEVICE_FLAGS} "-Wextra")
+        # Enabled only for CMake 3.17+ due to thrust and a bug in CMake (fixed in 3.17+)
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+            list(APPEND ${STDGPU_OUTPUT_DEVICE_FLAGS} "-Wshadow")
+            list(APPEND ${STDGPU_OUTPUT_DEVICE_FLAGS} "-Wsign-compare")
+            list(APPEND ${STDGPU_OUTPUT_DEVICE_FLAGS} "-Wconversion")
+            list(APPEND ${STDGPU_OUTPUT_DEVICE_FLAGS} "-Wfloat-equal")
+        endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/check_compute_capability.cmake")
+        if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
+            list(APPEND ${STDGPU_OUTPUT_DEVICE_FLAGS} "-Werror")
+        endif()
 
-# Minimum CC : Determined by used features, limits CUDA version at EOL
-set(STDGPU_CUDA_MIN_CC_MAJOR 3)
-set(STDGPU_CUDA_MIN_CC_MINOR 5)
-set(STDGPU_CUDA_MIN_CC ${STDGPU_CUDA_MIN_CC_MAJOR}${STDGPU_CUDA_MIN_CC_MINOR})
+        if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+            message(STATUS "Appended optimization flag (-O3,/O2) implicitly")
+        endif()
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        list(APPEND ${STDGPU_OUTPUT_DEVICE_FLAGS} "/W2") # or /W3 or /W4 depending on how useful this is
 
-# Maximum CC : Determined by minimum CUDA version
-set(STDGPU_CUDA_MAX_CC_MAJOR 7)
-set(STDGPU_CUDA_MAX_CC_MINOR 5)
-set(STDGPU_CUDA_MAX_CC ${STDGPU_CUDA_MAX_CC_MAJOR}${STDGPU_CUDA_MAX_CC_MINOR})
+        if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
+            list(APPEND ${STDGPU_OUTPUT_DEVICE_FLAGS} "/WX")
+        endif()
 
-message(STATUS "CUDA Compute Capability (CC) Configuration")
-message(STATUS "  Minimum required CC  : ${STDGPU_CUDA_MIN_CC}")
-message(STATUS "  Maximum supported CC : ${STDGPU_CUDA_MAX_CC} (newer supported via JIT compilation)")
-set(STDGPU_CUDA_HAVE_SUITABLE_GPU FALSE)
-
-foreach(STDGPU_CUDA_CC IN LISTS STDGPU_CUDA_COMPUTE_CAPABILITIES)
-    if(${STDGPU_CUDA_CC} LESS ${STDGPU_CUDA_MIN_CC})
-        # STDGPU_CUDA_CC < STDGPU_CUDA_MIN_CC
-        message(STATUS "  Skip compilation for CC ${STDGPU_CUDA_CC} which is too old")
-    elseif(NOT ${STDGPU_CUDA_CC} GREATER ${STDGPU_CUDA_MAX_CC})
-        # STDGPU_CUDA_MIN_CC <= STDGPU_CUDA_CC <= STDGPU_CUDA_MAX_CC
-        string(APPEND STDGPU_DEVICE_FLAGS " --generate-code arch=compute_${STDGPU_CUDA_CC},code=sm_${STDGPU_CUDA_CC}")
-        message(STATUS "  Enabled compilation for CC ${STDGPU_CUDA_CC}")
-        set(STDGPU_CUDA_HAVE_SUITABLE_GPU TRUE)
-    else()
-        # STDGPU_CUDA_MAX_CC < STDGPU_CUDA_CC
-        string(APPEND STDGPU_DEVICE_FLAGS " --generate-code arch=compute_${STDGPU_CUDA_MAX_CC},code=compute_${STDGPU_CUDA_MAX_CC}")
-        message(STATUS "  Enabled compilation for CC ${STDGPU_CUDA_CC} via JIT compilation of ${STDGPU_CUDA_MAX_CC}")
-        set(STDGPU_CUDA_HAVE_SUITABLE_GPU TRUE)
-    endif()
-endforeach()
-
-if(NOT STDGPU_CUDA_HAVE_SUITABLE_GPU)
-    message(FATAL_ERROR "  No CUDA-capable GPU with at least CC ${STDGPU_CUDA_MIN_CC} detected")
-endif()
-
-if(NOT MSVC)
-    string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wall")
-    string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wextra")
-    # Enabled only for CMake 3.17+ due to thrust and a bug in CMake (fixed in 3.17+)
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-        string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wshadow")
-        string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wsign-compare")
-        string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wconversion")
-        string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Wfloat-equal")
+        #list(APPEND ${STDGPU_OUTPUT_DEVICE_FLAGS} "/O2")
     endif()
 
-    if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
-        string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler -Werror")
+    if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+        string(REPLACE ";" "," ${STDGPU_OUTPUT_DEVICE_FLAGS} "${${STDGPU_OUTPUT_DEVICE_FLAGS}}")
+        set(${STDGPU_OUTPUT_DEVICE_FLAGS} "-Xcompiler=${${STDGPU_OUTPUT_DEVICE_FLAGS}}")
     endif()
 
-    if(${CMAKE_BUILD_TYPE} MATCHES "Release" OR ${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
-        message(STATUS "Appended optimization flag (-O3,/O2) implicitly")
-    endif()
-else()
-    string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler /W2") # or /W3 or /W4 depending on how useful this is
+    set(${STDGPU_OUTPUT_DEVICE_FLAGS} "$<$<COMPILE_LANGUAGE:CUDA>:${${STDGPU_OUTPUT_DEVICE_FLAGS}}>")
 
-    if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
-        string(APPEND STDGPU_DEVICE_FLAGS " -Xcompiler /WX")
-    endif()
+    # Make output variable visible
+    set(${STDGPU_OUTPUT_DEVICE_FLAGS} ${${STDGPU_OUTPUT_DEVICE_FLAGS}} PARENT_SCOPE)
+endfunction()
 
-    #string(APPEND STDGPU_DEVICE_FLAGS " /O2")
-endif()
-
-# Apply compiler flags
-string(APPEND CMAKE_CUDA_FLAGS ${STDGPU_DEVICE_FLAGS})
-
-message(STATUS "Created device flags : ${STDGPU_DEVICE_FLAGS}")
-message(STATUS "Building with CUDA flags : ${CMAKE_CUDA_FLAGS}")
 
 # Auxiliary compiler flags for tests to be used with target_compile_options
-if(NOT MSVC)
-    set(STDGPU_TEST_DEVICE_FLAGS "$<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-declarations>")
-endif()
+function(stdgpu_set_test_device_flags STDGPU_OUTPUT_DEVICE_TEST_FLAGS)
+    if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+        set(${STDGPU_OUTPUT_DEVICE_TEST_FLAGS} "$<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-declarations>")
+    endif()
+
+    # Make output variable visible
+    set(${STDGPU_OUTPUT_DEVICE_TEST_FLAGS} ${${STDGPU_OUTPUT_DEVICE_TEST_FLAGS}} PARENT_SCOPE)
+endfunction()
+
+
+function(stdgpu_cuda_set_architecture_flags STDGPU_OUTPUT_DEVICE_COMPILE_AND_LINK_FLAGS)
+    # NOTE Available in CMake 3.17+
+    # include("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/check_compute_capability.cmake")
+    include("${stdgpu_SOURCE_DIR}/cmake/${STDGPU_BACKEND_DIRECTORY}/check_compute_capability.cmake")
+
+    set(STDGPU_CUDA_MIN_CC 35) # Minimum CC : Determined by used features, limits CUDA version at EOL
+    set(STDGPU_CUDA_MAX_CC 75) # Maximum CC : Determined by minimum CUDA version
+
+    message(STATUS "CUDA Compute Capability (CC) Configuration")
+    message(STATUS "  Minimum required CC  : ${STDGPU_CUDA_MIN_CC}")
+    message(STATUS "  Maximum supported CC : ${STDGPU_CUDA_MAX_CC} (newer supported via JIT compilation)")
+    set(STDGPU_CUDA_HAVE_SUITABLE_GPU FALSE)
+
+    foreach(STDGPU_CUDA_CC IN LISTS STDGPU_CUDA_COMPUTE_CAPABILITIES)
+        # STDGPU_CUDA_CC < STDGPU_CUDA_MIN_CC
+        if(${STDGPU_CUDA_CC} LESS ${STDGPU_CUDA_MIN_CC})
+            message(STATUS "  Skip compilation for CC ${STDGPU_CUDA_CC} which is too old")
+        # STDGPU_CUDA_MIN_CC <= STDGPU_CUDA_CC <= STDGPU_CUDA_MAX_CC
+        elseif(NOT ${STDGPU_CUDA_CC} GREATER ${STDGPU_CUDA_MAX_CC})
+            if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+                string(APPEND ${STDGPU_OUTPUT_DEVICE_COMPILE_AND_LINK_FLAGS} " --generate-code arch=compute_${STDGPU_CUDA_CC},code=sm_${STDGPU_CUDA_CC}")
+                message(STATUS "  Enabled compilation for CC ${STDGPU_CUDA_CC}")
+                set(STDGPU_CUDA_HAVE_SUITABLE_GPU TRUE)
+            endif()
+        # STDGPU_CUDA_MAX_CC < STDGPU_CUDA_CC
+        else()
+            if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+                string(APPEND ${STDGPU_OUTPUT_DEVICE_COMPILE_AND_LINK_FLAGS} " --generate-code arch=compute_${STDGPU_CUDA_MAX_CC},code=compute_${STDGPU_CUDA_MAX_CC}")
+                message(STATUS "  Enabled compilation for CC ${STDGPU_CUDA_CC} via JIT compilation of ${STDGPU_CUDA_MAX_CC}")
+                set(STDGPU_CUDA_HAVE_SUITABLE_GPU TRUE)
+            endif()
+        endif()
+    endforeach()
+
+    if(NOT STDGPU_CUDA_HAVE_SUITABLE_GPU)
+        message(FATAL_ERROR "  No CUDA-capable GPU with at least CC ${STDGPU_CUDA_MIN_CC} detected")
+    endif()
+
+    # Make output variable visible
+    set(${STDGPU_OUTPUT_DEVICE_COMPILE_AND_LINK_FLAGS} ${${STDGPU_OUTPUT_DEVICE_COMPILE_AND_LINK_FLAGS}} PARENT_SCOPE)
+endfunction()

--- a/cmake/openmp/set_device_flags.cmake
+++ b/cmake/openmp/set_device_flags.cmake
@@ -1,2 +1,9 @@
+function(stdgpu_set_device_flags STDGPU_OUTPUT_DEVICE_FLAGS)
+    # No flags required
+endfunction()
 
-message(STATUS "Created device flags : See host flags")
+
+# Auxiliary compiler flags for tests to be used with target_compile_options
+function(stdgpu_set_test_device_flags STDGPU_OUTPUT_DEVICE_TEST_FLAGS)
+    # No flags required
+endfunction()

--- a/cmake/set_host_flags.cmake
+++ b/cmake/set_host_flags.cmake
@@ -1,39 +1,48 @@
+function(stdgpu_set_host_flags STDGPU_OUTPUT_HOST_FLAGS)
+    # Clear list before appending flags
+    unset(${STDGPU_OUTPUT_HOST_FLAGS})
 
-if(NOT MSVC)
-    string(APPEND STDGPU_HOST_FLAGS " -Wall")
-    string(APPEND STDGPU_HOST_FLAGS " -pedantic")
-    string(APPEND STDGPU_HOST_FLAGS " -Wextra")
-    string(APPEND STDGPU_HOST_FLAGS " -Wshadow")
-    string(APPEND STDGPU_HOST_FLAGS " -Wsign-compare")
-    string(APPEND STDGPU_HOST_FLAGS " -Wconversion")
-    string(APPEND STDGPU_HOST_FLAGS " -Wfloat-equal")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wall")
+        list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-pedantic")
+        list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wextra")
+        list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wshadow")
+        list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wsign-compare")
+        list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wconversion")
+        list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wfloat-equal")
 
-    if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
-        string(APPEND STDGPU_HOST_FLAGS " -Werror")
+        if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
+            list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Werror")
+        endif()
+
+        if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+            list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-O3")
+        endif()
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "/W2") # or /W3 or /W4 depending on how useful this is
+
+        if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
+            list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "/WX")
+        endif()
+
+        #list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "/O2")
     endif()
 
-    if(${CMAKE_BUILD_TYPE} MATCHES "Release" OR ${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
-        string(APPEND STDGPU_HOST_FLAGS " -O3")
-    endif()
-else()
-    string(APPEND STDGPU_HOST_FLAGS " /W2") # or /W3 or /W4 depending on how useful this is
+    set(${STDGPU_OUTPUT_HOST_FLAGS} "$<$<COMPILE_LANGUAGE:CXX>:${${STDGPU_OUTPUT_HOST_FLAGS}}>")
 
-    if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
-        string(APPEND STDGPU_HOST_FLAGS " /WX")
-    endif()
+    # Make output variable visible
+    set(${STDGPU_OUTPUT_HOST_FLAGS} ${${STDGPU_OUTPUT_HOST_FLAGS}} PARENT_SCOPE)
+endfunction()
 
-    #string(APPEND STDGPU_HOST_FLAGS " /O2")
-endif()
-
-# Apply compiler flags
-string(APPEND CMAKE_CXX_FLAGS ${STDGPU_HOST_FLAGS})
-
-message(STATUS "Created host flags : ${STDGPU_HOST_FLAGS}")
-message(STATUS "Building with CXX flags : ${CMAKE_CXX_FLAGS}")
 
 # Auxiliary compiler flags for tests to be used with target_compile_options
-if(NOT MSVC)
-    set(STDGPU_TEST_HOST_FLAGS "$<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>")
-else()
-    set(STDGPU_TEST_HOST_FLAGS "$<$<COMPILE_LANGUAGE:CXX>:/wd4996>")
-endif()
+function(stdgpu_set_test_host_flags STDGPU_OUTPUT_HOST_TEST_FLAGS)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set(${STDGPU_OUTPUT_HOST_TEST_FLAGS} "$<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>")
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        set(${STDGPU_OUTPUT_HOST_TEST_FLAGS} "$<$<COMPILE_LANGUAGE:CXX>:/wd4996>")
+    endif()
+
+    # Make output variable visible
+    set(${STDGPU_OUTPUT_HOST_TEST_FLAGS} ${${STDGPU_OUTPUT_HOST_TEST_FLAGS}} PARENT_SCOPE)
+endfunction()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,6 +5,8 @@
 macro(stdgpu_detail_add_example)
     set(STDGPU_EXAMPLES_NAME "${ARGV0}")
     add_executable(${STDGPU_EXAMPLES_NAME} "${STDGPU_EXAMPLES_NAME}.${ARGV1}")
+    target_compile_options(${STDGPU_EXAMPLES_NAME} PRIVATE ${STDGPU_DEVICE_FLAGS}
+                                                           ${STDGPU_HOST_FLAGS})
     target_link_libraries(${STDGPU_EXAMPLES_NAME} PRIVATE stdgpu::stdgpu)
 endmacro()
 

--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -55,6 +55,9 @@ target_include_directories(stdgpu PUBLIC
 
 target_compile_features(stdgpu PUBLIC cxx_std_14)
 
+target_compile_options(stdgpu PRIVATE ${STDGPU_DEVICE_FLAGS}
+                                      ${STDGPU_HOST_FLAGS})
+
 target_link_libraries(stdgpu PUBLIC thrust::thrust)
 
 add_library(stdgpu::stdgpu ALIAS stdgpu)

--- a/src/stdgpu/rocm/CMakeLists.txt
+++ b/src/stdgpu/rocm/CMakeLists.txt
@@ -12,6 +12,11 @@ target_sources(stdgpu PRIVATE impl/memory.cpp
 
 target_compile_definitions(stdgpu PUBLIC THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP)
 
+include("${stdgpu_SOURCE_DIR}/cmake/${STDGPU_BACKEND_DIRECTORY}/set_device_flags.cmake")
+# NOTE ROCm architecture flags must be passed as device link flags
+stdgpu_rocm_set_architecture_flags(STDGPU_DEVICE_LINK_FLAGS)
+message(STATUS "Created ROCm device link flags : ${STDGPU_DEVICE_LINK_FLAGS}")
+
 target_link_options(stdgpu PUBLIC ${STDGPU_DEVICE_LINK_FLAGS})
 
 

--- a/test/stdgpu/CMakeLists.txt
+++ b/test/stdgpu/CMakeLists.txt
@@ -16,10 +16,9 @@ add_subdirectory(${STDGPU_BACKEND_DIRECTORY})
 target_include_directories(teststdgpu PRIVATE
                                       "${CMAKE_CURRENT_SOURCE_DIR}/..") # test_utils
 
-message(STATUS "Applying auxiliary test device flags: ${STDGPU_TEST_DEVICE_FLAGS}")
-message(STATUS "Applying auxiliary test host flags: ${STDGPU_TEST_HOST_FLAGS}")
-
-target_compile_options(teststdgpu PRIVATE ${STDGPU_TEST_DEVICE_FLAGS}
+target_compile_options(teststdgpu PRIVATE ${STDGPU_DEVICE_FLAGS}
+                                          ${STDGPU_HOST_FLAGS}
+                                          ${STDGPU_TEST_DEVICE_FLAGS}
                                           ${STDGPU_TEST_HOST_FLAGS})
 
 target_link_libraries(teststdgpu PRIVATE


### PR DESCRIPTION
The current behavior of applying compiler flags is to append them to `CMAKE_<LANG>_FLAGS` which may not be robust. Furthermore, the respective files, i.e. `set_host_flags.cmake` and `set_device_flags.cmake`, directly apply the modification. Instead, the modern way to add compiler flags is through `target_compile_options(...)`.

Refactor the compile flag generation process by separating the set of flags into distinct functions and improve the compiler detection via `CMAKE_<LANG>_COMPILER_ID`. This results in a better grouping of flags across the backends and a cleaner handling of the generated flags across different compilers.