### PR TITLE
examples,src,test: Fix readability-magic-numbers warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,7 @@ modernize-*,\
 performance-*,\
 readability-*,\
 -readability-avoid-const-params-in-decls,\
+-readability-const-return-type,\
 "
 HeaderFilterRegex: 'src|test/stdgpu'
 ...

--- a/examples/createAndDestroyDeviceArray.cpp
+++ b/examples/createAndDestroyDeviceArray.cpp
@@ -22,8 +22,8 @@
 int
 main()
 {
-    stdgpu::index_t n = 1000;
-    int default_value = 42;
+    const stdgpu::index_t n = 1000;
+    const int default_value = 42;
 
     int* d_array = createDeviceArray<int>(n, default_value);
 

--- a/examples/createAndDestroyDeviceObject.cpp
+++ b/examples/createAndDestroyDeviceObject.cpp
@@ -114,7 +114,9 @@ fill_image(Image image)
 int
 main()
 {
-    Image image = Image::createHostObject(1920, 1080);
+    const stdgpu::index_t width = 1920;
+    const stdgpu::index_t height = 1080;
+    Image image = Image::createHostObject(width, height);
 
     fill_image(image);
 

--- a/examples/cuda/thrust_interoperability.cu
+++ b/examples/cuda/thrust_interoperability.cu
@@ -36,7 +36,7 @@ struct square
 int
 main()
 {
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n);
@@ -56,7 +56,9 @@ main()
                              0,
                              thrust::plus<int>());
 
-    std::cout << "The computed sum from i = 1 to " << n << " of i^2 is " << sum << " (" << n * (n + 1) * (2 * n + 1) / 6 << " expected)" << std::endl;
+    const int sum_closed_form = n * (n + 1) * (2 * n + 1) / 6;
+
+    std::cout << "The computed sum from i = 1 to " << n << " of i^2 is " << sum << " (" << sum_closed_form << " expected)" << std::endl;
 
     destroyDeviceArray<int>(d_input);
     destroyDeviceArray<int>(d_result);

--- a/examples/cuda/thrust_towards_ranges.cu
+++ b/examples/cuda/thrust_towards_ranges.cu
@@ -59,7 +59,7 @@ class atomic_sum
 int
 main()
 {
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n);
@@ -101,7 +101,9 @@ main()
     //
     // Or the call to device_range may also become an implicit operation in the future.
 
-    std::cout << "The computed sum from i = 1 to " << n << " of i^2 is " << sum.load() << " (" << n * (n + 1) * (2 * n + 1) / 6 << " expected)" << std::endl;
+    const int sum_closed_form = n * (n + 1) * (2 * n + 1) / 6;
+
+    std::cout << "The computed sum from i = 1 to " << n << " of i^2 is " << sum.load() << " (" << sum_closed_form << " expected)" << std::endl;
 
     destroyDeviceArray<int>(d_input);
     destroyDeviceArray<int>(d_result);

--- a/examples/openmp/thrust_interoperability.cpp
+++ b/examples/openmp/thrust_interoperability.cpp
@@ -36,7 +36,7 @@ struct square
 int
 main()
 {
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n);
@@ -56,7 +56,9 @@ main()
                              0,
                              thrust::plus<int>());
 
-    std::cout << "The computed sum from i = 1 to " << n << " of i^2 is " << sum << " (" << n * (n + 1) * (2 * n + 1) / 6 << " expected)" << std::endl;
+    const int sum_closed_form = n * (n + 1) * (2 * n + 1) / 6;
+
+    std::cout << "The computed sum from i = 1 to " << n << " of i^2 is " << sum << " (" << sum_closed_form << " expected)" << std::endl;
 
     destroyDeviceArray<int>(d_input);
     destroyDeviceArray<int>(d_result);

--- a/examples/openmp/thrust_towards_ranges.cpp
+++ b/examples/openmp/thrust_towards_ranges.cpp
@@ -59,7 +59,7 @@ class atomic_sum
 int
 main()
 {
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n);
@@ -101,7 +101,9 @@ main()
     //
     // Or the call to device_range may also become an implicit operation in the future.
 
-    std::cout << "The computed sum from i = 1 to " << n << " of i^2 is " << sum.load() << " (" << n * (n + 1) * (2 * n + 1) / 6 << " expected)" << std::endl;
+    const int sum_closed_form = n * (n + 1) * (2 * n + 1) / 6;
+
+    std::cout << "The computed sum from i = 1 to " << n << " of i^2 is " << sum.load() << " (" << sum_closed_form << " expected)" << std::endl;
 
     destroyDeviceArray<int>(d_input);
     destroyDeviceArray<int>(d_result);

--- a/examples/rocm/thrust_interoperability.cpp
+++ b/examples/rocm/thrust_interoperability.cpp
@@ -36,7 +36,7 @@ struct square
 int
 main()
 {
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n);
@@ -56,7 +56,9 @@ main()
                              0,
                              thrust::plus<int>());
 
-    std::cout << "The computed sum from i = 1 to " << n << " of i^2 is " << sum << " (" << n * (n + 1) * (2 * n + 1) / 6 << " expected)" << std::endl;
+    const int sum_closed_form = n * (n + 1) * (2 * n + 1) / 6;
+
+    std::cout << "The computed sum from i = 1 to " << n << " of i^2 is " << sum << " (" << sum_closed_form << " expected)" << std::endl;
 
     destroyDeviceArray<int>(d_input);
     destroyDeviceArray<int>(d_result);

--- a/examples/rocm/thrust_towards_ranges.cpp
+++ b/examples/rocm/thrust_towards_ranges.cpp
@@ -59,7 +59,7 @@ class atomic_sum
 int
 main()
 {
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n);
@@ -101,7 +101,9 @@ main()
     //
     // Or the call to device_range may also become an implicit operation in the future.
 
-    std::cout << "The computed sum from i = 1 to " << n << " of i^2 is " << sum.load() << " (" << n * (n + 1) * (2 * n + 1) / 6 << " expected)" << std::endl;
+    const int sum_closed_form = n * (n + 1) * (2 * n + 1) / 6;
+
+    std::cout << "The computed sum from i = 1 to " << n << " of i^2 is " << sum.load() << " (" << sum_closed_form << " expected)" << std::endl;
 
     destroyDeviceArray<int>(d_input);
     destroyDeviceArray<int>(d_result);

--- a/src/stdgpu/impl/limits_detail.h
+++ b/src/stdgpu/impl/limits_detail.h
@@ -317,7 +317,7 @@ struct numeric_limits<float>
     static constexpr STDGPU_HOST_DEVICE float max() noexcept                        { return FLT_MAX; }
     static constexpr STDGPU_HOST_DEVICE float lowest() noexcept                     { return -FLT_MAX; }
     static constexpr STDGPU_HOST_DEVICE float epsilon() noexcept                    { return FLT_EPSILON; }
-    static constexpr STDGPU_HOST_DEVICE float round_error() noexcept                { return 0.5F; }
+    static constexpr STDGPU_HOST_DEVICE float round_error() noexcept                { return 0.5F; } // NOLINT(readability-magic-numbers)
     static constexpr STDGPU_HOST_DEVICE float infinity() noexcept                   { return HUGE_VALF; }
     static constexpr bool is_specialized                                            = true;
     static constexpr bool is_signed                                                 = true;
@@ -335,7 +335,7 @@ struct numeric_limits<double>
     static constexpr STDGPU_HOST_DEVICE double max() noexcept                       { return DBL_MAX; }
     static constexpr STDGPU_HOST_DEVICE double lowest() noexcept                    { return -DBL_MAX; }
     static constexpr STDGPU_HOST_DEVICE double epsilon() noexcept                   { return DBL_EPSILON; }
-    static constexpr STDGPU_HOST_DEVICE double round_error() noexcept               { return 0.5; }
+    static constexpr STDGPU_HOST_DEVICE double round_error() noexcept               { return 0.5; } // NOLINT(readability-magic-numbers)
     static constexpr STDGPU_HOST_DEVICE double infinity() noexcept                  { return HUGE_VAL; }
     static constexpr bool is_specialized                                            = true;
     static constexpr bool is_signed                                                 = true;
@@ -353,7 +353,7 @@ struct numeric_limits<long double>
     static constexpr STDGPU_HOST_DEVICE long double max() noexcept                  { return LDBL_MAX; }
     static constexpr STDGPU_HOST_DEVICE long double lowest() noexcept               { return -LDBL_MAX; }
     static constexpr STDGPU_HOST_DEVICE long double epsilon() noexcept              { return LDBL_EPSILON; }
