### PR TITLE
src,test: Fix readability-implicit-bool-conversion warnings

### DIFF
--- a/src/stdgpu/impl/limits_detail.h
+++ b/src/stdgpu/impl/limits_detail.h
@@ -67,7 +67,7 @@ struct numeric_limits<char>
     static constexpr bool is_signed                                                 = true;
     static constexpr bool is_integer                                                = true;
     static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT - numeric_limits<char>::is_signed;
+    static constexpr int digits                                                     = CHAR_BIT - static_cast<int>(numeric_limits<char>::is_signed);
     static constexpr int radix                                                      = 2;
 };
 
@@ -125,7 +125,7 @@ struct numeric_limits<wchar_t>
     #endif
     static constexpr bool is_integer                                                = true;
     static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT * sizeof(wchar_t) - numeric_limits<wchar_t>::is_signed;
+    static constexpr int digits                                                     = CHAR_BIT * sizeof(wchar_t) - static_cast<int>(numeric_limits<wchar_t>::is_signed);
     static constexpr int radix                                                      = 2;
 };
 

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -311,7 +311,7 @@ class set_bits
         {
             _bitset.set(_positions[i]);
 
-            _set[_positions[i]] = _bitset[_positions[i]];
+            _set[_positions[i]] = static_cast<uint8_t>(_bitset[_positions[i]]);
         }
 
     private:
@@ -339,7 +339,7 @@ class reset_bits
         {
             _bitset.reset(_positions[i]);
 
-            _set[_positions[i]] = _bitset[_positions[i]];
+            _set[_positions[i]] = static_cast<uint8_t>(_bitset[_positions[i]]);
         }
 
     private:
@@ -372,7 +372,7 @@ class set_and_reset_bits
                 _bitset.reset(_positions[i]);
             }
 
-            _set[_positions[i]] = _bitset[_positions[i]];
+            _set[_positions[i]] = static_cast<uint8_t>(_bitset[_positions[i]]);
         }
 
     private:
@@ -400,7 +400,7 @@ class flip_bits
         {
             _bitset.flip(_positions[i]);
 
-            _set[_positions[i]] = _bitset[_positions[i]];
+            _set[_positions[i]] = static_cast<uint8_t>(_bitset[_positions[i]]);
         }
 
     private:


### PR DESCRIPTION
`limits` exploits the fact that boolean values may implicitly be converted to `1` and `0` integer values. This is useful for computing the number of digits for types that may be signed or unsigned such as `char` and `wchar_t`. Fix the related clang-tidy warnings by explicitly casting the boolean values to integers making this intentional usage clear.