### PR TITLE
CI: Add clang-tidy job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -175,6 +175,52 @@ jobs:
             bash <(curl -s https://codecov.io/bash) -Z -t $(codecov_upload_token) -f build/stdgpu_coverage.info
 
 - job:
+  displayName: Clang-Tidy OpenMP
+  pool:
+    vmImage: 'ubuntu-18.04'
+
+  steps:
+    - task: Bash@3
+      displayName: Install OpenMP
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/install_openmp_ubuntu1804.sh
+
+    - task: Bash@3
+      displayName: Install CMake 3.15+
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/install_cmake_ubuntu1804.sh
+
+    - task: Bash@3
+      displayName: Install clang-tidy
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/install_clang_tidy_ubuntu1804.sh
+
+    - task: Bash@3
+      displayName: Configure project
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/ci/configure_openmp_clang_tidy.sh
+
+    - task: Bash@3
+      displayName: Build project
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/build_debug.sh
+
+- job:
   displayName: Documentation OpenMP
   pool:
     vmImage: 'ubuntu-18.04'

--- a/scripts/ci/configure_openmp_clang_tidy.sh
+++ b/scripts/ci/configure_openmp_clang_tidy.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Create build directory
+sh scripts/utils/create_empty_directory.sh build
+
+# Download external dependencies
+sh scripts/utils/download_dependencies.sh
+
+# Configure project
+sh scripts/utils/configure_debug.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_ANALYZE_WITH_CLANG_TIDY=ON -DSTDGPU_TREAT_WARNINGS_AS_ERRORS=ON -Dthrust_ROOT=external/thrust

--- a/scripts/utils/install_clang_tidy_ubuntu1804.sh
+++ b/scripts/utils/install_clang_tidy_ubuntu1804.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+# Install clang-tidy
+sudo apt-get update
+sudo apt-get install clang-tidy


### PR DESCRIPTION
After the recent major warning cleanup, this process of detecting further potential bugs and regressions through clang-tidy can now be automated. Add a proper CI job which automatically performs clang-tidy checks and treats warnings as errors to ensure that they are not missed.