-    static constexpr STDGPU_HOST_DEVICE long double round_error() noexcept          { return 0.5L; }
+    static constexpr STDGPU_HOST_DEVICE long double round_error() noexcept          { return 0.5L; } // NOLINT(readability-magic-numbers)
     static constexpr STDGPU_HOST_DEVICE long double infinity() noexcept             { return HUGE_VALL; }
     static constexpr bool is_specialized                                            = true;
     static constexpr bool is_signed                                                 = true;

--- a/test/stdgpu/algorithm.cpp
+++ b/test/stdgpu/algorithm.cpp
@@ -125,7 +125,7 @@ thread_check_min_max_integer(const stdgpu::index_t iterations)
 template <typename T>
 void check_min_max_random_integer()
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
 
     test_utils::for_each_concurrent_thread(&thread_check_min_max_integer<T>,
                                            iterations_per_thread);
@@ -176,7 +176,8 @@ random_float(std::uniform_real_distribution<T>& dist,
 {
     T result = dist(rng);
 
-    return flip(rng) < T(0.5) ? result : -result;
+    const T half = static_cast<T>(0.5);
+    return flip(rng) < half ? result : -result;
 }
 
 template <typename T>
@@ -204,7 +205,7 @@ thread_check_min_max_float(const stdgpu::index_t iterations)
 template <typename T>
 void check_min_max_random_float()
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
 
     test_utils::for_each_concurrent_thread(&thread_check_min_max_float<T>,
                                            iterations_per_thread);
@@ -250,7 +251,7 @@ thread_check_clamp_integer(const stdgpu::index_t iterations)
 template <typename T>
 void check_clamp_random_integer()
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
 
     test_utils::for_each_concurrent_thread(&thread_check_clamp_integer<T>,
                                            iterations_per_thread);
@@ -322,7 +323,7 @@ thread_check_clamp_float(const stdgpu::index_t iterations)
 template <typename T>
 void check_clamp_random_float()
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
 
     test_utils::for_each_concurrent_thread(&thread_check_clamp_float<T>,
                                            iterations_per_thread);

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -210,12 +210,13 @@ void
 load_and_store()
 {
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+    const T new_value = static_cast<T>(42);
 
     EXPECT_EQ(value.load(), T());
 
-    value.store(T(42));
+    value.store(new_value);
 
-    EXPECT_EQ(value.load(), T(42));
+    EXPECT_EQ(value.load(), new_value);
 
     stdgpu::atomic<T>::destroyDeviceObject(value);
 }
@@ -243,12 +244,13 @@ void
 operator_load_and_store()
 {
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+    const T new_value = static_cast<T>(42);
 
     EXPECT_EQ(value, T());
 
-    value = T(42);
+    value = new_value;
 
-    EXPECT_EQ(value, T(42));
+    EXPECT_EQ(value, new_value);
 
     stdgpu::atomic<T>::destroyDeviceObject(value);
 }
@@ -1246,12 +1248,13 @@ sequence_fetch_inc_mod()
     T* sequence = createDeviceArray<T>(N, modulus_value);
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
-    value.store(42);
+    const T new_value = static_cast<T>(42);
+    value.store(new_value);
 
     thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
                      inc_mod_sequence<T>(value));
 
-    EXPECT_EQ(value.load(), T(42));
+    EXPECT_EQ(value.load(), new_value);
 
     destroyDeviceArray<T>(sequence);
     stdgpu::atomic<T>::destroyDeviceObject(value);
@@ -1304,12 +1307,13 @@ sequence_fetch_dec_mod()
     T* sequence = createDeviceArray<T>(N, modulus_value);
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
-    value.store(42);
+    const T new_value = static_cast<T>(42);
+    value.store(new_value);
 
     thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
                      dec_mod_dequence<T>(value));
 
-    EXPECT_EQ(value.load(), T(42));
+    EXPECT_EQ(value.load(), new_value);
 
     destroyDeviceArray<T>(sequence);
     stdgpu::atomic<T>::destroyDeviceObject(value);

--- a/test/stdgpu/bit.cpp
+++ b/test/stdgpu/bit.cpp
@@ -121,7 +121,7 @@ TEST_F(stdgpu_bit, has_single_bit)
     }
 
 
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
 
     test_utils::for_each_concurrent_thread(&thread_has_single_bit_random,
                                            iterations_per_thread,
@@ -154,7 +154,7 @@ thread_bit_ceil_random(const stdgpu::index_t iterations)
 
 TEST_F(stdgpu_bit, bit_ceil_random)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
 
     test_utils::for_each_concurrent_thread(&thread_bit_ceil_random,
                                            iterations_per_thread);
@@ -191,7 +191,7 @@ thread_bit_floor_random(const stdgpu::index_t iterations)
 
 TEST_F(stdgpu_bit, bit_floor_random)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
 
     test_utils::for_each_concurrent_thread(&thread_bit_floor_random,
                                            iterations_per_thread);
@@ -225,7 +225,7 @@ thread_bit_mod_random(const stdgpu::index_t iterations,
 TEST_F(stdgpu_bit, bit_mod_random)
 {
     const std::size_t divider = static_cast<std::size_t>(pow(2, 21));
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
 
     test_utils::for_each_concurrent_thread(&thread_bit_mod_random,
                                            iterations_per_thread,
@@ -235,16 +235,16 @@ TEST_F(stdgpu_bit, bit_mod_random)
 
 TEST_F(stdgpu_bit, bit_mod_one_positive)
 {
-    std::size_t number       = 42;
-    std::size_t divider      = 1;
+    const std::size_t number = 42;
+    const std::size_t divider = 1;
     EXPECT_EQ(stdgpu::bit_mod(number, divider), static_cast<std::size_t>(0));
 }
 
 
 TEST_F(stdgpu_bit, bit_mod_one_zero)
 {
-    std::size_t number       = 0;
-    std::size_t divider      = 1;
+    const std::size_t number = 0;
+    const std::size_t divider = 1;
     EXPECT_EQ(stdgpu::bit_mod(number, divider), static_cast<std::size_t>(0));
 }
 
@@ -281,7 +281,7 @@ thread_bit_width_random(const stdgpu::index_t iterations)
 
 TEST_F(stdgpu_bit, bit_width_random)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
 
     test_utils::for_each_concurrent_thread(&thread_bit_width_random,
                                            iterations_per_thread);
@@ -353,7 +353,7 @@ TEST_F(stdgpu_bit, ispow2)
     }
 
 
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
 
     test_utils::for_each_concurrent_thread(&thread_ispow2_random,
                                            iterations_per_thread,
@@ -382,7 +382,7 @@ thread_mod2_random(const stdgpu::index_t iterations,
 TEST_F(stdgpu_bit, mod2_random)
 {
     const std::size_t divider = static_cast<std::size_t>(pow(2, 21));
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
 
     test_utils::for_each_concurrent_thread(&thread_mod2_random,
                                            iterations_per_thread,
@@ -392,16 +392,16 @@ TEST_F(stdgpu_bit, mod2_random)
 
 TEST_F(stdgpu_bit, mod2_one_positive)
 {
-    std::size_t number       = 42;
-    std::size_t divider      = 1;
+    const std::size_t number = 42;
+    const std::size_t divider = 1;
     EXPECT_EQ(stdgpu::mod2(number, divider), static_cast<std::size_t>(0));
 }
 
 
 TEST_F(stdgpu_bit, mod2_one_zero)
 {
-    std::size_t number       = 0;
-    std::size_t divider      = 1;
+    const std::size_t number = 0;
+    const std::size_t divider = 1;
     EXPECT_EQ(stdgpu::mod2(number, divider), static_cast<std::size_t>(0));
 }
 

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -37,7 +37,6 @@ class stdgpu_bitset : public ::testing::Test
         // Called before each test
         void SetUp() override
         {
-            bitset_size = 1048576;   // 2^20
             bitset = stdgpu::bitset::createDeviceObject(bitset_size);
         }
 
@@ -47,7 +46,7 @@ class stdgpu_bitset : public ::testing::Test
             stdgpu::bitset::destroyDeviceObject(bitset);
         }
 
-        stdgpu::index_t bitset_size = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+        const stdgpu::index_t bitset_size = 1048576; // NOLINT(misc-non-private-member-variables-in-classes)
         stdgpu::bitset bitset = {}; // NOLINT(misc-non-private-member-variables-in-classes)
 };
 

--- a/test/stdgpu/cmath.cpp
+++ b/test/stdgpu/cmath.cpp
@@ -76,7 +76,7 @@ thread_positive_values(const stdgpu::index_t iterations)
 
 TEST_F(stdgpu_cmath, abs_positive_values)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 21));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 21));
 
     test_utils::for_each_concurrent_thread(&thread_positive_values,
                                            iterations_per_thread);
@@ -102,7 +102,7 @@ thread_negative_values(const stdgpu::index_t iterations)
 
 TEST_F(stdgpu_cmath, abs_negative_values)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 21));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 21));
 
     test_utils::for_each_concurrent_thread(&thread_negative_values,
                                            iterations_per_thread);

