### PR TITLE
General: Add support for Compute Capability 3.0 in CUDA backend

### DIFF
--- a/cmake/cuda/set_device_flags.cmake
+++ b/cmake/cuda/set_device_flags.cmake
@@ -58,7 +58,7 @@ function(stdgpu_cuda_set_architecture_flags STDGPU_OUTPUT_DEVICE_COMPILE_AND_LIN
     # include("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/check_compute_capability.cmake")
     include("${stdgpu_SOURCE_DIR}/cmake/${STDGPU_BACKEND_DIRECTORY}/check_compute_capability.cmake")
 
-    set(STDGPU_CUDA_MIN_CC 35) # Minimum CC : Determined by used features, limits CUDA version at EOL
+    set(STDGPU_CUDA_MIN_CC 30) # Minimum CC : Determined by used features, limits CUDA version at EOL
     set(STDGPU_CUDA_MAX_CC 75) # Maximum CC : Determined by minimum CUDA version
 
     message(STATUS "CUDA Compute Capability (CC) Configuration")

--- a/src/stdgpu/cuda/impl/atomic_detail.cuh
+++ b/src/stdgpu/cuda/impl/atomic_detail.cuh
@@ -16,6 +16,7 @@
 #ifndef STDGPU_CUDA_ATOMIC_DETAIL_H
 #define STDGPU_CUDA_ATOMIC_DETAIL_H
 
+#include <stdgpu/algorithm.h>
 #include <stdgpu/contract.h>
 #include <stdgpu/limits.h>
 #include <stdgpu/platform.h>
@@ -76,6 +77,100 @@ atomicMax(float* address,
 
     return __int_as_float(old);
 }
+
+
+#if defined(__CUDA_ARCH__)
+    #if __CUDA_ARCH__ < 350
+        inline STDGPU_DEVICE_ONLY unsigned long long int
+        atomicMin(unsigned long long int* address,
+                  const unsigned long long int value)
+        {
+            unsigned long long int old = *address;
+            unsigned long long int assumed;
+
+            do
+            {
+                assumed = old;
+                old = atomicCAS(address, assumed, stdgpu::min<unsigned long long int>(value, assumed));
+            }
+            while (assumed != old);
+
+            return old;
+        }
+
+
+        inline STDGPU_DEVICE_ONLY unsigned long long int
+        atomicMax(unsigned long long int* address,
+                  const unsigned long long int value)
+        {
+            unsigned long long int old = *address;
+            unsigned long long int assumed;
+
+            do
+            {
+                assumed = old;
+                old = atomicCAS(address, assumed, stdgpu::max<unsigned long long int>(value, assumed));
+            }
+            while (assumed != old);
+
+            return old;
+        }
+
+
+        inline STDGPU_DEVICE_ONLY unsigned long long int
+        atomicAnd(unsigned long long int* address,
+                  const unsigned long long int value)
+        {
+            unsigned long long int old = *address;
+            unsigned long long int assumed;
+
+            do
+            {
+                assumed = old;
+                old = atomicCAS(address, assumed, value & assumed);
+            }
+            while (assumed != old);
+
+            return old;
+        }
+
+
+        inline STDGPU_DEVICE_ONLY unsigned long long int
+        atomicOr(unsigned long long int* address,
+                 const unsigned long long int value)
+        {
+            unsigned long long int old = *address;
+            unsigned long long int assumed;
+
+            do
+            {
+                assumed = old;
+                old = atomicCAS(address, assumed, value | assumed);
+            }
+            while (assumed != old);
+
+            return old;
+        }
+
+
+        inline STDGPU_DEVICE_ONLY unsigned long long int
+        atomicXor(unsigned long long int* address,
+                  const unsigned long long int value)
+        {
+            unsigned long long int old = *address;
+            unsigned long long int assumed;
+
+            do
+            {
+                assumed = old;
+                old = atomicCAS(address, assumed, value ^ assumed);
+            }
+            while (assumed != old);
+
+            return old;
+        }
+    #endif
+#endif
 
 
 namespace stdgpu


### PR DESCRIPTION
The CUDA backend only supports GPUs with Compute Capability (CC) 3.5 and higher since some internal `atomic<op>` functions are only natively implemented for these GPUs. Backport the functions that are missing in CC 3.0 to add support for it and lower the respective minimum required CC from 3.5 to 3.0.