### PR TITLE
platform: Move STDGPU_HAS_CXX_17 to compiler

### DIFF
--- a/cmake/set_host_flags.cmake
+++ b/cmake/set_host_flags.cmake
@@ -10,6 +10,7 @@ function(stdgpu_set_host_flags STDGPU_OUTPUT_HOST_FLAGS)
         list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wsign-compare")
         list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wconversion")
         list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wfloat-equal")
+        list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wundef")
 
         if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
             list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Werror")

--- a/src/stdgpu/compiler.h
+++ b/src/stdgpu/compiler.h
@@ -91,6 +91,18 @@ namespace stdgpu
 #endif
 
 
+/**
+ * \def STDGPU_HAS_CXX_17
+ * \hideinitializer
+ * \brief Indicator of C++17 availability
+ */
+#if defined(__cplusplus) && __cplusplus >= 201703L
+    #define STDGPU_HAS_CXX_17 1
+#else
+    #define STDGPU_HAS_CXX_17 0
+#endif
+
+
 } // namespace stdgpu
 
 

--- a/src/stdgpu/platform.h
+++ b/src/stdgpu/platform.h
@@ -37,19 +37,6 @@ namespace stdgpu
 {
 
 /**
- * \def STDGPU_HAS_CXX_17
- * \hideinitializer
- * \brief Indicator of C++17 availability
- */
-#if defined(__cplusplus) && __cplusplus >= 201703L
-    #define STDGPU_HAS_CXX_17 1
-#else
-    #define STDGPU_HAS_CXX_17 0
-#endif
-
-
-
-/**
  * \hideinitializer
  * \brief Backend: CUDA
  */


### PR DESCRIPTION
In #119, automatic dispatching support has been added to the `platform` module. However, this caused a regression in `attribute` where `STDGPU_HAS_CXX_17` becomes undefined due to include changes. Since the latter is closer related to `compiler` rather than `platform`, move it to that place. Furthermore, extend the set of warnings to avoid such regressions in  the future.