### PR TITLE
contract: Enforce user semicolon for all possible expansions

### DIFF
--- a/src/stdgpu/contract.h
+++ b/src/stdgpu/contract.h
@@ -49,6 +49,8 @@ namespace stdgpu
  * \brief A macro to define in-body conditions for both host and device
  */
 #if STDGPU_ENABLE_CONTRACT_CHECKS
+    #define STDGPU_FORCE_USER_SEMICOLON(statement) do { statement } while (0)
+
     #define STDGPU_DETAIL_HOST_CHECK(type, condition) \
         if (!(condition)) \
         { \
@@ -60,9 +62,9 @@ namespace stdgpu
             std::terminate(); \
         }
 
-    #define STDGPU_DETAIL_HOST_EXPECTS(condition) STDGPU_DETAIL_HOST_CHECK("Precondition", condition)
-    #define STDGPU_DETAIL_HOST_ENSURES(condition) STDGPU_DETAIL_HOST_CHECK("Postcondition", condition)
-    #define STDGPU_DETAIL_HOST_ASSERT(condition) STDGPU_DETAIL_HOST_CHECK("Assertion", condition)
+    #define STDGPU_DETAIL_HOST_EXPECTS(condition) STDGPU_FORCE_USER_SEMICOLON(STDGPU_DETAIL_HOST_CHECK("Precondition", condition))
+    #define STDGPU_DETAIL_HOST_ENSURES(condition) STDGPU_FORCE_USER_SEMICOLON(STDGPU_DETAIL_HOST_CHECK("Postcondition", condition))
+    #define STDGPU_DETAIL_HOST_ASSERT(condition) STDGPU_FORCE_USER_SEMICOLON(STDGPU_DETAIL_HOST_CHECK("Assertion", condition))
 
     // FIXME:
     // HIP's device assert() function does not seem to override/overload the host compiler version.


### PR DESCRIPTION
The host versions of the `STDGPU_{EXPECTS,ENSURES,ASSERTS}` macros are internally defined as `if` statements which do not require semicolons at the end of the statement. However, this may lead to confusing warnings mentioning superfluous semicolons. Even worse, users might omit the semicolon at the end of the macros and get the impression that this version is more robust and produces less noise.

Fix this undesired behavior by enforcing a semicolon on the user side. This fixes potential warnings and makes wrong usage of the macros, i.e. omitting the semicolon, a compiler error.