### PR TITLE
src,test: Fix hicpp-braces-around-statements warnings

### DIFF
--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -315,7 +315,10 @@ template <typename T>
 inline STDGPU_HOST_DEVICE T
 atomic_ref<T>::load() const
 {
-    if (_value == nullptr) return 0;
+    if (_value == nullptr)
+    {
+        return 0;
+    }
 
     T local_value;
     #if STDGPU_CODE == STDGPU_CODE_DEVICE
@@ -340,7 +343,10 @@ template <typename T>
 inline STDGPU_HOST_DEVICE void
 atomic_ref<T>::store(const T desired)
 {
-    if (_value == nullptr) return;
+    if (_value == nullptr)
+    {
+        return;
+    }
 
     #if STDGPU_CODE == STDGPU_CODE_DEVICE
         *(_value) = desired;

--- a/src/stdgpu/impl/bit_detail.h
+++ b/src/stdgpu/impl/bit_detail.h
@@ -37,7 +37,10 @@ template <typename T>
 STDGPU_HOST_DEVICE T
 bit_width(T number)
 {
-    if (number == 0) return 0;
+    if (number == 0)
+    {
+        return 0;
+    }
 
     T result = 1;
     T shifted_number = number;
@@ -108,7 +111,10 @@ STDGPU_HOST_DEVICE T
 bit_floor(const T number)
 {
     // Special case zero
-    if (number == 0) return 0;
+    if (number == 0)
+    {
+        return 0;
+    }
 
     T result = number;
     for (index_t i = 0; i < numeric_limits<T>::digits; ++i)

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -466,7 +466,10 @@ template <typename T>
 inline void
 deque<T>::clear()
 {
-    if (empty()) return;
+    if (empty())
+    {
+        return;
+    }
 
     const index_t begin = static_cast<index_t>(_begin.load());
     const index_t end   = static_cast<index_t>(_end.load());
@@ -501,8 +504,10 @@ inline bool
 deque<T>::valid() const
 {
     // Special case : Zero capacity is valid
-    if (capacity() == 0) return true;
-
+    if (capacity() == 0)
+    {
+        return true;
+    }
 
     return (size_valid()
          && occupied_count_valid()

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -1023,8 +1023,10 @@ bool
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::valid() const
 {
     // Special case : Zero capacity is valid
-    if (total_count() == 0) return true;
-
+    if (total_count() == 0)
+    {
+        return true;
+    }
 
     return (offset_range_valid(*this)
          && loop_free(*this)

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -329,7 +329,10 @@ template <typename T>
 inline void
 vector<T>::clear()
 {
-    if (empty()) return;
+    if (empty())
+    {
+        return;
+    }
 
     const index_t current_size = size();
 
@@ -349,8 +352,10 @@ inline bool
 vector<T>::valid() const
 {
     // Special case : Zero capacity is valid
-    if (capacity() == 0) return true;
-
+    if (capacity() == 0)
+    {
+        return true;
+    }
 
     return (size_valid()
          && occupied_count_valid()

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -350,7 +350,9 @@ class add_sequence_with_compare_exchange_weak
         {
             T old = _value.load();
             while (!_value.compare_exchange_weak(old, old + x))
-            ;   // Wait until exchanged
+            {
+                // Wait until exchanged
+            }
         }
 
     private:
@@ -373,7 +375,9 @@ class add_sequence_with_compare_exchange_strong
         {
             T old = _value.load();
             while (!_value.compare_exchange_strong(old, old + x))
-            ;   // Wait until exchanged
+            {
+                // Wait until exchanged
+            }
         }
 
     private:

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -131,7 +131,10 @@ bool
 equal(const stdgpu::mutex_array& locks_1,
       const stdgpu::mutex_array& locks_2)
 {
-    if (locks_1.size() != locks_2.size()) return false;
+    if (locks_1.size() != locks_2.size())
+    {
+        return false;
+    }
 
     uint8_t* equality_flags = createDeviceArray<uint8_t>(locks_1.size());
 

--- a/test/stdgpu/unordered_map.inc
+++ b/test/stdgpu/unordered_map.inc
@@ -79,14 +79,14 @@ struct less
     operator()(const vec3int16& lhs,
                const vec3int16& rhs) const
     {
-        if (lhs.x < rhs.x) return true;
-        if (lhs.x > rhs.x) return false;
+        if (lhs.x < rhs.x) { return true; }
+        if (lhs.x > rhs.x) { return false; }
 
-        if (lhs.y < rhs.y) return true;
-        if (lhs.y > rhs.y) return false;
+        if (lhs.y < rhs.y) { return true; }
+        if (lhs.y > rhs.y) { return false; }
 
-        if (lhs.z < rhs.z) return true;
-        if (lhs.z > rhs.z) return false;
+        if (lhs.z < rhs.z) { return true; }
+        if (lhs.z > rhs.z) { return false; }
 
         return true;
     }

--- a/test/stdgpu/unordered_set.inc
+++ b/test/stdgpu/unordered_set.inc
@@ -75,14 +75,14 @@ struct less
     operator()(const vec3int16& lhs,
                const vec3int16& rhs) const
     {
-        if (lhs.x < rhs.x) return true;
-        if (lhs.x > rhs.x) return false;
+        if (lhs.x < rhs.x) { return true; }
+        if (lhs.x > rhs.x) { return false; }
 
-        if (lhs.y < rhs.y) return true;
-        if (lhs.y > rhs.y) return false;
+        if (lhs.y < rhs.y) { return true; }
+        if (lhs.y > rhs.y) { return false; }
 
-        if (lhs.z < rhs.z) return true;
-        if (lhs.z > rhs.z) return false;
+        if (lhs.z < rhs.z) { return true; }
+        if (lhs.z > rhs.z) { return false; }
 
         return true;
     }


### PR DESCRIPTION
Although `return` statements after `if` clauses do not require braces, it is still useful to have them for readability reasons. Fix these clang-tidy warnings.