### PR TITLE
General: Add cppcheck support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,12 @@ if(STDGPU_ANALYZE_WITH_CLANG_TIDY)
     stdgpu_setup_clang_tidy(STDGPU_PROPERTY_CLANG_TIDY)
 endif()
 
+option(STDGPU_ANALYZE_WITH_CPPCHECK "Analyzes the code with cppcheck, default: OFF" OFF)
+if(STDGPU_ANALYZE_WITH_CPPCHECK)
+    include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/setup_cppcheck.cmake")
+    stdgpu_setup_cppcheck(STDGPU_PROPERTY_CPPCHECK)
+endif()
+
 
 # Setup install paths
 set(STDGPU_LIB_INSTALL_DIR "lib")

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Build Option | Effect | Default
 `STDGPU_SETUP_COMPILER_FLAGS` | Constructs the compiler flags | `ON` if standalone, `OFF` if included via `add_subdirectory`
 `STDGPU_TREAT_WARNINGS_AS_ERRORS` | Treats compiler warnings as errors | `OFF`
 `STDGPU_ANALYZE_WITH_CLANG_TIDY` | Analyzes the code with clang-tidy | `OFF`
+`STDGPU_ANALYZE_WITH_CPPCHECK` | Analyzes the code with cppcheck | `OFF`
 `STDGPU_BUILD_SHARED_LIBS` | Builds the project as a shared library, if set to `ON`, or as a static library, if set to `OFF` | `BUILD_SHARED_LIBS`
 `STDGPU_BUILD_EXAMPLES` | Build the examples | `ON`
 `STDGPU_BUILD_TESTS` | Build the unit tests | `ON`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -221,6 +221,52 @@ jobs:
             sh scripts/build_debug.sh
 
 - job:
+  displayName: Cppcheck OpenMP
+  pool:
+    vmImage: 'ubuntu-18.04'
+
+  steps:
+    - task: Bash@3
+      displayName: Install OpenMP
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/install_openmp_ubuntu1804.sh
+
+    - task: Bash@3
+      displayName: Install CMake 3.15+
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/install_cmake_ubuntu1804.sh
+
+    - task: Bash@3
+      displayName: Install cppcheck
+      inputs:
+        targetType: 'inline'
+        script: |
+          set -e
+          sh scripts/utils/install_cppcheck_ubuntu1804.sh
+
+    - task: Bash@3
+      displayName: Configure project
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/ci/configure_openmp_cppcheck.sh
+
+    - task: Bash@3
+      displayName: Build project
+      inputs:
+        targetType: 'inline'
+        script: |
+            set -e
+            sh scripts/build_debug.sh
+
+- job:
   displayName: Documentation OpenMP
   pool:
     vmImage: 'ubuntu-18.04'

--- a/cmake/config_summary.cmake
+++ b/cmake/config_summary.cmake
@@ -15,6 +15,7 @@ function(stdgpu_print_configuration_summary)
     message(STATUS "  STDGPU_SETUP_COMPILER_FLAGS               :   ${STDGPU_SETUP_COMPILER_FLAGS} (depends on usage method)")
     message(STATUS "  STDGPU_TREAT_WARNINGS_AS_ERRORS           :   ${STDGPU_TREAT_WARNINGS_AS_ERRORS}")
     message(STATUS "  STDGPU_ANALYZE_WITH_CLANG_TIDY            :   ${STDGPU_ANALYZE_WITH_CLANG_TIDY}")
+    message(STATUS "  STDGPU_ANALYZE_WITH_CPPCHECK              :   ${STDGPU_ANALYZE_WITH_CPPCHECK}")
     message(STATUS "  STDGPU_BUILD_SHARED_LIBS                  :   ${STDGPU_BUILD_SHARED_LIBS} (depends on BUILD_SHARED_LIBS)")
 
     message(STATUS "")

