### PR TITLE
examples,src,test: Fix clang-tidy-8 warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,7 +6,6 @@ hicpp-*,\
 -hicpp-use-auto,\
 -hicpp-special-member-functions,\
 misc-*,\
--misc-macro-parentheses,\
 modernize-*,\
 -modernize-use-auto,\
 -modernize-pass-by-value,\

--- a/examples/contract.cpp
+++ b/examples/contract.cpp
@@ -23,11 +23,11 @@
 float
 safe_sqrt(const float x)
 {
-    STDGPU_EXPECTS(x >= 0.0f);
+    STDGPU_EXPECTS(x >= 0.0F);
 
     float result = std::sqrt(x);
 
-    STDGPU_ENSURES(result >= 0.0f);
+    STDGPU_ENSURES(result >= 0.0F);
     return result;
 }
 
@@ -37,7 +37,7 @@ main()
 {
     std::cout << "In debug mode, a pre-condition failure will be printed right after this line." << std::endl << std::endl;
 
-    float sqrt_m1 = safe_sqrt(-1.0f);
+    float sqrt_m1 = safe_sqrt(-1.0F);
 
     std::cout << std::endl << "This line is only visible when the contracts are deactivated (release mode) : safe_sqrt(-1.0f) = " << sqrt_m1 << std::endl;
 }

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -19,11 +19,11 @@
 #include <stdgpu/config.h>
 
 #if STDGPU_BACKEND == STDGPU_BACKEND_CUDA
-    #define STDGPU_BACKEND_ATOMIC_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/atomic.cuh>
+    #define STDGPU_BACKEND_ATOMIC_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/atomic.cuh> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
     #include STDGPU_BACKEND_ATOMIC_HEADER
     #undef STDGPU_BACKEND_ATOMIC_HEADER
 #else
-    #define STDGPU_BACKEND_ATOMIC_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/atomic.h>
+    #define STDGPU_BACKEND_ATOMIC_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/atomic.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
     #include STDGPU_BACKEND_ATOMIC_HEADER
     #undef STDGPU_BACKEND_ATOMIC_HEADER
 #endif

--- a/src/stdgpu/impl/bit_detail.h
+++ b/src/stdgpu/impl/bit_detail.h
@@ -44,7 +44,7 @@ bit_width(T number)
 
     T result = 1;
     T shifted_number = number;
-    while (shifted_number >>= 1)
+    while (shifted_number >>= static_cast<T>(1))
     {
         ++result;
     }
@@ -231,7 +231,7 @@ log2pow2(const T number)
 
     T result = 0;
     T shifted_number = number;
-    while (shifted_number >>= 1)
+    while (shifted_number >>= static_cast<T>(1))
     {
         ++result;
     }

--- a/src/stdgpu/impl/cmath_detail.h
+++ b/src/stdgpu/impl/cmath_detail.h
@@ -24,7 +24,7 @@ namespace stdgpu
 constexpr STDGPU_HOST_DEVICE float
 abs(const float arg)
 {
-    return (arg < 0.0f) ? -arg : arg;
+    return (arg < 0.0F) ? -arg : arg;
 }
 
 } // namespace stdgpu

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -21,7 +21,7 @@
 
 #include <stdgpu/config.h>
 
-#define STDGPU_BACKEND_MEMORY_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/memory.h>
+#define STDGPU_BACKEND_MEMORY_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/memory.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
 #include STDGPU_BACKEND_MEMORY_HEADER
 #undef STDGPU_BACKEND_MEMORY_HEADER
 

