### PR TITLE
src,test: Fix readability-else-after-return warnings

### DIFF
--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -411,7 +411,7 @@ deque<T>::size() const
         printf("stdgpu::deque::size : Size out of bounds: %" STDGPU_PRIINDEX " not in [0, %" STDGPU_PRIINDEX "]. Clamping to 0\n", current_size, _capacity);
         return 0;
     }
-    else if (current_size > _capacity)
+    if (current_size > _capacity)
     {
         printf("stdgpu::deque::size : Size out of bounds: %" STDGPU_PRIINDEX " not in [0, %" STDGPU_PRIINDEX "]. Clamping to %" STDGPU_PRIINDEX "\n", current_size, _capacity, _capacity);
         return _capacity;

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -357,7 +357,7 @@ deallocate(void* p,
         printf("stdgpu::detail::deallocate : Deallocating null pointer not possible\n");
         return;
     }
-    else if (!dispatch_allocation_manager(type).contains_memory(p))
+    if (!dispatch_allocation_manager(type).contains_memory(p))
     {
         printf("stdgpu::detail::deallocate : Deallocating unknown pointer or double freeing not possible\n");
         return;

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -78,22 +78,20 @@ fibonacci_hashing(const std::size_t hash,
     {
         return 0;
     }
-    else
-    {
-        // Improve robustness for Multiplicative Hashing
-        const std::size_t improved_hash = hash ^ (hash >> (numeric_limits<std::size_t>::digits - max_bit_width_result));
 
-        // 2^64/phi, where phi is the golden ratio
-        const std::size_t multiplier = 11400714819323198485llu;
+    // Improve robustness for Multiplicative Hashing
+    const std::size_t improved_hash = hash ^ (hash >> (numeric_limits<std::size_t>::digits - max_bit_width_result));
 
-        // Multiplicative Hashing to the desired range
-        index_t result = static_cast<index_t>((multiplier * improved_hash) >> (numeric_limits<std::size_t>::digits - max_bit_width_result));
+    // 2^64/phi, where phi is the golden ratio
+    const std::size_t multiplier = 11400714819323198485llu;
 
-        STDGPU_ENSURES(0 <= result);
-        STDGPU_ENSURES(result < bucket_count);
+    // Multiplicative Hashing to the desired range
+    index_t result = static_cast<index_t>((multiplier * improved_hash) >> (numeric_limits<std::size_t>::digits - max_bit_width_result));
 
-        return result;
-    }
+    STDGPU_ENSURES(0 <= result);
+    STDGPU_ENSURES(result < bucket_count);
+
+    return result;
 }
 
 
@@ -810,11 +808,9 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find_previous_entry_po
         {
             return previous_position;
         }
+
         // Increment previous (--> equal to key_index)
-        else
-        {
-            previous_position = key_index;
-        }
+        previous_position = key_index;
     }
 
     return key_index;

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -274,7 +274,7 @@ vector<T>::size() const
         printf("stdgpu::vector::size : Size out of bounds: %" STDGPU_PRIINDEX " not in [0, %" STDGPU_PRIINDEX "]. Clamping to 0\n", current_size, _capacity);
         return 0;
     }
-    else if (current_size > _capacity)
+    if (current_size > _capacity)
     {
         printf("stdgpu::vector::size : Size out of bounds: %" STDGPU_PRIINDEX " not in [0, %" STDGPU_PRIINDEX "]. Clamping to %" STDGPU_PRIINDEX "\n", current_size, _capacity, _capacity);
         return _capacity;

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -50,10 +50,8 @@ namespace test_utils
             {
                 return rd();
             }
-            else
-            {
-                throw std::runtime_error("Entropy is 0.0");
-            }
+
+            throw std::runtime_error("Entropy is 0.0");
         }
         // For some reason, this code fails to compile with NVCC+MSVC using the CUDA backend: STDGPU_MAYBE_UNUSED const std::exception& e
         // Thus, use the version below to fix unused paramater warnings


### PR DESCRIPTION
`else` statements after a `return` in the preceding `if` clause seem intuitive at first glance since they follow natural language. However, the `else` statement is superfluous from a technical point of view. Follow clang-tidy recommendations and drop these statements.