--- a/test/stdgpu/cstdlib.cpp
+++ b/test/stdgpu/cstdlib.cpp
@@ -74,7 +74,7 @@ thread_values(const stdgpu::index_t iterations)
 
 TEST_F(stdgpu_cstdlib, sizedivPow2_random)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 19));
 
     test_utils::for_each_concurrent_thread(&thread_values,
                                            iterations_per_thread);

--- a/test/stdgpu/cuda/device_info.cpp
+++ b/test/stdgpu/cuda/device_info.cpp
@@ -62,7 +62,7 @@ print_device_information()
     cudaMemGetInfo(&free_memory, &total_memory);
 
     std::string gpu_name = properties.name;
-    int gpu_name_total_width = 57;
+    const int gpu_name_total_width = 57;
     int gpu_name_size = static_cast<int>(gpu_name.size());
     int gpu_name_space_left  = std::max<int>(1, (gpu_name_total_width - gpu_name_size) / 2);
     int gpu_name_space_right = std::max<int>(1, gpu_name_total_width - gpu_name_size - gpu_name_space_left);

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -326,8 +326,9 @@ TEST_F(stdgpu_deque, pop_back_const_type)
 
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
+    const float part_second = 2.0F;
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     push_back_deque_const_type<T>(pool, 2.0F));
+                     push_back_deque_const_type<T>(pool, part_second));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -489,8 +490,9 @@ TEST_F(stdgpu_deque, push_back_const_type)
 
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
+    const float part_second = 2.0F;
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     push_back_deque_const_type<T>(pool, 2.0F));
+                     push_back_deque_const_type<T>(pool, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -636,8 +638,9 @@ TEST_F(stdgpu_deque, emplace_back_const_type)
 
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
+    const float part_second = 2.0F;
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     emplace_back_deque_const_type<T>(pool, 2.0F));
+                     emplace_back_deque_const_type<T>(pool, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -874,8 +877,9 @@ TEST_F(stdgpu_deque, pop_front_const_type)
 
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
+    const float part_second = 2.0F;
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     push_back_deque_const_type<T>(pool, 2.0F));
+                     push_back_deque_const_type<T>(pool, part_second));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1034,8 +1038,9 @@ TEST_F(stdgpu_deque, push_front_const_type)
 
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
+    const float part_second = 2.0F;
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     push_front_deque_const_type<T>(pool, 2.0F));
+                     push_front_deque_const_type<T>(pool, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -1178,8 +1183,9 @@ TEST_F(stdgpu_deque, emplace_front_const_type)
 
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
+    const float part_second = 2.0F;
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     emplace_front_deque_const_type<T>(pool, 2.0F));
+                     emplace_front_deque_const_type<T>(pool, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());

--- a/test/stdgpu/functional.cpp
+++ b/test/stdgpu/functional.cpp
@@ -120,7 +120,7 @@ check_integer()
         hashes.insert(hasher(i));
     }
 
-    EXPECT_GT(hashes.size(), 90 / 100 * N);
+    EXPECT_GT(hashes.size(), N * 90 / 100);
 }
 
 
@@ -224,8 +224,9 @@ check_floating_point_random()
     // Generate true random numbers
     std::size_t seed = test_utils::random_seed();
 
+    const T bound = static_cast<T>(1e38);
     std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
-    std::uniform_real_distribution<T> dist(static_cast<T>(-1e38), static_cast<T>(1e38));
+    std::uniform_real_distribution<T> dist(-bound, bound);
 
     std::unordered_set<std::size_t> hashes;
     hashes.reserve(static_cast<std::size_t>(N));
@@ -278,7 +279,7 @@ TEST_F(stdgpu_functional, enum)
     hashes.insert(hasher(two));
     hashes.insert(hasher(three));
 
-    EXPECT_GT(hashes.size(), 90 / 100 * 4);
+    EXPECT_GT(hashes.size(), 4 * 90 / 100);
 }
 
 
@@ -302,7 +303,7 @@ TEST_F(stdgpu_functional, enum_class)
     hashes.insert(hasher(scoped_enum::two));
     hashes.insert(hasher(scoped_enum::three));
 
-    EXPECT_GT(hashes.size(), 90 / 100 * 4);
+    EXPECT_GT(hashes.size(), 4 * 90 / 100);
 }
 
 

--- a/test/stdgpu/iterator.cpp
+++ b/test/stdgpu/iterator.cpp
@@ -171,9 +171,10 @@ class insert_iterator<unordered_set<int>>;
 
 TEST_F(stdgpu_iterator, size_device_void)
 {
-    int* array = createDeviceArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array = createDeviceArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size((void*)array), 42 * sizeof(int));
+    EXPECT_EQ(stdgpu::size((void*)array), size * sizeof(int));
 
     destroyDeviceArray<int>(array);
 }
@@ -181,11 +182,12 @@ TEST_F(stdgpu_iterator, size_device_void)
 
 TEST_F(stdgpu_iterator, size_host_void)
 {
-    int* array_result = createHostArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array = createHostArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size((void*)array_result), 42 * sizeof(int));
+    EXPECT_EQ(stdgpu::size((void*)array), size * sizeof(int));
 
-    destroyHostArray<int>(array_result);
+    destroyHostArray<int>(array);
 }
 
 
@@ -197,9 +199,10 @@ TEST_F(stdgpu_iterator, size_nullptr_void)
 
 TEST_F(stdgpu_iterator, size_device)
 {
-    int* array = createDeviceArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array = createDeviceArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size(array), static_cast<std::size_t>(42));
+    EXPECT_EQ(stdgpu::size(array), static_cast<std::size_t>(size));
 
     destroyDeviceArray<int>(array);
 }
@@ -207,11 +210,12 @@ TEST_F(stdgpu_iterator, size_device)
 
 TEST_F(stdgpu_iterator, size_host)
 {
-    int* array_result = createHostArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array = createHostArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size(array_result), static_cast<std::size_t>(42));
+    EXPECT_EQ(stdgpu::size(array), static_cast<std::size_t>(size));
 
-    destroyHostArray<int>(array_result);
+    destroyHostArray<int>(array);
 }
 
 