--- a/src/stdgpu/impl/ranges_detail.h
+++ b/src/stdgpu/impl/ranges_detail.h
@@ -296,27 +296,29 @@ namespace detail
 {
 
 template <typename T>
-struct select
+class select
 {
-    select() = default;
+    public:
+        select() = default;
 
-    // NOTE
-    // Implicit conversion required for {host,device}_indexed_range:
-    // Usage via constructor with arguments {host,device}_range<index_t>, T*
-    STDGPU_HOST_DEVICE
-    select(T* values) // NOLINT(hicpp-explicit-conversions)
-        : _values(values)
-    {
+        // NOTE
+        // Implicit conversion required for {host,device}_indexed_range:
+        // Usage via constructor with arguments {host,device}_range<index_t>, T*
+        STDGPU_HOST_DEVICE
+        select(T* values) // NOLINT(hicpp-explicit-conversions)
+            : _values(values)
+        {
 
-    }
+        }
 
-    STDGPU_HOST_DEVICE T
-    operator()(const index_t i) const
-    {
-        return _values[i];
-    }
+        STDGPU_HOST_DEVICE T
+        operator()(const index_t i) const
+        {
+            return _values[i];
+        }
 
-    T* _values = nullptr;
+    private:
+        T* _values = nullptr;
 };
 
 } // namespace detail

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -377,19 +377,19 @@ class unordered_base
         key_eq() const;
 
 
-        index_t _bucket_count = 0;                          /**< The number of buckets */
-        index_t _excess_count = 0;                          /**< The number of excess entries */
-        value_type* _values = nullptr;                      /**< The values */
-        index_t* _offsets = nullptr;                        /**< The offset to model linked list */
-        bitset _occupied = {};                              /**< The indicator array for occupied entries */
-        atomic<int> _occupied_count = {};                   /**< The number of occupied entries */
-        vector<index_t> _excess_list_positions = {};        /**< The excess list positions */
-        mutex_array _locks = {};                            /**< The locks used to insert and erase entries */
-        key_from_value _key_from_value = {};                /**< The value to key functor */
-        key_equal _key_equal = {};                          /**< The key comparison functor */
-        hasher _hash = {};                                  /**< The hashing function */
+        index_t _bucket_count = 0;                      /**< The number of buckets */                       // NOLINT(misc-non-private-member-variables-in-classes)
+        index_t _excess_count = 0;                      /**< The number of excess entries */                // NOLINT(misc-non-private-member-variables-in-classes)
+        value_type* _values = nullptr;                  /**< The values */                                  // NOLINT(misc-non-private-member-variables-in-classes)
+        index_t* _offsets = nullptr;                    /**< The offset to model linked list */             // NOLINT(misc-non-private-member-variables-in-classes)
+        bitset _occupied = {};                          /**< The indicator array for occupied entries */    // NOLINT(misc-non-private-member-variables-in-classes)
+        atomic<int> _occupied_count = {};               /**< The number of occupied entries */              // NOLINT(misc-non-private-member-variables-in-classes)
+        vector<index_t> _excess_list_positions = {};    /**< The excess list positions */                   // NOLINT(misc-non-private-member-variables-in-classes)
+        mutex_array _locks = {};                        /**< The locks used to insert and erase entries */  // NOLINT(misc-non-private-member-variables-in-classes)
+        key_from_value _key_from_value = {};            /**< The value to key functor */                    // NOLINT(misc-non-private-member-variables-in-classes)
+        key_equal _key_equal = {};                      /**< The key comparison functor */                  // NOLINT(misc-non-private-member-variables-in-classes)
+        hasher _hash = {};                              /**< The hashing function */                        // NOLINT(misc-non-private-member-variables-in-classes)
 
