### PR TITLE
src,test: Fix more clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,16 +4,16 @@ bugprone-*,\
 hicpp-*,\
 -hicpp-vararg,\
 -hicpp-use-auto,\
--hicpp-no-array-decay,\
 -hicpp-special-member-functions,\
 misc-*,\
 -misc-macro-parentheses,\
 modernize-*,\
 -modernize-use-auto,\
+-modernize-pass-by-value,\
+-modernize-return-braced-init-list,\
 performance-*,\
 readability-*,\
 -readability-avoid-const-params-in-decls,\
 "
 HeaderFilterRegex: 'src|test/stdgpu'
 ...
-

--- a/src/stdgpu/contract.h
+++ b/src/stdgpu/contract.h
@@ -56,7 +56,7 @@ namespace stdgpu
                    "  File      : %s:%d\n" \
                    "  Function  : %s\n" \
                    "  Condition : %s\n", \
-                   __FILE__, __LINE__, STDGPU_FUNC, #condition); \
+                   __FILE__, __LINE__, static_cast<const char*>(STDGPU_FUNC), #condition); \
             std::terminate(); \
         }
 

--- a/src/stdgpu/cstdlib.h
+++ b/src/stdgpu/cstdlib.h
@@ -34,8 +34,8 @@ namespace stdgpu
  */
 struct sizediv_t
 {
-    std::size_t quot;   /**< The quotient */
-    std::size_t rem;    /**< The remainder */
+    std::size_t quot = {};  /**< The quotient */
+    std::size_t rem = {};   /**< The remainder */
 };
 
 /**

--- a/src/stdgpu/impl/bitset.inc
+++ b/src/stdgpu/impl/bitset.inc
@@ -117,7 +117,7 @@ void
 bitset::destroyDeviceObject(bitset& device_object)
 {
     destroyDeviceArray<block_type>(device_object._bit_blocks);
-    device_object._bit_blocks   = 0;
+    device_object._bit_blocks   = nullptr;
     device_object._size         = 0;
 }
 

--- a/src/stdgpu/openmp/impl/memory.cpp
+++ b/src/stdgpu/openmp/impl/memory.cpp
@@ -37,7 +37,7 @@ dispatch_malloc(const dynamic_memory_type type,
         case dynamic_memory_type::host :
         case dynamic_memory_type::managed :
         {
-            *array = std::malloc(static_cast<std::size_t>(bytes));
+            *array = std::malloc(static_cast<std::size_t>(bytes)); // NOLINT(hicpp-no-malloc)
         }
         break;
 
@@ -59,7 +59,7 @@ dispatch_free(const dynamic_memory_type type,
         case dynamic_memory_type::host :
         case dynamic_memory_type::managed :
         {
-            std::free(array);
+            std::free(array); // NOLINT(hicpp-no-malloc)
         }
         break;
 

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -17,12 +17,14 @@
 
 #include <algorithm>
 #include <limits>
+#include <random>
 #include <unordered_set>
 #include <thrust/functional.h>
 #include <thrust/logical.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform.h>
 
+#include <test_utils.h>
 #include <stdgpu/bitset.cuh>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
@@ -287,7 +289,10 @@ generate_shuffled_sequence(const stdgpu::index_t size)
     }
 
     // Shuffle
-    std::random_shuffle(host_result, host_result + size);
+    std::size_t seed = test_utils::random_thread_seed();
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
+
+    std::shuffle(host_result, host_result + size, rng);
 
     return host_result;
 }

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -45,8 +45,8 @@ class stdgpu_bitset : public ::testing::Test
             stdgpu::bitset::destroyDeviceObject(bitset);
         }
 
-        stdgpu::index_t bitset_size;
-        stdgpu::bitset bitset;
+        stdgpu::index_t bitset_size = 0;
+        stdgpu::bitset bitset = {};
 };
 
 

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -43,8 +43,8 @@ class stdgpu_mutex : public ::testing::Test
             stdgpu::mutex_array::destroyDeviceObject(locks);
         }
 
-        stdgpu::index_t locks_size;
-        stdgpu::mutex_array locks;
+        stdgpu::index_t locks_size = 0;
+        stdgpu::mutex_array locks = {};
 };
 
 

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -67,7 +67,7 @@ class STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS : public ::testing::Test
             test_unordered_datastructure::destroyDeviceObject(hash_datastructure);
         }
 
-        test_unordered_datastructure hash_datastructure;
+        test_unordered_datastructure hash_datastructure = {};
 };
 
 


### PR DESCRIPTION
There are still a few clang-tidy warnings left. Fix them to enable clean builds with clang-tidy enabled. Furthermore, slightly adjust the set of considered warnings.