@@ -223,7 +227,8 @@ TEST_F(stdgpu_iterator, size_nullptr)
 
 TEST_F(stdgpu_iterator, size_device_shifted)
 {
-    int* array = createDeviceArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array = createDeviceArray<int>(size);
 
     EXPECT_EQ(stdgpu::size(array + 24), static_cast<std::size_t>(0));
 
@@ -233,7 +238,8 @@ TEST_F(stdgpu_iterator, size_device_shifted)
 
 TEST_F(stdgpu_iterator, size_host_shifted)
 {
-    int* array_result = createHostArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array_result = createHostArray<int>(size);
 
     EXPECT_EQ(stdgpu::size(array_result + 24), static_cast<std::size_t>(0));
 
@@ -263,13 +269,14 @@ TEST_F(stdgpu_iterator, size_host_wrong_alignment)
 
 TEST_F(stdgpu_iterator, device_begin_end)
 {
-    int* array = createDeviceArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array = createDeviceArray<int>(size);
 
     int* array_begin   = stdgpu::device_begin(array).get();
     int* array_end     = stdgpu::device_end(  array).get();
 
     EXPECT_EQ(array_begin, array);
-    EXPECT_EQ(array_end,   array + 42);
+    EXPECT_EQ(array_end,   array + size);
 
     destroyDeviceArray<int>(array);
 }
@@ -277,13 +284,14 @@ TEST_F(stdgpu_iterator, device_begin_end)
 
 TEST_F(stdgpu_iterator, host_begin_end)
 {
-    int* array_result = createHostArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array_result = createHostArray<int>(size);
 
     int* array_result_begin   = stdgpu::host_begin(array_result).get();
     int* array_result_end     = stdgpu::host_end(  array_result).get();
 
     EXPECT_EQ(array_result_begin, array_result);
-    EXPECT_EQ(array_result_end,   array_result + 42);
+    EXPECT_EQ(array_result_end,   array_result + size);
 
     destroyHostArray<int>(array_result);
 }
@@ -291,13 +299,14 @@ TEST_F(stdgpu_iterator, host_begin_end)
 
 TEST_F(stdgpu_iterator, device_begin_end_const)
 {
-    int* array = createDeviceArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array = createDeviceArray<int>(size);
 
     const int* array_begin   = stdgpu::device_begin(reinterpret_cast<const int*>(array)).get();
     const int* array_end     = stdgpu::device_end(  reinterpret_cast<const int*>(array)).get();
 
     EXPECT_EQ(array_begin, array);
-    EXPECT_EQ(array_end,   array + 42);
+    EXPECT_EQ(array_end,   array + size);
 
     destroyDeviceArray<int>(array);
 }
@@ -305,13 +314,14 @@ TEST_F(stdgpu_iterator, device_begin_end_const)
 
 TEST_F(stdgpu_iterator, host_begin_end_const)
 {
-    int* array_result = createHostArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array_result = createHostArray<int>(size);
 
     const int* array_result_begin   = stdgpu::host_begin(reinterpret_cast<const int*>(array_result)).get();
     const int* array_result_end     = stdgpu::host_end(  reinterpret_cast<const int*>(array_result)).get();
 
     EXPECT_EQ(array_result_begin, array_result);
-    EXPECT_EQ(array_result_end,   array_result + 42);
+    EXPECT_EQ(array_result_end,   array_result + size);
 
     destroyHostArray<int>(array_result);
 }
@@ -319,13 +329,14 @@ TEST_F(stdgpu_iterator, host_begin_end_const)
 
 TEST_F(stdgpu_iterator, device_cbegin_cend)
 {
-    int* array = createDeviceArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array = createDeviceArray<int>(size);
 
     const int* array_begin   = stdgpu::device_cbegin(array).get();
     const int* array_end     = stdgpu::device_cend(  array).get();
 
     EXPECT_EQ(array_begin, array);
-    EXPECT_EQ(array_end,   array + 42);
+    EXPECT_EQ(array_end,   array + size);
 
     destroyDeviceArray<int>(array);
 }
@@ -333,13 +344,14 @@ TEST_F(stdgpu_iterator, device_cbegin_cend)
 
 TEST_F(stdgpu_iterator, host_cbegin_cend)
 {
-    int* array_result = createHostArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array_result = createHostArray<int>(size);
 
     const int* array_result_begin   = stdgpu::host_cbegin(array_result).get();
     const int* array_result_end     = stdgpu::host_cend(  array_result).get();
 
     EXPECT_EQ(array_result_begin, array_result);
-    EXPECT_EQ(array_result_end,   array_result + 42);
+    EXPECT_EQ(array_result_end,   array_result + size);
 
     destroyHostArray<int>(array_result);
 }

--- a/test/stdgpu/main.cpp
+++ b/test/stdgpu/main.cpp
@@ -36,7 +36,7 @@ main(int argc, char* argv[])
     std::string project_name = "stdgpu";
     std::string project_version = STDGPU_VERSION_STRING;
 
-    int title_total_width = 57;
+    const int title_total_width = 57;
     int title_size = static_cast<int>(project_name.size()) + static_cast<int>(project_version.size()) + 1;
     int title_space_left  = std::max<int>(1, (title_total_width - title_size) / 2);
     int title_space_right = std::max<int>(1, title_total_width - title_size - title_space_left);

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -207,7 +207,8 @@ size_bytes<int>(int*);
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_device)
 {
-    int* array_device = createDeviceArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array_device = createDeviceArray<int>(size);
 
     EXPECT_EQ(stdgpu::get_dynamic_memory_type(array_device), stdgpu::dynamic_memory_type::device);
 
@@ -217,7 +218,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_device)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_host)
 {
-    int* array_host = createHostArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array_host = createHostArray<int>(size);
 
     EXPECT_EQ(stdgpu::get_dynamic_memory_type(array_host), stdgpu::dynamic_memory_type::host);
 
@@ -227,7 +229,9 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_host)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_managed_on_device)
 {
-    int* array_managed = createManagedArray<int>(42, 0, Initialization::DEVICE);
+    const stdgpu::index_t size = 42;
+    const int default_value = 0;
+    int* array_managed = createManagedArray<int>(size, default_value, Initialization::DEVICE);
 
     EXPECT_EQ(stdgpu::get_dynamic_memory_type(array_managed), stdgpu::dynamic_memory_type::managed);
 
@@ -237,7 +241,9 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_managed_on_device)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_managed_on_host)
 {
-    int* array_managed = createManagedArray<int>(42, 0, Initialization::HOST);
+    const stdgpu::index_t size = 42;
+    const int default_value = 0;
+    int* array_managed = createManagedArray<int>(size, default_value, Initialization::HOST);
 
     EXPECT_EQ(stdgpu::get_dynamic_memory_type(array_managed), stdgpu::dynamic_memory_type::managed);
 
@@ -248,7 +254,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_managed_on_host)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_invalid_pointer)
 {
-    int* array_invalid  = reinterpret_cast<int*>(42);
+    int* array_invalid = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
 
     EXPECT_EQ(stdgpu::get_dynamic_memory_type(array_invalid), stdgpu::dynamic_memory_type::invalid);
 }
@@ -256,7 +262,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_invalid_pointer)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_variable_pointer)
 {
-    int non_dynamic_array = 42;
+    int non_dynamic_array = 42; // NOLINT(readability-magic-numbers)
 
     EXPECT_EQ(stdgpu::get_dynamic_memory_type(&non_dynamic_array), stdgpu::dynamic_memory_type::invalid);
 }
@@ -270,9 +276,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_nullptr)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_device)
 {
-    int* array_device = createDeviceArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array_device = createDeviceArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size_bytes(array_device), 42 * sizeof(int));
+    EXPECT_EQ(stdgpu::size_bytes(array_device), size * sizeof(int));
 
     destroyDeviceArray<int>(array_device);
 }
@@ -280,9 +287,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_device)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_host)
 {
-    int* array_host = createHostArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array_host = createHostArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size_bytes(array_host), 42 * sizeof(int));
+    EXPECT_EQ(stdgpu::size_bytes(array_host), size * sizeof(int));
 
     destroyHostArray<int>(array_host);
 }
@@ -290,9 +298,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_host)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_managed_device)
 {
-    int* array_managed = createManagedArray<int>(42, 0, Initialization::DEVICE);
+    const stdgpu::index_t size = 42;
+    const int default_value = 0;
+    int* array_managed = createManagedArray<int>(size, default_value, Initialization::DEVICE);
 
-    EXPECT_EQ(stdgpu::size_bytes(array_managed), 42 * sizeof(int));
+    EXPECT_EQ(stdgpu::size_bytes(array_managed), size * sizeof(int));
 
     destroyManagedArray<int>(array_managed);
 }
@@ -300,9 +310,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_managed_device)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_manged_host)
 {
-    int* array_managed = createManagedArray<int>(42, 0, Initialization::HOST);
+    const stdgpu::index_t size = 42;
+    const int default_value = 0;
+    int* array_managed = createManagedArray<int>(size, default_value, Initialization::HOST);
 
-    EXPECT_EQ(stdgpu::size_bytes(array_managed), 42 * sizeof(int));
+    EXPECT_EQ(stdgpu::size_bytes(array_managed), size * sizeof(int));
 
     destroyManagedArray<int>(array_managed);
 }
@@ -316,9 +328,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_nullptr)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_device_shifted)
 {
-    int* array_device = createDeviceArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array_device = createDeviceArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size_bytes(array_device + 24), static_cast<stdgpu::index64_t>(0));
+    const stdgpu::index_t offset = 24;
+    EXPECT_EQ(stdgpu::size_bytes(array_device + offset), static_cast<stdgpu::index64_t>(0));
 
     destroyDeviceArray<int>(array_device);
 }
@@ -326,9 +340,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_device_shifted)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_host_shifted)
 {
-    int* array_host = createHostArray<int>(42);
+    const stdgpu::index_t size = 42;
+    int* array_host = createHostArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size_bytes(array_host + 24), static_cast<stdgpu::index64_t>(0));
+    const stdgpu::index_t offset = 24;
+    EXPECT_EQ(stdgpu::size_bytes(array_host + offset), static_cast<stdgpu::index64_t>(0));
 
     destroyHostArray<int>(array_host);
 }
@@ -336,9 +352,12 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_host_shifted)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_managed_device_shifted)
 {
-    int* array_managed = createManagedArray<int>(42, 0, Initialization::DEVICE);
+    const stdgpu::index_t size = 42;
+    const int default_value = 0;
+    int* array_managed = createManagedArray<int>(size, default_value, Initialization::DEVICE);
 
-    EXPECT_EQ(stdgpu::size_bytes(array_managed + 24), static_cast<stdgpu::index64_t>(0));
+    const stdgpu::index_t offset = 24;
+    EXPECT_EQ(stdgpu::size_bytes(array_managed + offset), static_cast<stdgpu::index64_t>(0));
 
     destroyManagedArray<int>(array_managed);
 }
