### PR TITLE
compiler: Fix NVCC detection

### DIFF
--- a/src/stdgpu/compiler.h
+++ b/src/stdgpu/compiler.h
@@ -82,7 +82,7 @@ namespace stdgpu
  * \hideinitializer
  * \brief The detected device compiler
  */
-#if defined(__CUDACC__)
+#if defined(__NVCC__)
     #define STDGPU_DEVICE_COMPILER STDGPU_DEVICE_COMPILER_NVCC
 #elif defined(__HCC__) || defined(__HIP__)
     #define STDGPU_DEVICE_COMPILER STDGPU_DEVICE_COMPILER_HCC


### PR DESCRIPTION
The `compiler` module uses the `__CUDA_ARCH__` define to detect NVCC. Since it is the only supported device compiler providing this define at the moment, the detection apparently seems to work. However, other compilers that also provide this define, e.g. Clang, may be added in the future which results in violating the current assumption. Use `__NVCC__` instead of `__CUDA_ARCH__` to fix this bug.