-        mutable vector<index_t> _range_indices = {};        /**< The buffer of range indices */
+        mutable vector<index_t> _range_indices = {};    /**< The buffer of range indices */                 // NOLINT(misc-non-private-member-variables-in-classes)
 
         // Deprecated
         static unordered_base

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -63,7 +63,7 @@ expected_collisions(const index_t bucket_count,
 inline STDGPU_HOST_DEVICE float
 default_max_load_factor()
 {
-    return 1.0f;
+    return 1.0F;
 }
 
 
@@ -85,7 +85,7 @@ fibonacci_hashing(const std::size_t hash,
     const std::size_t improved_hash = hash ^ (hash >> dropped_bit_width);
 
     // 2^64/phi, where phi is the golden ratio
-    const std::size_t multiplier = 11400714819323198485llu;
+    const std::size_t multiplier = 11400714819323198485LLU;
 
     // Multiplicative Hashing to the desired range
     index_t result = static_cast<index_t>((multiplier * improved_hash) >> dropped_bit_width);

--- a/src/stdgpu/platform.h
+++ b/src/stdgpu/platform.h
@@ -23,7 +23,7 @@
 #include <stdgpu/config.h>
 
 //! @cond Doxygen_Suppress
-#define STDGPU_BACKEND_PLATFORM_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/platform.h>
+#define STDGPU_BACKEND_PLATFORM_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/platform.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
 #include STDGPU_BACKEND_PLATFORM_HEADER
 #undef STDGPU_BACKEND_PLATFORM_HEADER
 //! @endcond

--- a/src/stdgpu/ranges.h
+++ b/src/stdgpu/ranges.h
@@ -354,7 +354,7 @@ namespace detail
  * \brief A functor to map from indices to values. The constructor expects a pointer to type T.
  */
 template <typename T>
-struct select;
+class select;
 
 } // namespace detail
 

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -47,8 +47,8 @@ class stdgpu_bitset : public ::testing::Test
             stdgpu::bitset::destroyDeviceObject(bitset);
         }
 
-        stdgpu::index_t bitset_size = 0;
-        stdgpu::bitset bitset = {};
+        stdgpu::index_t bitset_size = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+        stdgpu::bitset bitset = {}; // NOLINT(misc-non-private-member-variables-in-classes)
 };
 
 

--- a/test/stdgpu/cmath.cpp
+++ b/test/stdgpu/cmath.cpp
@@ -45,8 +45,8 @@ class stdgpu_cmath : public ::testing::Test
 
 TEST_F(stdgpu_cmath, abs_zero)
 {
-    EXPECT_FLOAT_EQ(stdgpu::abs( 0.0f), 0.0f);
-    EXPECT_FLOAT_EQ(stdgpu::abs(-0.0f), 0.0f);
+    EXPECT_FLOAT_EQ(stdgpu::abs( 0.0F), 0.0F);
+    EXPECT_FLOAT_EQ(stdgpu::abs(-0.0F), 0.0F);
 }
 
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -327,7 +327,7 @@ TEST_F(stdgpu_deque, pop_back_const_type)
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     push_back_deque_const_type<T>(pool, 2.0f));
+                     push_back_deque_const_type<T>(pool, 2.0F));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -490,7 +490,7 @@ TEST_F(stdgpu_deque, push_back_const_type)
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     push_back_deque_const_type<T>(pool, 2.0f));
+                     push_back_deque_const_type<T>(pool, 2.0F));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -637,7 +637,7 @@ TEST_F(stdgpu_deque, emplace_back_const_type)
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     emplace_back_deque_const_type<T>(pool, 2.0f));
+                     emplace_back_deque_const_type<T>(pool, 2.0F));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -875,7 +875,7 @@ TEST_F(stdgpu_deque, pop_front_const_type)
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     push_back_deque_const_type<T>(pool, 2.0f));
+                     push_back_deque_const_type<T>(pool, 2.0F));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1035,7 +1035,7 @@ TEST_F(stdgpu_deque, push_front_const_type)
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     push_front_deque_const_type<T>(pool, 2.0f));
+                     push_front_deque_const_type<T>(pool, 2.0F));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -1179,7 +1179,7 @@ TEST_F(stdgpu_deque, emplace_front_const_type)
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     emplace_front_deque_const_type<T>(pool, 2.0f));
+                     emplace_front_deque_const_type<T>(pool, 2.0F));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());

--- a/test/stdgpu/main.cpp
+++ b/test/stdgpu/main.cpp
@@ -21,7 +21,7 @@
 
 #include <stdgpu/config.h>
 
