### PR TITLE
examples,src,test: Fix hicpp-explicit-conversion warnings

### DIFF
--- a/examples/cuda/thrust_towards_ranges.cu
+++ b/examples/cuda/thrust_towards_ranges.cu
@@ -39,7 +39,7 @@ struct square_int
 class atomic_sum
 {
     public:
-        atomic_sum(stdgpu::atomic<int> sum)
+        explicit atomic_sum(stdgpu::atomic<int> sum)
             : _sum(sum)
         {
 

--- a/examples/openmp/thrust_towards_ranges.cpp
+++ b/examples/openmp/thrust_towards_ranges.cpp
@@ -39,7 +39,7 @@ struct square_int
 class atomic_sum
 {
     public:
-        atomic_sum(stdgpu::atomic<int> sum)
+        explicit atomic_sum(stdgpu::atomic<int> sum)
             : _sum(sum)
         {
 

--- a/examples/rocm/thrust_towards_ranges.cpp
+++ b/examples/rocm/thrust_towards_ranges.cpp
@@ -39,7 +39,7 @@ struct square_int
 class atomic_sum
 {
     public:
-        atomic_sum(stdgpu::atomic<int> sum)
+        explicit atomic_sum(stdgpu::atomic<int> sum)
             : _sum(sum)
         {
 

--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -108,7 +108,7 @@ class atomic
          * \note Equivalent to load()
          */
         STDGPU_HOST_DEVICE
-        operator T() const;
+        operator T() const; // NOLINT(hicpp-explicit-conversions)
 
 
         /**
@@ -390,7 +390,7 @@ class atomic_ref
          * \note Equivalent to load()
          */
         STDGPU_HOST_DEVICE
-        operator T() const;
+        operator T() const; // NOLINT(hicpp-explicit-conversions)
 
 
         /**

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -88,7 +88,7 @@ class bitset
                  * \return The value of the bit
                  */
                 STDGPU_DEVICE_ONLY
-                operator bool() const;
+                operator bool() const; // NOLINT(hicpp-explicit-conversions)
 
                 /**
                  * \brief Returns the inverse of the value of the bit

--- a/src/stdgpu/impl/bitset.inc
+++ b/src/stdgpu/impl/bitset.inc
@@ -71,7 +71,7 @@ class set_bits
 class flip_bits
 {
     public:
-        flip_bits(const bitset& bits)
+        explicit flip_bits(const bitset& bits)
             : _bits(bits)
         {
 

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -516,7 +516,7 @@ template <typename T>
 class deque_collect_positions
 {
     public:
-        deque_collect_positions(const deque<T>& d)
+        explicit deque_collect_positions(const deque<T>& d)
             : _d(d)
         {
 

--- a/src/stdgpu/impl/iterator_detail.h
+++ b/src/stdgpu/impl/iterator_detail.h
@@ -260,7 +260,7 @@ class back_insert_iterator_proxy
 {
     public:
         STDGPU_HOST_DEVICE
-        back_insert_iterator_proxy(const Container& c)
+        explicit back_insert_iterator_proxy(const Container& c)
             : _c(c)
         {
 
@@ -295,7 +295,7 @@ class front_insert_iterator_proxy
 {
     public:
         STDGPU_HOST_DEVICE
-        front_insert_iterator_proxy(const Container& c)
+        explicit front_insert_iterator_proxy(const Container& c)
             : _c(c)
         {
 
@@ -330,7 +330,7 @@ class insert_iterator_proxy
 {
     public:
         STDGPU_HOST_DEVICE
-        insert_iterator_proxy(const Container& c)
+        explicit insert_iterator_proxy(const Container& c)
             : _c(c)
         {
 

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -57,7 +57,7 @@ class construct_value
 {
     public:
         STDGPU_HOST_DEVICE
-        construct_value(const T& value)
+        explicit construct_value(const T& value)
             : _value(value)
         {
 

--- a/src/stdgpu/impl/mutex.inc
+++ b/src/stdgpu/impl/mutex.inc
@@ -48,7 +48,7 @@ namespace detail
 class unlocked
 {
     public:
-        unlocked(const mutex_array& lock_bits)
+        explicit unlocked(const mutex_array& lock_bits)
             : _lock_bits(lock_bits)
         {
 

--- a/src/stdgpu/impl/ranges_detail.h
+++ b/src/stdgpu/impl/ranges_detail.h
@@ -300,8 +300,11 @@ struct select
 {
     select() = default;
 
+    // NOTE
+    // Implicit conversion required for {host,device}_indexed_range:
+    // Usage via constructor with arguments {host,device}_range<index_t>, T*
     STDGPU_HOST_DEVICE
-    select(T* values)
+    select(T* values) // NOLINT(hicpp-explicit-conversions)
         : _values(values)
     {
 

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -157,7 +157,7 @@ template <typename Key, typename Value, typename KeyFromValue, typename Hash, ty
 class unordered_base_collect_positions
 {
     public:
-        unordered_base_collect_positions(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
+        explicit unordered_base_collect_positions(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
             : _base(base)
         {
 
@@ -194,7 +194,7 @@ template <typename Key, typename Value, typename KeyFromValue, typename Hash, ty
 class offset_inside_range
 {
     public:
-        offset_inside_range(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
+        explicit offset_inside_range(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
             : _base(base)
         {
 
@@ -231,7 +231,7 @@ class count_visits
 {
     public:
         count_visits(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base,
-                    int* flags)
+                     int* flags)
             : _base(base),
               _flags(flags)
         {
@@ -295,7 +295,7 @@ template <typename Key, typename Value, typename KeyFromValue, typename Hash, ty
 class value_reachable
 {
     public:
-        value_reachable(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
+        explicit value_reachable(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
             : _base(base)
         {
 
@@ -334,7 +334,7 @@ template <typename Key, typename Value, typename KeyFromValue, typename Hash, ty
 class values_unique
 {
     public:
-        values_unique(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
+        explicit values_unique(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
             : _base(base)
         {
 
@@ -387,7 +387,7 @@ template <typename Key, typename Value, typename KeyFromValue, typename Hash, ty
 class insert_value
 {
     public:
-        insert_value(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
+        explicit insert_value(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
             : _base(base)
         {
 
@@ -408,7 +408,7 @@ template <typename Key, typename Value, typename KeyFromValue, typename Hash, ty
 class erase_from_key
 {
     public:
-        erase_from_key(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
+        explicit erase_from_key(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
             : _base(base)
         {
 
@@ -429,7 +429,7 @@ template <typename Key, typename Value, typename KeyFromValue, typename Hash, ty
 class erase_from_value
 {
     public:
-        erase_from_value(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
+        explicit erase_from_value(const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>& base)
             : _base(base)
         {
 

--- a/src/stdgpu/iterator.h
+++ b/src/stdgpu/iterator.h
@@ -439,7 +439,7 @@ class back_insert_iterator
          * \param[in] c The container into which the elements are inserted
          */
         STDGPU_HOST_DEVICE
-        back_insert_iterator(Container& c);
+        explicit back_insert_iterator(Container& c);
 
     private:
         STDGPU_HOST_DEVICE typename super_t::reference
@@ -478,7 +478,7 @@ class front_insert_iterator
          * \param[in] c The container into which the elements are inserted
          */
         STDGPU_HOST_DEVICE
-        front_insert_iterator(Container& c);
+        explicit front_insert_iterator(Container& c);
 
     private:
         STDGPU_HOST_DEVICE typename super_t::reference
@@ -520,7 +520,7 @@ class insert_iterator
          * \param[in] c The container into which the elements are inserted
          */
         STDGPU_HOST_DEVICE
-        insert_iterator(Container& c);
+        explicit insert_iterator(Container& c);
 
     private:
         STDGPU_HOST_DEVICE typename super_t::reference

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -93,7 +93,7 @@ class mutex_array
                 friend mutex_ref;
 
                 STDGPU_HOST_DEVICE
-                reference(bitset::reference bit_ref);
+                explicit reference(bitset::reference bit_ref);
 
                 bitset::reference _bit_ref;
         };
@@ -181,7 +181,7 @@ class mutex_ref
          * \note This is a porting aid to mutex_array::reference which has the same API but is more lightweight than this class
          */
         STDGPU_DEVICE_ONLY
-        operator mutex_array::reference();
+        operator mutex_array::reference(); // NOLINT(hicpp-explicit-conversions)
 
         /**
          * \brief See mutex_array::reference

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -275,7 +275,7 @@ template <typename T>
 class exchange_sequence
 {
     public:
-        exchange_sequence(stdgpu::atomic<T> value)
+        explicit exchange_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -339,7 +339,7 @@ template <typename T>
 class add_sequence_with_compare_exchange_weak
 {
     public:
-        add_sequence_with_compare_exchange_weak(stdgpu::atomic<T> value)
+        explicit add_sequence_with_compare_exchange_weak(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -362,7 +362,7 @@ template <typename T>
 class add_sequence_with_compare_exchange_strong
 {
     public:
-        add_sequence_with_compare_exchange_strong(stdgpu::atomic<T> value)
+        explicit add_sequence_with_compare_exchange_strong(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -459,7 +459,7 @@ template <typename T>
 class add_sequence
 {
     public:
-        add_sequence(stdgpu::atomic<T> value)
+        explicit add_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -480,7 +480,7 @@ template <typename T>
 class add_equals_sequence
 {
     public:
-        add_equals_sequence(stdgpu::atomic<T> value)
+        explicit add_equals_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -575,7 +575,7 @@ template <typename T>
 class sub_sequence
 {
     public:
-        sub_sequence(stdgpu::atomic<T> value)
+        explicit sub_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -596,7 +596,7 @@ template <typename T>
 class sub_equals_sequence
 {
     public:
-        sub_equals_sequence(stdgpu::atomic<T> value)
+        explicit sub_equals_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -710,7 +710,7 @@ template <typename T>
 class or_sequence
 {
     public:
-        or_sequence(stdgpu::atomic<T> value)
+        explicit or_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -733,7 +733,7 @@ template <typename T>
 class or_equals_sequence
 {
     public:
-        or_equals_sequence(stdgpu::atomic<T> value)
+        explicit or_equals_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -978,7 +978,7 @@ template <typename T>
 class xor_sequence
 {
     public:
-        xor_sequence(stdgpu::atomic<T> value)
+        explicit xor_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -1001,7 +1001,7 @@ template <typename T>
 class xor_equals_sequence
 {
     public:
-        xor_equals_sequence(stdgpu::atomic<T> value)
+        explicit xor_equals_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -1098,7 +1098,7 @@ template <typename T>
 class min_sequence
 {
     public:
-        min_sequence(stdgpu::atomic<T> value)
+        explicit min_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -1157,7 +1157,7 @@ template <typename T>
 class max_sequence
 {
     public:
-        max_sequence(stdgpu::atomic<T> value)
+        explicit max_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -1216,7 +1216,7 @@ template <typename T>
 class inc_mod_sequence
 {
     public:
-        inc_mod_sequence(stdgpu::atomic<T> value)
+        explicit inc_mod_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -1274,7 +1274,7 @@ template <typename T>
 class dec_mod_dequence
 {
     public:
-        dec_mod_dequence(stdgpu::atomic<T> value)
+        explicit dec_mod_dequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -1332,7 +1332,7 @@ template <typename T>
 class pre_inc_sequence
 {
     public:
-        pre_inc_sequence(stdgpu::atomic<T> value)
+        explicit pre_inc_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -1396,7 +1396,7 @@ template <typename T>
 class post_inc_sequence
 {
     public:
-        post_inc_sequence(stdgpu::atomic<T> value)
+        explicit post_inc_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -1460,7 +1460,7 @@ template <typename T>
 class pre_dec_sequence
 {
     public:
-        pre_dec_sequence(stdgpu::atomic<T> value)
+        explicit pre_dec_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 
@@ -1531,7 +1531,7 @@ template <typename T>
 class post_dec_sequence
 {
     public:
-        post_dec_sequence(stdgpu::atomic<T> value)
+        explicit post_dec_sequence(stdgpu::atomic<T> value)
             : _value(value)
         {
 

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -60,7 +60,7 @@ TEST_F(stdgpu_bitset, default_values)
 class set_all_bits
 {
     public:
-        set_all_bits(stdgpu::bitset bitset)
+        explicit set_all_bits(stdgpu::bitset bitset)
             : _bitset(bitset)
         {
 
@@ -82,7 +82,7 @@ class set_all_bits
 class reset_all_bits
 {
     public:
-        reset_all_bits(stdgpu::bitset bitset)
+        explicit reset_all_bits(stdgpu::bitset bitset)
             : _bitset(bitset)
         {
 
@@ -104,7 +104,7 @@ class reset_all_bits
 class set_and_reset_all_bits
 {
     public:
-        set_and_reset_all_bits(stdgpu::bitset bitset)
+        explicit set_and_reset_all_bits(stdgpu::bitset bitset)
             : _bitset(bitset)
         {
 
@@ -131,7 +131,7 @@ class set_and_reset_all_bits
 class flip_all_bits
 {
     public:
-        flip_all_bits(stdgpu::bitset bitset)
+        explicit flip_all_bits(stdgpu::bitset bitset)
             : _bitset(bitset)
         {
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -68,7 +68,7 @@ template <typename T>
 class pop_back_deque
 {
     public:
-        pop_back_deque(stdgpu::deque<T> pool)
+        explicit pop_back_deque(stdgpu::deque<T> pool)
             : _pool(pool)
         {
 
@@ -88,7 +88,7 @@ template <typename Pair>
 class pop_back_deque_const_type
 {
     public:
-        pop_back_deque_const_type(stdgpu::deque<Pair> pool)
+        explicit pop_back_deque_const_type(stdgpu::deque<Pair> pool)
             : _pool(pool)
         {
 
@@ -109,7 +109,7 @@ template <typename T>
 class push_back_deque
 {
     public:
-        push_back_deque(stdgpu::deque<T> pool)
+        explicit push_back_deque(stdgpu::deque<T> pool)
             : _pool(pool)
         {
 
@@ -153,7 +153,7 @@ template <typename T>
 class emplace_back_deque
 {
     public:
-        emplace_back_deque(stdgpu::deque<T> pool)
+        explicit emplace_back_deque(stdgpu::deque<T> pool)
             : _pool(pool)
         {
 
@@ -215,14 +215,14 @@ class nondefault_int_deque
         nondefault_int_deque() = delete;
 
         STDGPU_HOST_DEVICE
-        nondefault_int_deque(const int x)
+        nondefault_int_deque(const int x) // NOLINT(hicpp-explicit-conversions)
             : _x(x)
         {
 
         }
 
         STDGPU_HOST_DEVICE
-        operator int() const
+        operator int() const // NOLINT(hicpp-explicit-conversions)
         {
             return _x;
         }
@@ -670,7 +670,7 @@ template <typename T>
 class pop_front_deque
 {
     public:
-        pop_front_deque(stdgpu::deque<T> pool)
+        explicit pop_front_deque(stdgpu::deque<T> pool)
             : _pool(pool)
         {
 
@@ -690,7 +690,7 @@ template <typename Pair>
 class pop_front_deque_const_type
 {
     public:
-        pop_front_deque_const_type(stdgpu::deque<Pair> pool)
+        explicit pop_front_deque_const_type(stdgpu::deque<Pair> pool)
             : _pool(pool)
         {
 
@@ -711,7 +711,7 @@ template <typename T>
 class push_front_deque
 {
     public:
-        push_front_deque(stdgpu::deque<T> pool)
+        explicit push_front_deque(stdgpu::deque<T> pool)
             : _pool(pool)
         {
 
@@ -755,7 +755,7 @@ template <typename T>
 class emplace_front_deque
 {
     public:
-        emplace_front_deque(stdgpu::deque<T> pool)
+        explicit emplace_front_deque(stdgpu::deque<T> pool)
             : _pool(pool)
         {
 
@@ -1597,7 +1597,7 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_front)
 class at_non_const_deque
 {
     public:
-        at_non_const_deque(stdgpu::deque<int> pool)
+        explicit at_non_const_deque(stdgpu::deque<int> pool)
             : _pool(pool)
         {
 
@@ -1639,7 +1639,7 @@ TEST_F(stdgpu_deque, at_non_const)
 class access_operator_non_const_deque
 {
     public:
-        access_operator_non_const_deque(stdgpu::deque<int> pool)
+        explicit access_operator_non_const_deque(stdgpu::deque<int> pool)
             : _pool(pool)
         {
 

--- a/test/stdgpu/iterator.cpp
+++ b/test/stdgpu/iterator.cpp
@@ -350,7 +350,7 @@ class back_insert_interface
     public:
         using value_type = std::vector<int>::value_type;
 
-        back_insert_interface(std::vector<int>& vector)
+        explicit back_insert_interface(std::vector<int>& vector)
             : _vector(vector)
         {
 
@@ -372,7 +372,7 @@ class front_insert_interface
     public:
         using value_type = std::vector<int>::value_type;
 
-        front_insert_interface(std::vector<int>& vector)
+        explicit front_insert_interface(std::vector<int>& vector)
             : _vector(vector)
         {
 
@@ -394,7 +394,7 @@ class insert_interface
     public:
         using value_type = std::vector<int>::value_type;
 
-        insert_interface(std::vector<int>& vector)
+        explicit insert_interface(std::vector<int>& vector)
             : _vector(vector)
         {
 

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -52,7 +52,7 @@ class STDGPU_MEMORY_TEST_CLASS : public ::testing::Test
 class equal_to_number
 {
     public:
-        equal_to_number(const int number)
+        explicit equal_to_number(const int number)
             : _number(number)
         {
 
@@ -1571,7 +1571,7 @@ namespace
     class default_construct
     {
         public:
-            default_construct(const int default_value)
+            explicit default_construct(const int default_value)
                 : _default_value(default_value)
             {
 

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -58,7 +58,7 @@ TEST_F(stdgpu_mutex, default_values)
 class lock_and_unlock
 {
     public:
-        lock_and_unlock(stdgpu::mutex_array locks)
+        explicit lock_and_unlock(stdgpu::mutex_array locks)
             : _locks(locks)
         {
 
@@ -151,7 +151,7 @@ equal(const stdgpu::mutex_array& locks_1,
 class lock_single_functor
 {
     public:
-        lock_single_functor(stdgpu::mutex_array locks)
+        explicit lock_single_functor(stdgpu::mutex_array locks)
             : _locks(locks)
         {
 
@@ -212,7 +212,7 @@ TEST_F(stdgpu_mutex, single_try_lock_while_locked)
 class lock_multiple_functor
 {
     public:
-        lock_multiple_functor(stdgpu::mutex_array locks)
+        explicit lock_multiple_functor(stdgpu::mutex_array locks)
             : _locks(locks)
         {
 
@@ -345,7 +345,7 @@ TEST_F(stdgpu_mutex, multiple_try_lock_both_locked)
 class lock_multiple_functor_new_reference
 {
     public:
-        lock_multiple_functor_new_reference(stdgpu::mutex_array locks)
+        explicit lock_multiple_functor_new_reference(stdgpu::mutex_array locks)
             : _locks(locks)
         {
 
@@ -387,7 +387,7 @@ lock_multiple_new_reference(const stdgpu::mutex_array locks,
 class lock_single_functor_new_reference
 {
     public:
-        lock_single_functor_new_reference(stdgpu::mutex_array locks)
+        explicit lock_single_functor_new_reference(stdgpu::mutex_array locks)
             : _locks(locks)
         {
 

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -110,7 +110,7 @@ namespace
     {
         public:
             STDGPU_HOST_DEVICE
-            random_key(const std::size_t seed)
+            explicit random_key(const std::size_t seed)
                 : _seed(seed)
             {
 
@@ -2177,7 +2177,7 @@ namespace
     class insert_vector
     {
         public:
-            insert_vector(stdgpu::vector<test_unordered_datastructure::key_type> keys)
+            explicit insert_vector(stdgpu::vector<test_unordered_datastructure::key_type> keys)
                 : _keys(keys)
             {
 
@@ -2232,7 +2232,7 @@ namespace
     class erase_hash
     {
         public:
-            erase_hash(test_unordered_datastructure hash_datastructure)
+            explicit erase_hash(test_unordered_datastructure hash_datastructure)
                 : _hash_datastructure(hash_datastructure)
             {
 

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -65,7 +65,7 @@ template <typename T>
 class pop_back_vector
 {
     public:
-        pop_back_vector(stdgpu::vector<T> pool)
+        explicit pop_back_vector(stdgpu::vector<T> pool)
             : _pool(pool)
         {
 
@@ -85,7 +85,7 @@ template <typename Pair>
 class pop_back_vector_const_type
 {
     public:
-        pop_back_vector_const_type(stdgpu::vector<Pair> pool)
+        explicit pop_back_vector_const_type(stdgpu::vector<Pair> pool)
             : _pool(pool)
         {
 
@@ -106,7 +106,7 @@ template <typename T>
 class push_back_vector
 {
     public:
-        push_back_vector(stdgpu::vector<T> pool)
+        explicit push_back_vector(stdgpu::vector<T> pool)
             : _pool(pool)
         {
 
@@ -126,7 +126,7 @@ template <typename Pair>
 class push_back_vector_const_type
 {
     public:
-        push_back_vector_const_type(stdgpu::vector<Pair> pool,
+        explicit push_back_vector_const_type(stdgpu::vector<Pair> pool,
                                     const typename Pair::second_type& second)
             : _pool(pool),
               _second(second)
@@ -150,7 +150,7 @@ template <typename T>
 class emplace_back_vector
 {
     public:
-        emplace_back_vector(stdgpu::vector<T> pool)
+        explicit emplace_back_vector(stdgpu::vector<T> pool)
             : _pool(pool)
         {
 
@@ -212,14 +212,14 @@ class nondefault_int_vector
         nondefault_int_vector() = delete;
 
         STDGPU_HOST_DEVICE
-        nondefault_int_vector(const int x)
+        nondefault_int_vector(const int x) // NOLINT(hicpp-explicit-conversions)
             : _x(x)
         {
 
         }
 
         STDGPU_HOST_DEVICE
-        operator int() const
+        operator int() const // NOLINT(hicpp-explicit-conversions)
         {
             return _x;
         }
@@ -778,7 +778,7 @@ TEST_F(stdgpu_vector, simultaneous_push_back_and_pop_back)
 class at_non_const_vector
 {
     public:
-        at_non_const_vector(stdgpu::vector<int> pool)
+        explicit at_non_const_vector(stdgpu::vector<int> pool)
             : _pool(pool)
         {
 
@@ -820,7 +820,7 @@ TEST_F(stdgpu_vector, at_non_const)
 class access_operator_non_const_vector
 {
     public:
-        access_operator_non_const_vector(stdgpu::vector<int> pool)
+        explicit access_operator_non_const_vector(stdgpu::vector<int> pool)
             : _pool(pool)
         {
 


### PR DESCRIPTION
A common pitfall are single-parameter constructors since they allow implicit conversions between classes/types. Since this behavior is usually undesired, they should be marked `explicit`. Fix all of these undesired cases. For the few desired ones, suppress the clang-tidy warnings.