### PR TITLE
src,test: Fix some minor warnings

### DIFF
--- a/cmake/set_host_flags.cmake
+++ b/cmake/set_host_flags.cmake
@@ -11,6 +11,7 @@ function(stdgpu_set_host_flags STDGPU_OUTPUT_HOST_FLAGS)
         list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wconversion")
         list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wfloat-equal")
         list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wundef")
+        list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Wdouble-promotion")
 
         if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
             list(APPEND ${STDGPU_OUTPUT_HOST_FLAGS} "-Werror")

--- a/src/stdgpu/cuda/impl/memory.cpp
+++ b/src/stdgpu/cuda/impl/memory.cpp
@@ -84,6 +84,7 @@ dispatch_malloc(const dynamic_memory_type type,
         }
         break;
 
+        case dynamic_memory_type::invalid :
         default :
         {
             printf("stdgpu::cuda::dispatch_malloc : Unsupported dynamic memory type\n");
@@ -116,6 +117,7 @@ dispatch_free(const dynamic_memory_type type,
         }
         break;
 
+        case dynamic_memory_type::invalid :
         default :
         {
             printf("stdgpu::cuda::dispatch_free : Unsupported dynamic memory type\n");

--- a/src/stdgpu/hip/impl/memory.cpp
+++ b/src/stdgpu/hip/impl/memory.cpp
@@ -84,6 +84,7 @@ dispatch_malloc(const dynamic_memory_type type,
         }
         break;
 
+        case dynamic_memory_type::invalid :
         default :
         {
             printf("stdgpu::hip::dispatch_malloc : Unsupported dynamic memory type\n");
@@ -116,6 +117,7 @@ dispatch_free(const dynamic_memory_type type,
         }
         break;
 
+        case dynamic_memory_type::invalid :
         default :
         {
             printf("stdgpu::hip::dispatch_free : Unsupported dynamic memory type\n");

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -159,6 +159,7 @@ dispatch_allocation_manager(const dynamic_memory_type type)
             return manager_managed;
         }
 
+        case dynamic_memory_type::invalid :
         default :
         {
             printf("stdgpu::detail::dispatch_allocation_manager : Unsupported dynamic memory type\n");

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -146,21 +146,18 @@ dispatch_allocation_manager(const dynamic_memory_type type)
             static allocation_manager manager_device;
             return manager_device;
         }
-        break;
 
         case dynamic_memory_type::host :
         {
             static allocation_manager manager_host;
             return manager_host;
         }
-        break;
 
         case dynamic_memory_type::managed :
         {
             static allocation_manager manager_managed;
             return manager_managed;
         }
-        break;
 
         default :
         {

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -554,7 +554,7 @@ allocator_traits<Allocator>::max_size(STDGPU_MAYBE_UNUSED const Allocator& a)
 
 template <typename Allocator>
 Allocator
-allocator_traits<Allocator>::select_on_container_copy_construction(STDGPU_MAYBE_UNUSED const Allocator& a)
+allocator_traits<Allocator>::select_on_container_copy_construction(const Allocator& a)
 {
     return a;
 }

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -51,7 +51,7 @@ expected_collisions(const index_t bucket_count,
 
     float k = static_cast<float>(bucket_count);
     float n = static_cast<float>(capacity);
-    index_t result = static_cast<index_t>(n * (1.0 - std::pow(1.0 - (1.0 / k), n - 1.0)));
+    index_t result = static_cast<index_t>(n * (1.0F - std::pow(1.0F - (1.0F / k), n - 1.0F)));
 
     STDGPU_ENSURES(result >= 0);
 

--- a/src/stdgpu/openmp/impl/memory.cpp
+++ b/src/stdgpu/openmp/impl/memory.cpp
@@ -41,6 +41,7 @@ dispatch_malloc(const dynamic_memory_type type,
         }
         break;
 
+        case dynamic_memory_type::invalid :
         default :
         {
             printf("stdgpu::openmp::dispatch_malloc : Unsupported dynamic memory type\n");
@@ -63,6 +64,7 @@ dispatch_free(const dynamic_memory_type type,
         }
         break;
 
+        case dynamic_memory_type::invalid :
         default :
         {
             printf("stdgpu::openmp::dispatch_free : Unsupported dynamic memory type\n");

--- a/test/stdgpu/iterator.cpp
+++ b/test/stdgpu/iterator.cpp
@@ -174,7 +174,7 @@ TEST_F(stdgpu_iterator, size_device_void)
     const stdgpu::index_t size = 42;
     int* array = createDeviceArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size((void*)array), size * sizeof(int));
+    EXPECT_EQ(stdgpu::size(reinterpret_cast<void*>(array)), size * sizeof(int));
 
     destroyDeviceArray<int>(array);
 }
@@ -185,7 +185,7 @@ TEST_F(stdgpu_iterator, size_host_void)
     const stdgpu::index_t size = 42;
     int* array = createHostArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size((void*)array), size * sizeof(int));
+    EXPECT_EQ(stdgpu::size(reinterpret_cast<void*>(array)), size * sizeof(int));
 
     destroyHostArray<int>(array);
 }
@@ -193,7 +193,8 @@ TEST_F(stdgpu_iterator, size_host_void)
 
 TEST_F(stdgpu_iterator, size_nullptr_void)
 {
-    EXPECT_EQ(stdgpu::size((void*)nullptr), static_cast<std::size_t>(0));
+    int* array = nullptr;
+    EXPECT_EQ(stdgpu::size(reinterpret_cast<void*>(array)), static_cast<std::size_t>(0));
 }
 
 
@@ -221,7 +222,8 @@ TEST_F(stdgpu_iterator, size_host)
 
 TEST_F(stdgpu_iterator, size_nullptr)
 {
-    EXPECT_EQ(stdgpu::size((int*)nullptr), static_cast<std::size_t>(0));
+    int* array = nullptr;
+    EXPECT_EQ(stdgpu::size(array), static_cast<std::size_t>(0));
 }
 
 


### PR DESCRIPTION
Using `-Weverything`, Clang analyzes the code for any possible warning it knows about. Since not all of them are meaningful for most projects, we also do not enable it by default. Nevertheless, fix some of these warnings to cleanup the code.