### PR TITLE
examples,src,test: Fix hicpp-signed-bitwise warnings

### DIFF
--- a/examples/createAndDestroyDeviceObject.cpp
+++ b/examples/createAndDestroyDeviceObject.cpp
@@ -13,6 +13,7 @@
  *  limitations under the License.
  */
 
+#include <limits>                   // std::numeric_limits
 #include <stdgpu/memory.h>          // createDeviceArray, destroyDeviceArray, createHostArray, destroyHostArray
 #include <stdgpu/platform.h>        // STDGPU_HOST_DEVICE
 
@@ -96,11 +97,13 @@ class Image
 void
 fill_image(Image image)
 {
+    const stdgpu::index_t value_bound = static_cast<stdgpu::index_t>(std::numeric_limits<std::uint8_t>::max()) + 1;
+
     for (stdgpu::index_t i = 0; i < image.width(); ++i)
     {
         for (stdgpu::index_t j = 0; j < image.height(); ++j)
         {
-            std::uint8_t value = static_cast<std::uint8_t>((i * i + j * j) % (1 << 8));
+            std::uint8_t value = static_cast<std::uint8_t>((i * i + j * j) % value_bound);
 
             image(i, j) = value;
         }

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -541,7 +541,7 @@ template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator&=(const T arg)
 {
-    return fetch_and(arg) & arg;
+    return fetch_and(arg) & arg; // NOLINT(hicpp-signed-bitwise)
 }
 
 
@@ -550,7 +550,7 @@ template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator|=(const T arg)
 {
-    return fetch_or(arg) | arg;
+    return fetch_or(arg) | arg; // NOLINT(hicpp-signed-bitwise)
 }
 
 
@@ -559,7 +559,7 @@ template <typename U, typename>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator^=(const T arg)
 {
-    return fetch_xor(arg) ^ arg;
+    return fetch_xor(arg) ^ arg; // NOLINT(hicpp-signed-bitwise)
 }
 
 } // namespace stdgpu

--- a/src/stdgpu/impl/bit_detail.h
+++ b/src/stdgpu/impl/bit_detail.h
@@ -94,7 +94,7 @@ bit_ceil(const T number)
     result--;
     for (index_t i = 0; i < numeric_limits<T>::digits; ++i)
     {
-        result |= result >> i;
+        result |= result >> static_cast<T>(i);
     }
     result++;
 
@@ -119,9 +119,9 @@ bit_floor(const T number)
     T result = number;
     for (index_t i = 0; i < numeric_limits<T>::digits; ++i)
     {
-        result |= result >> i;
+        result |= result >> static_cast<T>(i);
     }
-    result &= ~(result >> 1);
+    result &= ~(result >> static_cast<T>(1));
 
     STDGPU_ENSURES(has_single_bit(result));
 

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -31,14 +31,15 @@ bitset::reference::reference(bitset::reference::block_type* bit_block,
     : _bit_block(bit_block),
       _bit_n(bit_n)
 {
-
+    STDGPU_EXPECTS(0 <= bit_n);
+    STDGPU_EXPECTS(bit_n < _bits_per_block);
 }
 
 
 inline STDGPU_DEVICE_ONLY bool //NOLINT(misc-unconventional-assign-operator)
 bitset::reference::operator=(bool x)
 {
-    block_type set_pattern = static_cast<block_type>(1) << _bit_n;
+    block_type set_pattern = static_cast<block_type>(1) << static_cast<block_type>(_bit_n);
     block_type reset_pattern = ~set_pattern;
 
     block_type old;
@@ -80,7 +81,7 @@ bitset::reference::operator~() const
 inline STDGPU_DEVICE_ONLY bool
 bitset::reference::flip()
 {
-    block_type flip_pattern = static_cast<block_type>(1) << _bit_n;
+    block_type flip_pattern = static_cast<block_type>(1) << static_cast<block_type>(_bit_n);
 
     stdgpu::atomic_ref<block_type> bit_block(*_bit_block);
     block_type old = bit_block.fetch_xor(flip_pattern);
@@ -96,7 +97,7 @@ bitset::reference::bit(bitset::reference::block_type bits,
     STDGPU_EXPECTS(0 <= n);
     STDGPU_EXPECTS(n < _bits_per_block);
 
-    return ((bits & (static_cast<block_type>(1) << n)) != 0);
+    return ((bits & (static_cast<block_type>(1) << static_cast<block_type>(n))) != 0);
 }
 
 

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -79,14 +79,16 @@ fibonacci_hashing(const std::size_t hash,
         return 0;
     }
 
+    const std::size_t dropped_bit_width = static_cast<std::size_t>(numeric_limits<std::size_t>::digits - max_bit_width_result);
+
     // Improve robustness for Multiplicative Hashing
-    const std::size_t improved_hash = hash ^ (hash >> (numeric_limits<std::size_t>::digits - max_bit_width_result));
+    const std::size_t improved_hash = hash ^ (hash >> dropped_bit_width);
 
     // 2^64/phi, where phi is the golden ratio
     const std::size_t multiplier = 11400714819323198485llu;
 
     // Multiplicative Hashing to the desired range
-    index_t result = static_cast<index_t>((multiplier * improved_hash) >> (numeric_limits<std::size_t>::digits - max_bit_width_result));
+    index_t result = static_cast<index_t>((multiplier * improved_hash) >> dropped_bit_width);
 
     STDGPU_ENSURES(0 <= result);
     STDGPU_ENSURES(result < bucket_count);

--- a/src/stdgpu/openmp/impl/atomic_detail.h
+++ b/src/stdgpu/openmp/impl/atomic_detail.h
@@ -100,7 +100,7 @@ atomic_fetch_and(T* address,
     #pragma omp critical
     {
         old = *address;
-        *address = old & arg;
+        *address = old & arg; // NOLINT(hicpp-signed-bitwise)
     }
     return old;
 }
@@ -115,7 +115,7 @@ atomic_fetch_or(T* address,
     #pragma omp critical
     {
         old = *address;
-        *address = old | arg;
+        *address = old | arg; // NOLINT(hicpp-signed-bitwise)
     }
     return old;
 }
@@ -130,7 +130,7 @@ atomic_fetch_xor(T* address,
     #pragma omp critical
     {
         old = *address;
-        *address = old ^ arg;
+        *address = old ^ arg; // NOLINT(hicpp-signed-bitwise)
     }
     return old;
 }

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -706,7 +706,7 @@ bool
 bit_set(const T value,
         const stdgpu::index_t bit_position)
 {
-    return (1 == ( (value >> bit_position) & 1));
+    return (1 == ( (value >> bit_position) & 1)); // NOLINT(hicpp-signed-bitwise)
 }
 
 
@@ -723,7 +723,7 @@ class or_sequence
         STDGPU_DEVICE_ONLY void
         operator()(const stdgpu::index_t i)
         {
-            T pattern = static_cast<T>(1) << i;
+            T pattern = static_cast<T>(1) << i; // NOLINT(hicpp-signed-bitwise)
 
             _value.fetch_or(pattern);
         }
@@ -746,7 +746,7 @@ class or_equals_sequence
         STDGPU_DEVICE_ONLY void
         operator()(const stdgpu::index_t i)
         {
-            T pattern = static_cast<T>(1) << i;
+            T pattern = static_cast<T>(1) << i; // NOLINT(hicpp-signed-bitwise)
 
             _value |= pattern;
         }
@@ -845,7 +845,7 @@ class and_sequence
         STDGPU_DEVICE_ONLY void
         operator()(const stdgpu::index_t i)
         {
-            T pattern = _one_pattern - (static_cast<T>(1) << i);
+            T pattern = _one_pattern - (static_cast<T>(1) << i); // NOLINT(hicpp-signed-bitwise)
 
             _value.fetch_and(pattern);
         }
@@ -871,7 +871,7 @@ class and_equals_sequence
         STDGPU_DEVICE_ONLY void
         operator()(const stdgpu::index_t i)
         {
-            T pattern = _one_pattern - (static_cast<T>(1) << i);
+            T pattern = _one_pattern - (static_cast<T>(1) << i); // NOLINT(hicpp-signed-bitwise)
 
             _value &= pattern;
         }
@@ -991,7 +991,7 @@ class xor_sequence
         STDGPU_DEVICE_ONLY void
         operator()(const stdgpu::index_t i)
         {
-            T pattern = static_cast<T>(1) << i;
+            T pattern = static_cast<T>(1) << i; // NOLINT(hicpp-signed-bitwise)
 
             _value.fetch_xor(pattern);
         }
@@ -1014,7 +1014,7 @@ class xor_equals_sequence
         STDGPU_DEVICE_ONLY void
         operator()(const stdgpu::index_t i)
         {
-            T pattern = static_cast<T>(1) << i;
+            T pattern = static_cast<T>(1) << i; // NOLINT(hicpp-signed-bitwise)
 
             _value ^= pattern;
         }

--- a/test/stdgpu/bit.cpp
+++ b/test/stdgpu/bit.cpp
@@ -136,7 +136,8 @@ thread_bit_ceil_random(const stdgpu::index_t iterations)
     std::size_t seed = test_utils::random_thread_seed();
 
     std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
-    std::uniform_int_distribution<std::size_t> dist(std::numeric_limits<std::size_t>::lowest(), static_cast<std::size_t>(1) << (std::numeric_limits<std::size_t>::digits - 1));
+    std::uniform_int_distribution<std::size_t> dist(std::numeric_limits<std::size_t>::lowest(),
+                                                    static_cast<std::size_t>(1) << static_cast<std::size_t>(std::numeric_limits<std::size_t>::digits - 1));
 
     for (stdgpu::index_t i = 0; i < iterations; ++i)
     {
@@ -269,7 +270,7 @@ thread_bit_width_random(const stdgpu::index_t iterations)
         std::size_t number_lower_bound = static_cast<std::size_t>(1) << (result - 1);
         EXPECT_GE(number, number_lower_bound);
 
-        if (number < static_cast<std::size_t>(1) << (std::numeric_limits<std::size_t>::digits - 1))
+        if (number < static_cast<std::size_t>(1) << static_cast<std::size_t>(std::numeric_limits<std::size_t>::digits - 1))
         {
             std::size_t number_upper_bound = static_cast<std::size_t>(1) << result;
             EXPECT_LT(number, number_upper_bound);

--- a/test/stdgpu/cstdlib.cpp
+++ b/test/stdgpu/cstdlib.cpp
@@ -61,7 +61,7 @@ thread_values(const stdgpu::index_t iterations)
     for (stdgpu::index_t i = 0; i < iterations; ++i)
     {
         std::size_t x = dist_x(rng);
-        std::size_t y = (static_cast<std::size_t>(1) << dist_y(rng));
+        std::size_t y = static_cast<std::size_t>(1) << static_cast<std::size_t>(dist_y(rng));
 
         std::lldiv_t div_ll         = std::lldiv(static_cast<long long int>(x), static_cast<long long int>(y));
         stdgpu::sizediv_t div_size  = stdgpu::sizedivPow2(x, y);


### PR DESCRIPTION
Bit operations on signed integer types include cases with undefined behavior making this potentially dangerous. Fix some cases where casting to a proper unsigned type is safe. Suppress the warning if the behavior there is intentional, e.g. for the operations on `atomic` and `atomic_ref`.