@@ -346,9 +365,12 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_managed_device_shifted)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_managed_host_shifted)
 {
-    int* array_managed = createManagedArray<int>(42, 0, Initialization::HOST);
+    const stdgpu::index_t size = 42;
+    const int default_value = 0;
+    int* array_managed = createManagedArray<int>(size, default_value, Initialization::HOST);
 
-    EXPECT_EQ(stdgpu::size_bytes(array_managed + 24), static_cast<stdgpu::index64_t>(0));
+    const stdgpu::index_t offset = 24;
+    EXPECT_EQ(stdgpu::size_bytes(array_managed + offset), static_cast<stdgpu::index64_t>(0));
 
     destroyManagedArray<int>(array_managed);
 }
@@ -400,8 +422,8 @@ namespace
     {
         for (stdgpu::index_t i = 0; i < iterations; ++i)
         {
-            int default_value = 10;
-            stdgpu::index64_t size = 42;
+            const stdgpu::index64_t size = 42;
+            const int default_value = 10;
 
             int* array_device = createDeviceArray<int>(size, default_value);
 
@@ -420,8 +442,8 @@ namespace
     {
         for (stdgpu::index_t i = 0; i < iterations; ++i)
         {
-            int default_value = 10;
-            stdgpu::index64_t size = 42;
+            const stdgpu::index64_t size = 42;
+            const int default_value = 10;
 
             int* array_host = createHostArray<int>(size, default_value);
 
@@ -439,8 +461,8 @@ namespace
     {
         for (stdgpu::index_t i = 0; i < iterations; ++i)
         {
-            int default_value = 10;
-            stdgpu::index64_t size = 42;
+            const stdgpu::index64_t size = 42;
+            const int default_value = 10;
 
             int* array_managed_device = createManagedArray<int>(size, default_value, Initialization::DEVICE);
             int* array_managed_host = createManagedArray<int>(size, default_value, Initialization::HOST);
@@ -472,8 +494,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyDeviceArray)
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyDeviceArray_const_type)
 {
     using T = thrust::pair<const int,float>;
-    T default_value = {10, 2.0F};
-    stdgpu::index64_t size = 42;
+    const T default_value = {10, 2.0F};
+    const stdgpu::index64_t size = 42;
 
     T* array_device = createDeviceArray<T>(size, default_value);
 
@@ -485,7 +507,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyDeviceArray_const_type)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyDeviceArray_parallel)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
 
     test_utils::for_each_concurrent_thread(&createAndDestroyDeviceFunction,
                                            iterations_per_thread);
@@ -501,8 +523,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyHostArray)
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyHostArray_const_type)
 {
     using T = thrust::pair<const int,float>;
-    T default_value = {10, 2.0F};
-    stdgpu::index64_t size = 42;
+    const T default_value = {10, 2.0F};
+    const stdgpu::index64_t size = 42;
 
     T* array_host = createHostArray<T>(size, default_value);
 
@@ -514,7 +536,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyHostArray_const_type)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyHostArray_parallel)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
 
     test_utils::for_each_concurrent_thread(&createAndDestroyHostFunction,
                                            iterations_per_thread);