-#define STDGPU_BACKEND_DEVICE_INFO_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/device_info.h>
+#define STDGPU_BACKEND_DEVICE_INFO_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/device_info.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
 #include STDGPU_BACKEND_DEVICE_INFO_HEADER
 #undef STDGPU_BACKEND_DEVICE_INFO_HEADER
 

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -472,7 +472,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyDeviceArray)
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyDeviceArray_const_type)
 {
     using T = thrust::pair<const int,float>;
-    T default_value = {10, 2.0f};
+    T default_value = {10, 2.0F};
     stdgpu::index64_t size = 42;
 
     T* array_device = createDeviceArray<T>(size, default_value);
@@ -501,7 +501,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyHostArray)
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyHostArray_const_type)
 {
     using T = thrust::pair<const int,float>;
-    T default_value = {10, 2.0f};
+    T default_value = {10, 2.0F};
     stdgpu::index64_t size = 42;
 
     T* array_host = createHostArray<T>(size, default_value);
@@ -530,7 +530,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyManagedArray)
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyManagedArray_const_type)
 {
     using T = thrust::pair<const int,float>;
-    T default_value = {10, 2.0f};
+    T default_value = {10, 2.0F};
     stdgpu::index64_t size = 42;
 
     T* array_managed = createManagedArray<T>(size, default_value);

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -1463,7 +1463,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, construct_at)
     ASSERT_EQ(Counter::constructor_calls, 0);
     ASSERT_EQ(Counter::destructor_calls, 0);
 
-    for (stdgpu::index_t i = 0; i < size; ++i)
+    for (stdgpu::index64_t i = 0; i < size; ++i)
     {
         stdgpu::construct_at(array + i);
     }
@@ -1535,7 +1535,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroy_at)
     ASSERT_EQ(Counter::constructor_calls, 0);
     ASSERT_EQ(Counter::destructor_calls, 0);
 
-    for (stdgpu::index_t i = 0; i < size; ++i)
+    for (stdgpu::index64_t i = 0; i < size; ++i)
     {
         stdgpu::destroy_at(array + i);
     }

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -43,8 +43,8 @@ class stdgpu_mutex : public ::testing::Test
             stdgpu::mutex_array::destroyDeviceObject(locks);
         }
 
-        stdgpu::index_t locks_size = 0;
-        stdgpu::mutex_array locks = {};
+        stdgpu::index_t locks_size = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+        stdgpu::mutex_array locks = {}; // NOLINT(misc-non-private-member-variables-in-classes)
 };
 
 

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -67,7 +67,7 @@ class STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS : public ::testing::Test
             test_unordered_datastructure::destroyDeviceObject(hash_datastructure);
         }
 
-        test_unordered_datastructure hash_datastructure = {};
+        test_unordered_datastructure hash_datastructure = {}; // NOLINT(misc-non-private-member-variables-in-classes)
 };
 
 

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -197,8 +197,8 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_hits)
     stdgpu::index_t number_hits = static_cast<stdgpu::index_t>(thrust::count_if(stdgpu::device_cbegin(bucket_hits), stdgpu::device_cend(bucket_hits),
                                                                greater_value<0>()));
 
-    float percent_hits = 80.0f;
-    EXPECT_GT(number_hits, static_cast<stdgpu::index_t>(static_cast<float>(hash_datastructure.bucket_count()) * percent_hits / 100.0f));
+    float percent_hits = 80.0F;
+    EXPECT_GT(number_hits, static_cast<stdgpu::index_t>(static_cast<float>(hash_datastructure.bucket_count()) * percent_hits / 100.0F));
 
     destroyDeviceArray<int>(bucket_hits);
     destroyDeviceArray<test_unordered_datastructure::key_type>(keys);
@@ -234,8 +234,8 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_collisions)
     stdgpu::index_t number_collisions = static_cast<stdgpu::index_t>(thrust::count_if(stdgpu::device_cbegin(bucket_hits), stdgpu::device_cend(bucket_hits),
                                                                      greater_value<1>()));
 