--- a/cmake/setup_cppcheck.cmake
+++ b/cmake/setup_cppcheck.cmake
@@ -1,0 +1,22 @@
+function(stdgpu_setup_cppcheck STDGPU_OUTPUT_PROPERTY_CPPCHECK)
+    find_program(STDGPU_CPPCHECK
+                 NAMES
+                 "cppcheck")
+
+    if(NOT STDGPU_CPPCHECK)
+        message(FATAL_ERROR "cppcheck not found.")
+    endif()
+
+    set(${STDGPU_OUTPUT_PROPERTY_CPPCHECK} "${STDGPU_CPPCHECK}" "--enable=warning,style,performance,portability" "--force" "--inline-suppr" "--quiet")
+
+    if(NOT DEFINED STDGPU_TREAT_WARNINGS_AS_ERRORS)
+        message(FATAL_ERROR "STDGPU_TREAT_WARNINGS_AS_ERRORS not defined.")
+    endif()
+
+    if(STDGPU_TREAT_WARNINGS_AS_ERRORS)
+        list(APPEND ${STDGPU_OUTPUT_PROPERTY_CPPCHECK} "--error-exitcode=1")
+    endif()
+
+    # Make output variable visible
+    set(${STDGPU_OUTPUT_PROPERTY_CPPCHECK} ${${STDGPU_OUTPUT_PROPERTY_CPPCHECK}} PARENT_SCOPE)
+endfunction()

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -198,6 +198,7 @@ Build Option | Effect | Default
 `STDGPU_SETUP_COMPILER_FLAGS` | Constructs the compiler flags | `ON` if standalone, `OFF` if included via `add_subdirectory`
 `STDGPU_TREAT_WARNINGS_AS_ERRORS` | Treats compiler warnings as errors | `OFF`
 `STDGPU_ANALYZE_WITH_CLANG_TIDY` | Analyzes the code with clang-tidy | `OFF`
+`STDGPU_ANALYZE_WITH_CPPCHECK` | Analyzes the code with cppcheck | `OFF`
 `STDGPU_BUILD_SHARED_LIBS` | Builds the project as a shared library, if set to `ON`, or as a static library, if set to `OFF` | `BUILD_SHARED_LIBS`
 `STDGPU_BUILD_EXAMPLES` | Build the examples | `ON`
 `STDGPU_BUILD_TESTS` | Build the unit tests | `ON`

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,6 +9,7 @@ macro(stdgpu_detail_add_example)
                                                            ${STDGPU_HOST_FLAGS})
     target_link_libraries(${STDGPU_EXAMPLES_NAME} PRIVATE stdgpu::stdgpu)
     set_target_properties(${STDGPU_EXAMPLES_NAME} PROPERTIES CXX_CLANG_TIDY "${STDGPU_PROPERTY_CLANG_TIDY}")
+    set_target_properties(${STDGPU_EXAMPLES_NAME} PROPERTIES CXX_CPPCHECK "${STDGPU_PROPERTY_CPPCHECK}")
 endmacro()
 
 macro(stdgpu_add_example_cpp)

--- a/scripts/ci/configure_openmp_cppcheck.sh
+++ b/scripts/ci/configure_openmp_cppcheck.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Create build directory
+sh scripts/utils/create_empty_directory.sh build
+
+# Download external dependencies
+sh scripts/utils/download_dependencies.sh
+
+# Configure project
+sh scripts/utils/configure_debug.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_ANALYZE_WITH_CPPCHECK=ON -DSTDGPU_TREAT_WARNINGS_AS_ERRORS=ON -Dthrust_ROOT=external/thrust

--- a/scripts/utils/install_cppcheck_ubuntu1804.sh
+++ b/scripts/utils/install_cppcheck_ubuntu1804.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+# Install cppcheck
+sudo apt-get update
+sudo apt-get install cppcheck

