### PR TITLE
compiler,plaform: Use unique numbers as internal macro definitions

### DIFF
--- a/src/stdgpu/compiler.h
+++ b/src/stdgpu/compiler.h
@@ -29,38 +29,38 @@ namespace stdgpu
  * \hideinitializer
  * \brief Host compiler: Unknown
  */
-#define STDGPU_HOST_COMPILER_UNKNOWN -1
+#define STDGPU_HOST_COMPILER_UNKNOWN 10
 /**
  * \hideinitializer
  * \brief Host compiler: GCC
  */
-#define STDGPU_HOST_COMPILER_GCC      0
+#define STDGPU_HOST_COMPILER_GCC     11
 /**
  * \hideinitializer
  * \brief Host compiler: Clang
  */
-#define STDGPU_HOST_COMPILER_CLANG    1
+#define STDGPU_HOST_COMPILER_CLANG   12
 /**
  * \hideinitializer
  * \brief Host compiler: Microsoft Visual C++
  */
-#define STDGPU_HOST_COMPILER_MSVC     2
+#define STDGPU_HOST_COMPILER_MSVC    13
 
 /**
  * \hideinitializer
  * \brief Device compiler: Unknown
  */
-#define STDGPU_DEVICE_COMPILER_UNKNOWN -1
+#define STDGPU_DEVICE_COMPILER_UNKNOWN 20
 /**
  * \hideinitializer
  * \brief Device compiler: NVCC
  */
-#define STDGPU_DEVICE_COMPILER_NVCC     0
+#define STDGPU_DEVICE_COMPILER_NVCC    21
 /**
  * \hideinitializer
  * \brief Device compiler: HCC
  */
-#define STDGPU_DEVICE_COMPILER_HCC      1
+#define STDGPU_DEVICE_COMPILER_HCC     22
 
 /**
  * \def STDGPU_HOST_COMPILER

--- a/src/stdgpu/platform.h
+++ b/src/stdgpu/platform.h
@@ -53,17 +53,17 @@ namespace stdgpu
  * \hideinitializer
  * \brief Backend: CUDA
  */
-#define STDGPU_BACKEND_CUDA   0
+#define STDGPU_BACKEND_CUDA   100
 /**
  * \hideinitializer
  * \brief Backend: OpenMP
  */
-#define STDGPU_BACKEND_OPENMP 1
+#define STDGPU_BACKEND_OPENMP 101
 /**
  * \hideinitializer
  * \brief Backend: ROCm
  */
-#define STDGPU_BACKEND_ROCM   2
+#define STDGPU_BACKEND_ROCM   102
 
 
 // STDGPU_BACKEND is defined in stdgpu/config.h
@@ -109,12 +109,12 @@ namespace detail
  * \hideinitializer
  * \brief Code path: Host
  */
-#define STDGPU_CODE_HOST   0
+#define STDGPU_CODE_HOST   1000
 /**
  * \hideinitializer
  * \brief Code path: Device
  */
-#define STDGPU_CODE_DEVICE 1
+#define STDGPU_CODE_DEVICE 1001
 
 
 namespace detail


### PR DESCRIPTION
Macros in the `compiler` and `platform` are implemented through magic numbers to distinguish the individual values. However, the ranges of many different groups of macros overlap which leads to unexpected behavior if mixing them up. Use unique identifiers for all valued macros. This fixing potential weird behavior in such cases.

Note that mixing up macros is a bug itself and needs to be fixed. This change helps to unveil such erroneous cases. 