### PR TITLE
src: Fix misc-unconventional-assign-operator warnings

### DIFF
--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -126,7 +126,7 @@ class atomic
          * \return The desired value
          * \note Equivalent to store()
          */
-        STDGPU_HOST_DEVICE T
+        STDGPU_HOST_DEVICE T //NOLINT(misc-unconventional-assign-operator)
         operator=(const T desired);
 
 
@@ -408,7 +408,7 @@ class atomic_ref
          * \return The desired value
          * \note Equivalent to store()
          */
-        STDGPU_HOST_DEVICE T
+        STDGPU_HOST_DEVICE T //NOLINT(misc-unconventional-assign-operator)
         operator=(const T desired);
 
 

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -72,7 +72,7 @@ class bitset
                  * \param[in] x A bit value to assign
                  * \return The old value of the bit
                  */
-                STDGPU_DEVICE_ONLY bool
+                STDGPU_DEVICE_ONLY bool //NOLINT(misc-unconventional-assign-operator)
                 operator=(bool x);
 
                 /**
@@ -80,7 +80,7 @@ class bitset
                  * \param[in] x The reference object to assign
                  * \return The old value of the bit
                  */
-                STDGPU_DEVICE_ONLY bool
+                STDGPU_DEVICE_ONLY bool //NOLINT(misc-unconventional-assign-operator)
                 operator=(const reference& x);
 
                 /**

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -97,8 +97,8 @@ atomic<T>::store(const T desired)
 }
 
 
-template <typename T>
-inline STDGPU_HOST_DEVICE T
+template <typename T> //NOLINT(misc-unconventional-assign-operator)
+inline STDGPU_HOST_DEVICE T //NOLINT(misc-unconventional-assign-operator)
 atomic<T>::operator=(const T desired)
 {
     return _value_ref.operator=(desired);
@@ -356,8 +356,8 @@ atomic_ref<T>::store(const T desired)
 }
 
 
-template <typename T>
-inline STDGPU_HOST_DEVICE T
+template <typename T> //NOLINT(misc-unconventional-assign-operator)
+inline STDGPU_HOST_DEVICE T //NOLINT(misc-unconventional-assign-operator)
 atomic_ref<T>::operator=(const T desired)
 {
     store(desired);

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -35,7 +35,7 @@ bitset::reference::reference(bitset::reference::block_type* bit_block,
 }
 
 
-inline STDGPU_DEVICE_ONLY bool
+inline STDGPU_DEVICE_ONLY bool //NOLINT(misc-unconventional-assign-operator)
 bitset::reference::operator=(bool x)
 {
     block_type set_pattern = static_cast<block_type>(1) << _bit_n;
@@ -56,7 +56,7 @@ bitset::reference::operator=(bool x)
 }
 
 
-inline STDGPU_DEVICE_ONLY bool
+inline STDGPU_DEVICE_ONLY bool //NOLINT(misc-unconventional-assign-operator)
 bitset::reference::operator=(const reference& x)
 {
     return operator=(static_cast<bool>(x));

--- a/src/stdgpu/impl/iterator_detail.h
+++ b/src/stdgpu/impl/iterator_detail.h
@@ -266,7 +266,7 @@ class back_insert_iterator_proxy
 
         }
 
-        STDGPU_HOST_DEVICE back_insert_iterator_proxy
+        STDGPU_HOST_DEVICE back_insert_iterator_proxy&
         operator=(const typename Container::value_type& value)
         {
             _c.push_back(value);
@@ -301,7 +301,7 @@ class front_insert_iterator_proxy
 
         }
 
-        STDGPU_HOST_DEVICE front_insert_iterator_proxy
+        STDGPU_HOST_DEVICE front_insert_iterator_proxy&
         operator=(const typename Container::value_type& value)
         {
             _c.push_front(value);
@@ -336,7 +336,7 @@ class insert_iterator_proxy
 
         }
 
-        STDGPU_HOST_DEVICE insert_iterator_proxy
+        STDGPU_HOST_DEVICE insert_iterator_proxy&
         operator=(const typename Container::value_type& value)
         {
             _c.insert(value);


### PR DESCRIPTION
Assignment operators usually coincide with the copy-assignment operator. However, for some cases such as `atomic` and `atomic_ref`, other forms of assignment operators are actually desired. Suppress the related clang-tidy warnings for these cases. Furthermore, fix the wrong return types of the internal iterator proxy classes.