--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -61,6 +61,7 @@ target_compile_options(stdgpu PRIVATE ${STDGPU_DEVICE_FLAGS}
 target_link_libraries(stdgpu PUBLIC thrust::thrust)
 
 set_target_properties(stdgpu PROPERTIES CXX_CLANG_TIDY "${STDGPU_PROPERTY_CLANG_TIDY}")
+set_target_properties(stdgpu PROPERTIES CXX_CPPCHECK "${STDGPU_PROPERTY_CPPCHECK}")
 
 add_library(stdgpu::stdgpu ALIAS stdgpu)
 

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -20,10 +20,12 @@
 
 #if STDGPU_BACKEND == STDGPU_BACKEND_CUDA
     #define STDGPU_BACKEND_ATOMIC_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/atomic.cuh> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
+    // cppcheck-suppress preprocessorErrorDirective
     #include STDGPU_BACKEND_ATOMIC_HEADER
     #undef STDGPU_BACKEND_ATOMIC_HEADER
 #else
     #define STDGPU_BACKEND_ATOMIC_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/atomic.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
+    // cppcheck-suppress preprocessorErrorDirective
     #include STDGPU_BACKEND_ATOMIC_HEADER
     #undef STDGPU_BACKEND_ATOMIC_HEADER
 #endif

--- a/src/stdgpu/impl/bit_detail.h
+++ b/src/stdgpu/impl/bit_detail.h
@@ -17,7 +17,8 @@
 #define STDGPU_BIT_DETAIL_H
 
 #if STDGPU_BACKEND == STDGPU_BACKEND_CUDA && STDGPU_DETAIL_IS_DEVICE_COMPILED
-    #define STDGPU_BACKEND_BIT_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/bit.cuh>
+    #define STDGPU_BACKEND_BIT_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/bit.cuh> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
+    // cppcheck-suppress preprocessorErrorDirective
     #include STDGPU_BACKEND_BIT_HEADER
     #undef STDGPU_BACKEND_BIT_HEADER
 #endif

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -22,6 +22,7 @@
 #include <stdgpu/config.h>
 
 #define STDGPU_BACKEND_MEMORY_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/memory.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
+// cppcheck-suppress preprocessorErrorDirective
 #include STDGPU_BACKEND_MEMORY_HEADER
 #undef STDGPU_BACKEND_MEMORY_HEADER
 

--- a/src/stdgpu/platform.h
+++ b/src/stdgpu/platform.h
@@ -24,6 +24,7 @@
 
 //! @cond Doxygen_Suppress
 #define STDGPU_BACKEND_PLATFORM_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/platform.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
+// cppcheck-suppress preprocessorErrorDirective
 #include STDGPU_BACKEND_PLATFORM_HEADER
 #undef STDGPU_BACKEND_PLATFORM_HEADER
 //! @endcond

--- a/test/stdgpu/CMakeLists.txt
+++ b/test/stdgpu/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(teststdgpu PRIVATE
                                  gtest)
 
 set_target_properties(teststdgpu PROPERTIES CXX_CLANG_TIDY "${STDGPU_PROPERTY_CLANG_TIDY}")
+set_target_properties(teststdgpu PROPERTIES CXX_CPPCHECK "${STDGPU_PROPERTY_CPPCHECK}")
 
 
 add_test(NAME teststdgpu

--- a/test/stdgpu/main.cpp
+++ b/test/stdgpu/main.cpp
@@ -22,6 +22,7 @@
 #include <stdgpu/config.h>
 
 #define STDGPU_BACKEND_DEVICE_INFO_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/device_info.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
+// cppcheck-suppress preprocessorErrorDirective
 #include STDGPU_BACKEND_DEVICE_INFO_HEADER
 #undef STDGPU_BACKEND_DEVICE_INFO_HEADER
 


### PR DESCRIPTION
Similar to the recently added clang-tidy support (see #129), cppcheck allows for static analysis of the code to detect potential bugs and regressions. Add native support for cppcheck and a corresponding CI job to automate this process.