### PR TITLE
contract: Fix user semicolon enforcement for disabled checks

### DIFF
--- a/src/stdgpu/contract.h
+++ b/src/stdgpu/contract.h
@@ -48,8 +48,12 @@ namespace stdgpu
  * \hideinitializer
  * \brief A macro to define in-body conditions for both host and device
  */
+
+//! @cond Doxygen_Suppress
+#define STDGPU_DETAIL_EMPTY_STATEMENT (void)0
+//! @endcond
+
 #if STDGPU_ENABLE_CONTRACT_CHECKS
-    #define STDGPU_FORCE_USER_SEMICOLON(statement) do { statement } while (0)
 
     #define STDGPU_DETAIL_HOST_CHECK(type, condition) \
         if (!(condition)) \
@@ -60,18 +64,19 @@ namespace stdgpu
                    "  Condition : %s\n", \
                    __FILE__, __LINE__, static_cast<const char*>(STDGPU_FUNC), #condition); \
             std::terminate(); \
-        }
+        } \
+        STDGPU_DETAIL_EMPTY_STATEMENT
 
-    #define STDGPU_DETAIL_HOST_EXPECTS(condition) STDGPU_FORCE_USER_SEMICOLON(STDGPU_DETAIL_HOST_CHECK("Precondition", condition))
-    #define STDGPU_DETAIL_HOST_ENSURES(condition) STDGPU_FORCE_USER_SEMICOLON(STDGPU_DETAIL_HOST_CHECK("Postcondition", condition))
-    #define STDGPU_DETAIL_HOST_ASSERT(condition) STDGPU_FORCE_USER_SEMICOLON(STDGPU_DETAIL_HOST_CHECK("Assertion", condition))
+    #define STDGPU_DETAIL_HOST_EXPECTS(condition) STDGPU_DETAIL_HOST_CHECK("Precondition", condition)
+    #define STDGPU_DETAIL_HOST_ENSURES(condition) STDGPU_DETAIL_HOST_CHECK("Postcondition", condition)
+    #define STDGPU_DETAIL_HOST_ASSERT(condition) STDGPU_DETAIL_HOST_CHECK("Assertion", condition)
 
     // FIXME:
     // HIP's device assert() function does not seem to override/overload the host compiler version.
     // Even using HIP's device assert() function implementation directly results in linker errors.
     // Thus, disable contract checks until a better workaround/fix is found.
     #if STDGPU_BACKEND == STDGPU_BACKEND_HIP
-        #define STDGPU_DETAIL_WORKAROUND_ASSERT(condition)
+        #define STDGPU_DETAIL_WORKAROUND_ASSERT(condition) STDGPU_DETAIL_EMPTY_STATEMENT
     #else
         #define STDGPU_DETAIL_WORKAROUND_ASSERT(condition) assert(condition)
     #endif
@@ -90,9 +95,9 @@ namespace stdgpu
         #define STDGPU_ASSERT(condition) STDGPU_DETAIL_HOST_ASSERT(condition)
     #endif
 #else
-    #define STDGPU_EXPECTS(condition)
-    #define STDGPU_ENSURES(condition)
-    #define STDGPU_ASSERT(condition)
+    #define STDGPU_EXPECTS(condition) STDGPU_DETAIL_EMPTY_STATEMENT
+    #define STDGPU_ENSURES(condition) STDGPU_DETAIL_EMPTY_STATEMENT
+    #define STDGPU_ASSERT(condition) STDGPU_DETAIL_EMPTY_STATEMENT
 #endif
 
 } // namespace stdgpu


### PR DESCRIPTION
In #148, the macros in the `contract` module have been fixed to enforce semicolons at macro invocation. However, this fix was incomplete and does not cover the case when the contract checks are disabled. Replace it with a more robust version which is based on the definition of `assert`.