### PR TITLE
General: Add clang-tidy support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+---
+Checks: "-*,\
+bugprone-*,\
+hicpp-*,\
+-hicpp-vararg,\
+-hicpp-use-auto,\
+-hicpp-no-array-decay,\
+-hicpp-special-member-functions,\
+misc-*,\
+-misc-macro-parentheses,\
+modernize-*,\
+-modernize-use-auto,\
+performance-*,\
+readability-*,\
+-readability-avoid-const-params-in-decls,\
+"
+HeaderFilterRegex: 'src|test/stdgpu'
+...
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,13 @@ if(STDGPU_SETUP_COMPILER_FLAGS)
 endif()
 
 
+option(STDGPU_ANALYZE_WITH_CLANG_TIDY "Analyzes the code with clang-tidy, default: OFF" OFF)
+if(STDGPU_ANALYZE_WITH_CLANG_TIDY)
+    include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/setup_clang_tidy.cmake")
+    stdgpu_setup_clang_tidy(STDGPU_PROPERTY_CLANG_TIDY)
+endif()
+
+
 # Setup install paths
 set(STDGPU_LIB_INSTALL_DIR "lib")
 set(STDGPU_BIN_INSTALL_DIR "bin")

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Build Option | Effect | Default
 `STDGPU_BACKEND` | Device system backend | `STDGPU_BACKEND_CUDA`
 `STDGPU_SETUP_COMPILER_FLAGS` | Constructs the compiler flags | `ON` if standalone, `OFF` if included via `add_subdirectory`
 `STDGPU_TREAT_WARNINGS_AS_ERRORS` | Treats compiler warnings as errors | `OFF`
+`STDGPU_ANALYZE_WITH_CLANG_TIDY` | Analyzes the code with clang-tidy | `OFF`
 `STDGPU_BUILD_SHARED_LIBS` | Builds the project as a shared library, if set to `ON`, or as a static library, if set to `OFF` | `BUILD_SHARED_LIBS`
 `STDGPU_BUILD_EXAMPLES` | Build the examples | `ON`
 `STDGPU_BUILD_TESTS` | Build the unit tests | `ON`

--- a/cmake/config_summary.cmake
+++ b/cmake/config_summary.cmake
@@ -14,6 +14,7 @@ function(stdgpu_print_configuration_summary)
     message(STATUS "  STDGPU_BACKEND                            :   ${STDGPU_BACKEND}")
     message(STATUS "  STDGPU_SETUP_COMPILER_FLAGS               :   ${STDGPU_SETUP_COMPILER_FLAGS} (depends on usage method)")
     message(STATUS "  STDGPU_TREAT_WARNINGS_AS_ERRORS           :   ${STDGPU_TREAT_WARNINGS_AS_ERRORS}")
+    message(STATUS "  STDGPU_ANALYZE_WITH_CLANG_TIDY            :   ${STDGPU_ANALYZE_WITH_CLANG_TIDY}")
     message(STATUS "  STDGPU_BUILD_SHARED_LIBS                  :   ${STDGPU_BUILD_SHARED_LIBS} (depends on BUILD_SHARED_LIBS)")
 
     message(STATUS "")

--- a/cmake/setup_clang_tidy.cmake
+++ b/cmake/setup_clang_tidy.cmake
@@ -1,0 +1,22 @@
+function(stdgpu_setup_clang_tidy STDGPU_OUTPUT_PROPERTY_CLANG_TIDY)
+    find_program(STDGPU_CLANG_TIDY
+                 NAMES
+                 "clang-tidy")
+
+    if(NOT STDGPU_CLANG_TIDY)
+        message(FATAL_ERROR "clang-tidy not found.")
+    endif()
+
+    set(${STDGPU_OUTPUT_PROPERTY_CLANG_TIDY} "${STDGPU_CLANG_TIDY}")
+
+    if(NOT DEFINED STDGPU_TREAT_WARNINGS_AS_ERRORS)
+        message(FATAL_ERROR "STDGPU_TREAT_WARNINGS_AS_ERRORS not defined.")
+    endif()
+
+    if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
+        list(APPEND ${STDGPU_OUTPUT_PROPERTY_CLANG_TIDY} "-warnings-as-errors=*")
+    endif()
+
+    # Make output variable visible
+    set(${STDGPU_OUTPUT_PROPERTY_CLANG_TIDY} ${${STDGPU_OUTPUT_PROPERTY_CLANG_TIDY}} PARENT_SCOPE)
+endfunction()

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -197,6 +197,7 @@ Build Option | Effect | Default
 `STDGPU_BACKEND` | Device system backend | `STDGPU_BACKEND_CUDA`
 `STDGPU_SETUP_COMPILER_FLAGS` | Constructs the compiler flags | `ON` if standalone, `OFF` if included via `add_subdirectory`
 `STDGPU_TREAT_WARNINGS_AS_ERRORS` | Treats compiler warnings as errors | `OFF`
+`STDGPU_ANALYZE_WITH_CLANG_TIDY` | Analyzes the code with clang-tidy | `OFF`
 `STDGPU_BUILD_SHARED_LIBS` | Builds the project as a shared library, if set to `ON`, or as a static library, if set to `OFF` | `BUILD_SHARED_LIBS`
 `STDGPU_BUILD_EXAMPLES` | Build the examples | `ON`
 `STDGPU_BUILD_TESTS` | Build the unit tests | `ON`

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,6 +8,7 @@ macro(stdgpu_detail_add_example)
     target_compile_options(${STDGPU_EXAMPLES_NAME} PRIVATE ${STDGPU_DEVICE_FLAGS}
                                                            ${STDGPU_HOST_FLAGS})
     target_link_libraries(${STDGPU_EXAMPLES_NAME} PRIVATE stdgpu::stdgpu)
+    set_target_properties(${STDGPU_EXAMPLES_NAME} PROPERTIES CXX_CLANG_TIDY "${STDGPU_PROPERTY_CLANG_TIDY}")
 endmacro()
 
 macro(stdgpu_add_example_cpp)

--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -60,6 +60,8 @@ target_compile_options(stdgpu PRIVATE ${STDGPU_DEVICE_FLAGS}
 
 target_link_libraries(stdgpu PUBLIC thrust::thrust)
 
+set_target_properties(stdgpu PROPERTIES CXX_CLANG_TIDY "${STDGPU_PROPERTY_CLANG_TIDY}")
+
 add_library(stdgpu::stdgpu ALIAS stdgpu)
 
 

--- a/test/stdgpu/CMakeLists.txt
+++ b/test/stdgpu/CMakeLists.txt
@@ -25,6 +25,8 @@ target_link_libraries(teststdgpu PRIVATE
                                  stdgpu::stdgpu
                                  gtest)
 
+set_target_properties(teststdgpu PROPERTIES CXX_CLANG_TIDY "${STDGPU_PROPERTY_CLANG_TIDY}")
+
 
 add_test(NAME teststdgpu
          COMMAND teststdgpu)


### PR DESCRIPTION
clang-tidy allows to improve code quality and reduce the likelihood of introducing unnoticed regressions. Add native support for clang-tidy to build and analyze the project with clang-tidy.

Here, the config file `.clang-tidy` contains an initial set of enabled warnings after experimenting with some options. This list will be updated and extended in the future.