### PR TITLE
bitset: Fix deprecated-copy warning

### DIFF
--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -68,6 +68,14 @@ class bitset
                 reference() = delete;
 
                 /**
+                 * \brief Default copy constructor
+                 * \param[in] x The reference object to copy
+                 */
+                // NOTE ROCm's HCC compiler has problems with the C++11 default version, so fallback to custom version
+                STDGPU_HOST_DEVICE
+                reference(const reference& x);
+
+                /**
                  * \brief Performs atomic assignment of a bit value
                  * \param[in] x A bit value to assign
                  * \return The old value of the bit

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -36,6 +36,15 @@ bitset::reference::reference(bitset::reference::block_type* bit_block,
 }
 
 
+inline STDGPU_HOST_DEVICE
+bitset::reference::reference(const bitset::reference& x) //NOLINT(hicpp-use-equals-default,modernize-use-equals-default)
+    : _bit_block(x._bit_block),
+      _bit_n(x._bit_n)
+{
+
+}
+
+
 inline STDGPU_DEVICE_ONLY bool //NOLINT(misc-unconventional-assign-operator)
 bitset::reference::operator=(bool x)
 {

--- a/src/stdgpu/impl/mutex_detail.cuh
+++ b/src/stdgpu/impl/mutex_detail.cuh
@@ -66,7 +66,7 @@ mutex_ref::locked() const
 
 
 inline STDGPU_HOST_DEVICE
-mutex_array::reference::reference(bitset::reference bit_ref)
+mutex_array::reference::reference(const bitset::reference& bit_ref)
     : _bit_ref(bit_ref)
 {
 

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -93,7 +93,7 @@ class mutex_array
                 friend mutex_ref;
 
                 STDGPU_HOST_DEVICE
-                explicit reference(bitset::reference bit_ref);
+                explicit reference(const bitset::reference& bit_ref);
 
                 bitset::reference _bit_ref;
         };


### PR DESCRIPTION
Recent compilers such as GCC 10 and Clang 10 emit a stricter set of warnings. Fix the newly appearing `-Wdeprecated-copy` warning by explicitly defining a copy constructor. Since ROCm's HCC compiler seems to have problems with the C++11 default version, we fallback to old C++98 style copy constructors.