@@ -530,8 +552,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyManagedArray)
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyManagedArray_const_type)
 {
     using T = thrust::pair<const int,float>;
-    T default_value = {10, 2.0F};
-    stdgpu::index64_t size = 42;
+    const T default_value = {10, 2.0F};
+    const stdgpu::index64_t size = 42;
 
     T* array_managed = createManagedArray<T>(size, default_value);
 
@@ -544,7 +566,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyManagedArray_const_type)
 /*
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyManagedArray_parallel)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
 
     test_utils::for_each_concurrent_thread(&createAndDestroyManagedFunction,
                                            iterations_per_thread);
@@ -606,8 +628,8 @@ namespace
     {
         for (stdgpu::index_t i = 0; i < iterations; ++i)
         {
-            int default_value = 10;
-            stdgpu::index64_t size = 42;
+            const stdgpu::index64_t size = 42;
+            const int default_value = 10;
 
             int* array = createDeviceArray<int>(size, default_value);
             int* array_copy = copyCreateDevice2DeviceArray<int>(array, size);
@@ -633,7 +655,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateDevice2DeviceArray)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateDevice2DeviceArray_parallel)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
 
     test_utils::for_each_concurrent_thread(&copyCreateDevice2DeviceFunction,
                                            iterations_per_thread);
@@ -646,8 +668,8 @@ namespace
     {
         for (stdgpu::index_t i = 0; i < iterations; ++i)
         {
-            int default_value = 10;
-            stdgpu::index64_t size = 42;
+            const stdgpu::index64_t size = 42;
+            const int default_value = 10;
 
             int* array = createDeviceArray<int>(size, default_value);
             int* array_host = createHostArray<int>(size, default_value);
@@ -675,7 +697,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2DeviceArray)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2DeviceArray_parallel)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
 
     test_utils::for_each_concurrent_thread(&copyCreateHost2DeviceFunction,
                                            iterations_per_thread);
@@ -684,8 +706,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2DeviceArray_parallel)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2DeviceArray_no_check)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
 
     int* array = createDeviceArray<int>(size, default_value);
     int* array_host = new int[static_cast<std::size_t>(size)];
@@ -713,8 +735,8 @@ namespace
     {
         for (stdgpu::index_t i = 0; i < iterations; ++i)
         {
-            int default_value = 10;
-            stdgpu::index64_t size = 42;
+            const stdgpu::index64_t size = 42;
+            const int default_value = 10;
 
             int* array = createDeviceArray<int>(size, default_value);
             int* array_host = createHostArray<int>(size, default_value);
@@ -740,7 +762,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateDevice2HostArray)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateDevice2HostArray_parallel)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
 
     test_utils::for_each_concurrent_thread(&copyCreateDevice2HostFunction,
                                            iterations_per_thread);
@@ -753,8 +775,8 @@ namespace
     {
         for (stdgpu::index_t i = 0; i < iterations; ++i)
         {
-            int default_value = 10;
-            stdgpu::index64_t size = 42;
+            const stdgpu::index64_t size = 42;
+            const int default_value = 10;
 
             int* array_host = createHostArray<int>(size, default_value);
             int* array_copy = copyCreateHost2HostArray<int>(array_host, size);
@@ -778,7 +800,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2HostArray)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2HostArray_parallel)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
 
     test_utils::for_each_concurrent_thread(&copyCreateHost2HostFunction,
                                            iterations_per_thread);
@@ -787,8 +809,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2HostArray_parallel)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2HostArray_no_check)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
 
     int* array_host = new int[static_cast<std::size_t>(size)];
     for (stdgpu::index64_t i = 0; i < size; ++i)
@@ -811,7 +833,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_empty)
 {
     int* array_host = createHostArray<int>(1, 0);
 
-    int* array_host_copy = reinterpret_cast<int*>(42);
+    int* array_host_copy = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
 
     copyHost2HostArray<int>(array_host, 0, array_host_copy);
     EXPECT_EQ(array_host_copy, reinterpret_cast<int*>(42));
@@ -824,7 +846,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2HostArray_empty)
 {
     int* array_device = createDeviceArray<int>(1, 0);
 
-    int* array_host_copy = reinterpret_cast<int*>(42);
+    int* array_host_copy = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
 
     copyDevice2HostArray<int>(array_device, 0, array_host_copy);
     EXPECT_EQ(array_host_copy, reinterpret_cast<int*>(42));
@@ -837,7 +859,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2DeviceArray_empty)
 {
     int* array_host = createHostArray<int>(1, 0);
 
-    int* array_device_copy = reinterpret_cast<int*>(42);
+    int* array_device_copy = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
 
     copyHost2DeviceArray<int>(array_host, 0, array_device_copy);
     EXPECT_EQ(array_device_copy, reinterpret_cast<int*>(42));
@@ -849,7 +871,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2DeviceArray_empty)
 {
     int* array_device = createDeviceArray<int>(1, 0);
 
-    int* array_device_copy = reinterpret_cast<int*>(42);
+    int* array_device_copy = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
 
     copyDevice2DeviceArray<int>(array_device, 0, array_device_copy);
     EXPECT_EQ(array_device_copy, reinterpret_cast<int*>(42));
@@ -864,8 +886,8 @@ namespace
     {
         for (stdgpu::index_t i = 0; i < iterations; ++i)
         {
-            int default_value = 10;
-            stdgpu::index64_t size = 42;
+            const stdgpu::index64_t size = 42;
+            const int default_value = 10;
 
             int* array = createDeviceArray<int>(size, default_value);
             int* array_copy = createDeviceArray<int>(size, 0);
@@ -892,7 +914,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2DeviceArray)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2DeviceArray_parallel)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
 
     test_utils::for_each_concurrent_thread(&copyDevice2DeviceFunction,
                                            iterations_per_thread);
@@ -901,8 +923,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2DeviceArray_parallel)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2DeviceArray_self)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
 
     int* array = createDeviceArray<int>(size, default_value);
     int* array_copy = array;
@@ -924,8 +946,8 @@ namespace
     {
         for (stdgpu::index_t i = 0; i < iterations; ++i)
         {
-            int default_value = 10;
-            stdgpu::index64_t size = 42;
+            const stdgpu::index64_t size = 42;
+            const int default_value = 10;
 
             int* array = createDeviceArray<int>(size, default_value);
             int* array_host = createHostArray<int>(size, default_value);
@@ -954,7 +976,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2DeviceArray)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2DeviceArray_parallel)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
 
     test_utils::for_each_concurrent_thread(&copyHost2DeviceFunction,
                                            iterations_per_thread);
@@ -963,8 +985,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2DeviceArray_parallel)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2DeviceArray_no_check)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
 
     int* array = createDeviceArray<int>(size, default_value);
     int* array_host = new int[static_cast<std::size_t>(size)];
@@ -993,8 +1015,8 @@ namespace
     {
         for (stdgpu::index_t i = 0; i < iterations; ++i)
         {
-            int default_value = 10;
-            stdgpu::index64_t size = 42;
+            const stdgpu::index64_t size = 42;
+            const int default_value = 10;
 
             int* array = createDeviceArray<int>(size, default_value);
             int* array_host = createHostArray<int>(size, default_value);
@@ -1021,7 +1043,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2HostArray)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2HostArray_parallel)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
 
     test_utils::for_each_concurrent_thread(&copyDevice2HostFunction,
                                            iterations_per_thread);
@@ -1030,8 +1052,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2HostArray_parallel)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2HostArray_no_check)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
 
     int* array = createDeviceArray<int>(size, default_value);
     int* array_host = createHostArray<int>(size, default_value);
@@ -1055,8 +1077,8 @@ namespace
     {
         for (stdgpu::index_t i = 0; i < iterations; ++i)
         {
-            int default_value = 10;
-            stdgpu::index64_t size = 42;
+            const stdgpu::index64_t size = 42;
+            const int default_value = 10;
 
             int* array_host = createHostArray<int>(size, default_value);
             int* array_copy = createHostArray<int>(size, 0);
@@ -1081,7 +1103,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_parallel)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 7));
 
     test_utils::for_each_concurrent_thread(&copyHost2HostFunction,
                                            iterations_per_thread);
@@ -1090,8 +1112,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_parallel)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_no_check)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
 
     int* array_host = new int[static_cast<std::size_t>(size)];
     for (stdgpu::index64_t i = 0; i < size; ++i)
@@ -1113,8 +1135,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_no_check)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_self)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
 
     int* array_host = createHostArray<int>(size, default_value);
     int* array_copy = array_host;
@@ -1130,8 +1152,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_self)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_self_no_check)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
 
     int* array_host = new int[static_cast<std::size_t>(size)];
     for (stdgpu::index64_t i = 0; i < size; ++i)
@@ -1152,8 +1174,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_self_no_check)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyDeviceArray_double_free)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
 
     int* array_device   = createDeviceArray<int>(size, default_value);
     int* array_device_2 = array_device;
@@ -1165,8 +1187,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyDeviceArray_double_free)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyHostArray_double_free)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
 
     int* array_host     = createHostArray<int>(size, default_value);
     int* array_host_2   = array_host;
@@ -1178,8 +1200,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyHostArray_double_free)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyManangedArray_double_free)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
 
     int* array_managed_device = createManagedArray<int>(size, default_value, Initialization::DEVICE);
     int* array_managed_host = createManagedArray<int>(size, default_value, Initialization::HOST);
@@ -1195,11 +1217,12 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyManangedArray_double_free)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyDeviceArray_double_free_shifted)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
+    const stdgpu::index_t offset = 24;
 
     int* array_device = createDeviceArray<int>(size, default_value);
-    int* array_device_2 = array_device + 24;
+    int* array_device_2 = array_device + offset;
 
     destroyDeviceArray<int>(array_device);
     destroyDeviceArray<int>(array_device_2);
@@ -1208,11 +1231,12 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyDeviceArray_double_free_shifted)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyHostArray_double_free_shifted)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
+    const stdgpu::index_t offset = 24;
 
     int* array_host = createHostArray<int>(size, default_value);
-    int* array_host_2 = array_host + 24;
+    int* array_host_2 = array_host + offset;
 
     destroyHostArray<int>(array_host);
     destroyHostArray<int>(array_host_2);
@@ -1221,13 +1245,14 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyHostArray_double_free_shifted)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyManangedArray_double_free_shifted)
 {
-    int default_value = 10;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
+    const stdgpu::index_t offset = 24;
 
     int* array_managed_device = createManagedArray<int>(size, default_value, Initialization::DEVICE);
     int* array_managed_host = createManagedArray<int>(size, default_value, Initialization::HOST);
-    int* array_managed_device_2 = array_managed_device + 24;
-    int* array_managed_host_2 = array_managed_host + 24;
+    int* array_managed_device_2 = array_managed_device + offset;
+    int* array_managed_host_2 = array_managed_host + offset;
 
     destroyManagedArray<int>(array_managed_device);
     destroyManagedArray<int>(array_managed_device_2);
@@ -1239,12 +1264,12 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroyManangedArray_double_free_shifted)
 TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_device_allocator)
 {
     stdgpu::safe_device_allocator<int> a;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
 
     int* array = a.allocate(size);
 
     #if STDGPU_DETAIL_IS_DEVICE_COMPILED
-        int default_value = 10;
+        const int default_value = 10;
         thrust::fill(stdgpu::device_begin(array), stdgpu::device_end(array),
                      default_value);
 
@@ -1259,11 +1284,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_device_allocator)
 TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_host_allocator)
 {
     stdgpu::safe_host_allocator<int> a;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
 
     int* array = a.allocate(size);
 
-    int default_value = 10;
+    const int default_value = 10;
     thrust::fill(stdgpu::host_begin(array), stdgpu::host_end(array),
                  default_value);
 
@@ -1278,11 +1303,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_host_allocator)
 TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_managed_allocator)
 {
     stdgpu::safe_managed_allocator<int> a;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
 
     int* array = a.allocate(size);
 
-    int default_value = 10;
+    const int default_value = 10;
     thrust::fill(stdgpu::host_begin(array), stdgpu::host_end(array),
                  default_value);
 
@@ -1299,11 +1324,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_deallocate)
     using Allocator = stdgpu::safe_host_allocator<int>;
 
     Allocator a;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
 
     int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
 
-    int default_value = 10;
+    const int default_value = 10;
     thrust::fill(stdgpu::host_begin(array), stdgpu::host_end(array),
                  default_value);
 
@@ -1320,12 +1345,12 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_hint_deallocate)
     using Allocator = stdgpu::safe_host_allocator<int>;
 
     Allocator a;
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
 
     int* array_hint = stdgpu::allocator_traits<Allocator>::allocate(a, size);
     int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size, array_hint);
 
-    int default_value = 10;
+    const int default_value = 10;
     thrust::fill(stdgpu::host_begin(array), stdgpu::host_end(array),
                  default_value);
 
@@ -1413,7 +1438,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_construct_destroy)
     using Allocator = stdgpu::safe_host_allocator<Counter>;
     Allocator a;
 
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
 
     typename Allocator::value_type* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
 
@@ -1454,7 +1479,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, construct_at)
     using Allocator = stdgpu::safe_host_allocator<Counter>;
     Allocator a;
 
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
 
     typename Allocator::value_type* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
 
@@ -1480,7 +1505,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroy)
     using Allocator = stdgpu::safe_host_allocator<Counter>;
     Allocator a;
 
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
 
     typename Allocator::value_type* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
 
@@ -1503,7 +1528,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroy_n)
     using Allocator = stdgpu::safe_host_allocator<Counter>;
     Allocator a;
 
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
 
     typename Allocator::value_type* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
 
@@ -1526,7 +1551,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroy_at)
     using Allocator = stdgpu::safe_host_allocator<Counter>;
     Allocator a;
 
-    stdgpu::index64_t size = 42;
+    const stdgpu::index64_t size = 42;
 
     typename Allocator::value_type* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
 
@@ -1550,8 +1575,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroy_at)
 TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_pinned_host_allocator)
 {
     stdgpu::safe_pinned_host_allocator<int> a;
-    stdgpu::index64_t size = 42;
-    int default_value = 10;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
 
     int* array_host = a.allocate(size);
 
@@ -1601,8 +1626,8 @@ namespace
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, default_allocator_traits)
 {
-    stdgpu::index64_t size = 42;
-    int default_value = 10;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
 
     int* array_host = createHostArray<int>(size);
 

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -33,7 +33,6 @@ class stdgpu_mutex : public ::testing::Test
         // Called before each test
         void SetUp() override
         {
-            locks_size = 100000;
             locks = stdgpu::mutex_array::createDeviceObject(locks_size);
         }
 
@@ -43,7 +42,7 @@ class stdgpu_mutex : public ::testing::Test
             stdgpu::mutex_array::destroyDeviceObject(locks);
         }
 
-        stdgpu::index_t locks_size = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+        const stdgpu::index_t locks_size = 100000; // NOLINT(misc-non-private-member-variables-in-classes)
         stdgpu::mutex_array locks = {}; // NOLINT(misc-non-private-member-variables-in-classes)
 };
 
@@ -77,7 +76,8 @@ class lock_and_unlock
 
                     // Waste time ...
                     long j = 0;
-                    for (int k = 0; k < 10000; k++)
+                    const int iterations = 10000;
+                    for (int k = 0; k < iterations; ++k)
                     {
                         j += k;
                     }

--- a/test/stdgpu/openmp/device_info.cpp
+++ b/test/stdgpu/openmp/device_info.cpp
@@ -31,8 +31,8 @@ namespace openmp
 void
 print_device_information()
 {
-    std::string gpu_name = "Built-in CPU";
-    int gpu_name_total_width = 57;
+    const std::string gpu_name = "Built-in CPU";
+    const int gpu_name_total_width = 57;
     int gpu_name_size = static_cast<int>(gpu_name.size());
     int gpu_name_space_left  = std::max<int>(1, (gpu_name_total_width - gpu_name_size) / 2);
     int gpu_name_space_right = std::max<int>(1, gpu_name_total_width - gpu_name_size - gpu_name_space_left);

--- a/test/stdgpu/rocm/device_info.cpp
+++ b/test/stdgpu/rocm/device_info.cpp
@@ -62,7 +62,7 @@ print_device_information()
     hipMemGetInfo(&free_memory, &total_memory);
 
     std::string gpu_name = properties.name;
-    int gpu_name_total_width = 57;
+    const int gpu_name_total_width = 57;
     int gpu_name_size = static_cast<int>(gpu_name.size());
     int gpu_name_space_left  = std::max<int>(1, (gpu_name_total_width - gpu_name_size) / 2);
     int gpu_name_space_right = std::max<int>(1, gpu_name_total_width - gpu_name_size - gpu_name_space_left);

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -58,7 +58,7 @@ class STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS : public ::testing::Test
         // Called before each test
         void SetUp() override
         {
-            hash_datastructure = test_unordered_datastructure::createDeviceObject(100000);
+            hash_datastructure = test_unordered_datastructure::createDeviceObject(hash_datastructure_size);
         }
 
         // Called after each test
@@ -67,6 +67,7 @@ class STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS : public ::testing::Test
             test_unordered_datastructure::destroyDeviceObject(hash_datastructure);
         }
 
+        const stdgpu::index_t hash_datastructure_size = 100000; // NOLINT(misc-non-private-member-variables-in-classes)
         test_unordered_datastructure hash_datastructure = {}; // NOLINT(misc-non-private-member-variables-in-classes)
 };
 
@@ -96,7 +97,7 @@ namespace
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, hash_inside_range)
 {
-    stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 21));
+    const stdgpu::index_t iterations_per_thread = static_cast<stdgpu::index_t>(pow(2, 21));
 
     test_utils::for_each_concurrent_thread(&thread_hash_inside_range,
                                            iterations_per_thread,
@@ -197,7 +198,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_hits)
     stdgpu::index_t number_hits = static_cast<stdgpu::index_t>(thrust::count_if(stdgpu::device_cbegin(bucket_hits), stdgpu::device_cend(bucket_hits),
                                                                greater_value<0>()));
 
-    float percent_hits = 80.0F;
+    const float percent_hits = 80.0F;
     EXPECT_GT(number_hits, static_cast<stdgpu::index_t>(static_cast<float>(hash_datastructure.bucket_count()) * percent_hits / 100.0F));
 
     destroyDeviceArray<int>(bucket_hits);
@@ -234,7 +235,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_collisions)
     stdgpu::index_t number_collisions = static_cast<stdgpu::index_t>(thrust::count_if(stdgpu::device_cbegin(bucket_hits), stdgpu::device_cend(bucket_hits),
                                                                      greater_value<1>()));
 
-    float percent_collisions = 40.0F;
+    const float percent_collisions = 40.0F;
     EXPECT_LT(number_collisions, static_cast<stdgpu::index_t>(static_cast<float>(N) * percent_collisions / 100.0F));
 
     destroyDeviceArray<int>(bucket_hits);
@@ -780,8 +781,8 @@ namespace
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_no_collision)
 {
-    test_unordered_datastructure::key_type position_1(-7, -3, 15);
-    test_unordered_datastructure::key_type position_2(-5, -15, 13);
+    const test_unordered_datastructure::key_type position_1(-7, -3, 15);
+    const test_unordered_datastructure::key_type position_2(-5, -15, 13);
 
 
     // Insert test data
@@ -809,10 +810,10 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_no_collision)
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_collision)
 {
-    test_unordered_datastructure::key_type position_1(-7, -3, 15);
-    test_unordered_datastructure::key_type position_2( 7,  3, 15);
-    test_unordered_datastructure::key_type position_3(-5, -15, 13);
-    test_unordered_datastructure::key_type position_4( 5,  15, 13);
+    const test_unordered_datastructure::key_type position_1(-7, -3, 15);
+    const test_unordered_datastructure::key_type position_2( 7,  3, 15);
+    const test_unordered_datastructure::key_type position_3(-5, -15, 13);
+    const test_unordered_datastructure::key_type position_4( 5,  15, 13);
 
     ASSERT_EQ(hash_datastructure.bucket(position_1), hash_datastructure.bucket(position_2));
     ASSERT_EQ(hash_datastructure.bucket(position_3), hash_datastructure.bucket(position_4));
@@ -863,8 +864,8 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_collision)
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_no_collision)
 {
-    test_unordered_datastructure::key_type position_1(-7, -3, 15);
-    test_unordered_datastructure::key_type position_2(-5, -15, 13);
+    const test_unordered_datastructure::key_type position_1(-7, -3, 15);
+    const test_unordered_datastructure::key_type position_2(-5, -15, 13);
 
 
     // Insert test data
@@ -914,10 +915,10 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_no_collision)
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_collision)
 {
-    test_unordered_datastructure::key_type position_1(-7, -3, 15);
-    test_unordered_datastructure::key_type position_2( 7,  3, 15);
-    test_unordered_datastructure::key_type position_3(-5, -15, 13);
-    test_unordered_datastructure::key_type position_4( 5,  15, 13);
+    const test_unordered_datastructure::key_type position_1(-7, -3, 15);
+    const test_unordered_datastructure::key_type position_2( 7,  3, 15);
+    const test_unordered_datastructure::key_type position_3(-5, -15, 13);
+    const test_unordered_datastructure::key_type position_4( 5,  15, 13);
 
     ASSERT_EQ(hash_datastructure.bucket(position_1), hash_datastructure.bucket(position_2));
     ASSERT_EQ(hash_datastructure.bucket(position_3), hash_datastructure.bucket(position_4));
@@ -1002,7 +1003,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_collision)
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_double)
 {
-    test_unordered_datastructure::key_type position(-7, -3, 15);
+    const test_unordered_datastructure::key_type position(-7, -3, 15);
 
 
     // Insert test data
@@ -1028,7 +1029,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_double)
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_double)
 {
-    test_unordered_datastructure::key_type position(-7, -3, 15);
+    const test_unordered_datastructure::key_type position(-7, -3, 15);
 
 
     // Insert test data
@@ -1169,7 +1170,7 @@ namespace
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_multiple_no_collision)
 {
-    test_unordered_datastructure::key_type position(-7, -3, 15);
+    const test_unordered_datastructure::key_type position(-7, -3, 15);
 
     insert_key_multiple(hash_datastructure, position);
 }
@@ -1177,7 +1178,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_multiple_no_collision)
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_multiple_no_collision)
 {
-    test_unordered_datastructure::key_type position(-7, -3, 15);
+    const test_unordered_datastructure::key_type position(-7, -3, 15);
 
 
     // Insert test data
@@ -1197,8 +1198,8 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_multiple_no_collision)
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_multiple_collision)
 {
-    test_unordered_datastructure::key_type position_1(-7, -3, 15);
-    test_unordered_datastructure::key_type position_2( 7,  3, 15);
+    const test_unordered_datastructure::key_type position_1(-7, -3, 15);
+    const test_unordered_datastructure::key_type position_2( 7,  3, 15);
 
     ASSERT_EQ(hash_datastructure.bucket(position_1), hash_datastructure.bucket(position_2));
 
@@ -1219,8 +1220,8 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_multiple_collision)
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_multiple_collision_head_first)
 {
-    test_unordered_datastructure::key_type position_1(-7, -3, 15);
-    test_unordered_datastructure::key_type position_2( 7,  3, 15);
+    const test_unordered_datastructure::key_type position_1(-7, -3, 15);
+    const test_unordered_datastructure::key_type position_2( 7,  3, 15);
 
     ASSERT_EQ(hash_datastructure.bucket(position_1), hash_datastructure.bucket(position_2));
 
@@ -1251,8 +1252,8 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_multiple_collision_head_
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_multiple_collision_tail_first)
 {
-    test_unordered_datastructure::key_type position_1(-7, -3, 15);
-    test_unordered_datastructure::key_type position_2( 7,  3, 15);
+    const test_unordered_datastructure::key_type position_1(-7, -3, 15);
+    const test_unordered_datastructure::key_type position_2( 7,  3, 15);
 
     ASSERT_EQ(hash_datastructure.bucket(position_1), hash_datastructure.bucket(position_2));
 
@@ -1286,8 +1287,8 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_while_full)
     test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1);
 
     // Fill tiny hash table
-    test_unordered_datastructure::key_type position_1(1, 2, 3);
-    test_unordered_datastructure::key_type position_2(4, 5, 6);
+    const test_unordered_datastructure::key_type position_1(1, 2, 3);
+    const test_unordered_datastructure::key_type position_2(4, 5, 6);
 
     insert_key(tiny_hash_datastructure, position_1);
     insert_key(tiny_hash_datastructure, position_2);
@@ -1297,7 +1298,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_while_full)
     EXPECT_EQ(tiny_hash_datastructure.size(), 2);
 
     // Insert entry in full hash table
-    test_unordered_datastructure::key_type position_3(7, 8, 9);
+    const test_unordered_datastructure::key_type position_3(7, 8, 9);
 
     bool inserted_3 = insert_key(tiny_hash_datastructure, position_3);
     EXPECT_FALSE(inserted_3);
@@ -1314,8 +1315,8 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_multiple_while_full)
     test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1);
 
     // Fill tiny hash table
-    test_unordered_datastructure::key_type position_1(1, 2, 3);
-    test_unordered_datastructure::key_type position_2(4, 5, 6);
+    const test_unordered_datastructure::key_type position_1(1, 2, 3);
+    const test_unordered_datastructure::key_type position_2(4, 5, 6);
 
     insert_key(tiny_hash_datastructure, position_1);
     insert_key(tiny_hash_datastructure, position_2);
@@ -1325,7 +1326,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_multiple_while_full)
     EXPECT_EQ(tiny_hash_datastructure.size(), 2);
 
     // Multi-insert entry in full hash table
-    test_unordered_datastructure::key_type position_3(7, 8, 9);
+    const test_unordered_datastructure::key_type position_3(7, 8, 9);
 
 
     const stdgpu::index_t N = 100000;
@@ -1353,9 +1354,9 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_while_excess_empty)
     test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(2);
 
     // Fill tiny hash table
-    test_unordered_datastructure::key_type position_1( 1,  2,  3);
-    test_unordered_datastructure::key_type position_2(-1,  2,  3);
-    test_unordered_datastructure::key_type position_3( 1, -2,  3);
+    const test_unordered_datastructure::key_type position_1( 1,  2,  3);
+    const test_unordered_datastructure::key_type position_2(-1,  2,  3);
+    const test_unordered_datastructure::key_type position_3( 1, -2,  3);
 
     insert_key(tiny_hash_datastructure, position_1);
     insert_key(tiny_hash_datastructure, position_2);
@@ -1465,7 +1466,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_one_free
     test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1);
 
     // Fill tiny hash table and only keep one free
-    test_unordered_datastructure::key_type position_1(1, 2, 3);
+    const test_unordered_datastructure::key_type position_1(1, 2, 3);
 
     insert_key(tiny_hash_datastructure, position_1);
 
@@ -1521,9 +1522,9 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_excess_e
     test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(2);
 
     // Fill tiny hash table
-    test_unordered_datastructure::key_type position_1( 1,  2,  3);
-    test_unordered_datastructure::key_type position_2(-1,  2,  3);
-    test_unordered_datastructure::key_type position_3( 1, -2,  3);
+    const test_unordered_datastructure::key_type position_1( 1,  2,  3);
+    const test_unordered_datastructure::key_type position_2(-1,  2,  3);
+    const test_unordered_datastructure::key_type position_3( 1, -2,  3);
 
     insert_key(tiny_hash_datastructure, position_1);
     insert_key(tiny_hash_datastructure, position_2);
@@ -1561,7 +1562,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, emplace_parallel_while_one_fre
     test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1);
 
     // Fill tiny hash table and only keep one free
-    test_unordered_datastructure::key_type position_1(1, 2, 3);
+    const test_unordered_datastructure::key_type position_1(1, 2, 3);
 
     insert_key(tiny_hash_datastructure, position_1);
 
@@ -1617,9 +1618,9 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, emplace_parallel_while_excess_
     test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(2);
 
     // Fill tiny hash table
-    test_unordered_datastructure::key_type position_1( 1,  2,  3);
-    test_unordered_datastructure::key_type position_2(-1,  2,  3);
-    test_unordered_datastructure::key_type position_3( 1, -2,  3);
+    const test_unordered_datastructure::key_type position_1( 1,  2,  3);
+    const test_unordered_datastructure::key_type position_2(-1,  2,  3);
+    const test_unordered_datastructure::key_type position_3( 1, -2,  3);
 
     insert_key(tiny_hash_datastructure, position_1);
     insert_key(tiny_hash_datastructure, position_2);

--- a/test/stdgpu/unordered_map.inc
+++ b/test/stdgpu/unordered_map.inc
@@ -98,9 +98,13 @@ struct hash
     inline STDGPU_HOST_DEVICE std::size_t
     operator()(const vec3int16& key) const
     {
-        return (static_cast<std::size_t>(key.x) * static_cast<std::size_t>(73856093U))
-             ^ (static_cast<std::size_t>(key.y) * static_cast<std::size_t>(19349669U))
-             ^ (static_cast<std::size_t>(key.z) * static_cast<std::size_t>(83492791U));
+        const std::size_t prime_x = static_cast<std::size_t>(73856093U);
+        const std::size_t prime_y = static_cast<std::size_t>(19349669U);
+        const std::size_t prime_z = static_cast<std::size_t>(83492791U);
+
+        return (static_cast<std::size_t>(key.x) * prime_x)
+             ^ (static_cast<std::size_t>(key.y) * prime_y)
+             ^ (static_cast<std::size_t>(key.z) * prime_z);
     }
 };
 

--- a/test/stdgpu/unordered_set.inc
+++ b/test/stdgpu/unordered_set.inc
@@ -94,9 +94,13 @@ struct hash
     inline STDGPU_HOST_DEVICE std::size_t
     operator()(const vec3int16& key) const
     {
-        return (static_cast<std::size_t>(key.x) * static_cast<std::size_t>(73856093U))
-             ^ (static_cast<std::size_t>(key.y) * static_cast<std::size_t>(19349669U))
-             ^ (static_cast<std::size_t>(key.z) * static_cast<std::size_t>(83492791U));
+        const std::size_t prime_x = static_cast<std::size_t>(73856093U);
+        const std::size_t prime_y = static_cast<std::size_t>(19349669U);
+        const std::size_t prime_z = static_cast<std::size_t>(83492791U);
+
+        return (static_cast<std::size_t>(key.x) * prime_x)
+             ^ (static_cast<std::size_t>(key.y) * prime_y)
+             ^ (static_cast<std::size_t>(key.z) * prime_z);
     }
 };
 

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -323,8 +323,9 @@ TEST_F(stdgpu_vector, pop_back_const_type)
 
     stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
 
+    const float part_second = 2.0F;
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     push_back_vector_const_type<T>(pool, 2.0F));
+                     push_back_vector_const_type<T>(pool, part_second));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -486,8 +487,9 @@ TEST_F(stdgpu_vector, push_back_const_type)
 
     stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
 
+    const float part_second = 2.0F;
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     push_back_vector_const_type<T>(pool, 2.0F));
+                     push_back_vector_const_type<T>(pool, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -633,8 +635,9 @@ TEST_F(stdgpu_vector, emplace_back_const_type)
 
     stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
 
+    const float part_second = 2.0F;
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
-                     emplace_back_vector_const_type<T>(pool, 2.0F));
+                     emplace_back_vector_const_type<T>(pool, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());


### PR DESCRIPTION
In addition the recent warning fixes (see #140), there are still some warnings left. Fix these `readability-magic-numbers` warnings to ensure clean builds under `clang-tidy-8`.