-    float percent_collisions = 40.0f;
-    EXPECT_LT(number_collisions, static_cast<stdgpu::index_t>(static_cast<float>(N) * percent_collisions / 100.0f));
+    float percent_collisions = 40.0F;
+    EXPECT_LT(number_collisions, static_cast<stdgpu::index_t>(static_cast<float>(N) * percent_collisions / 100.0F));
 
     destroyDeviceArray<int>(bucket_hits);
     destroyDeviceArray<test_unordered_datastructure::key_type>(keys);

--- a/test/stdgpu/unordered_map.inc
+++ b/test/stdgpu/unordered_map.inc
@@ -98,9 +98,9 @@ struct hash
     inline STDGPU_HOST_DEVICE std::size_t
     operator()(const vec3int16& key) const
     {
-        return (static_cast<std::size_t>(key.x) * static_cast<std::size_t>(73856093u))
-             ^ (static_cast<std::size_t>(key.y) * static_cast<std::size_t>(19349669u))
-             ^ (static_cast<std::size_t>(key.z) * static_cast<std::size_t>(83492791u));
+        return (static_cast<std::size_t>(key.x) * static_cast<std::size_t>(73856093U))
+             ^ (static_cast<std::size_t>(key.y) * static_cast<std::size_t>(19349669U))
+             ^ (static_cast<std::size_t>(key.z) * static_cast<std::size_t>(83492791U));
     }
 };
 

--- a/test/stdgpu/unordered_map.inc
+++ b/test/stdgpu/unordered_map.inc
@@ -59,9 +59,9 @@ struct vec3int16
 
     }
 
-    std::int16_t x = 0;
-    std::int16_t y = 0;
-    std::int16_t z = 0;
+    std::int16_t x = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+    std::int16_t y = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+    std::int16_t z = 0; // NOLINT(misc-non-private-member-variables-in-classes)
 };
 
 inline STDGPU_HOST_DEVICE bool

--- a/test/stdgpu/unordered_set.inc
+++ b/test/stdgpu/unordered_set.inc
@@ -53,9 +53,9 @@ struct vec3int16
 
     }
 
-    std::int16_t x = 0;
-    std::int16_t y = 0;
-    std::int16_t z = 0;
+    std::int16_t x = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+    std::int16_t y = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+    std::int16_t z = 0; // NOLINT(misc-non-private-member-variables-in-classes)
 };
 
 

--- a/test/stdgpu/unordered_set.inc
+++ b/test/stdgpu/unordered_set.inc
@@ -94,9 +94,9 @@ struct hash
     inline STDGPU_HOST_DEVICE std::size_t
     operator()(const vec3int16& key) const
     {
-        return (static_cast<std::size_t>(key.x) * static_cast<std::size_t>(73856093u))
-             ^ (static_cast<std::size_t>(key.y) * static_cast<std::size_t>(19349669u))
-             ^ (static_cast<std::size_t>(key.z) * static_cast<std::size_t>(83492791u));
+        return (static_cast<std::size_t>(key.x) * static_cast<std::size_t>(73856093U))
+             ^ (static_cast<std::size_t>(key.y) * static_cast<std::size_t>(19349669U))
+             ^ (static_cast<std::size_t>(key.z) * static_cast<std::size_t>(83492791U));
     }
 };
 

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -324,7 +324,7 @@ TEST_F(stdgpu_vector, pop_back_const_type)
     stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     push_back_vector_const_type<T>(pool, 2.0f));
+                     push_back_vector_const_type<T>(pool, 2.0F));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -487,7 +487,7 @@ TEST_F(stdgpu_vector, push_back_const_type)
     stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     push_back_vector_const_type<T>(pool, 2.0f));
+                     push_back_vector_const_type<T>(pool, 2.0F));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -634,7 +634,7 @@ TEST_F(stdgpu_vector, emplace_back_const_type)
     stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     emplace_back_vector_const_type<T>(pool, 2.0f));
+                     emplace_back_vector_const_type<T>(pool, 2.0F));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());


### PR DESCRIPTION
Recent versions of clang-tidy contain a larger set of diagnostics. Fix these newly appearing warnings to further improve the code quality.