### PR TITLE
src,test: Fix several signed/unigned MSVC warnings

### DIFF
--- a/src/stdgpu/impl/bit_detail.h
+++ b/src/stdgpu/impl/bit_detail.h
@@ -63,7 +63,7 @@ popcount(T number)
     for (result = 0; number; ++result)
     {
         // Clear the least significant bit set
-        number &= number - 1;
+        number &= number - static_cast<T>(1);
     }
 
     STDGPU_ENSURES(0 <= result);
@@ -79,7 +79,7 @@ template <typename T, typename>
 STDGPU_HOST_DEVICE bool
 has_single_bit(const T number)
 {
-    return ((number != 0) && !(number & (number - 1)));
+    return ((number != 0) && !(number & (number - static_cast<T>(1))));
 }
 
 

--- a/test/stdgpu/bit.cpp
+++ b/test/stdgpu/bit.cpp
@@ -302,18 +302,18 @@ TEST_F(stdgpu_bit, popcount_zero)
 
 TEST_F(stdgpu_bit, popcount_pow2)
 {
-    for (std::size_t i = 0; i < std::numeric_limits<std::size_t>::digits; ++i)
+    for (int i = 0; i < std::numeric_limits<std::size_t>::digits; ++i)
     {
-        EXPECT_EQ(stdgpu::popcount(static_cast<std::size_t>(1) << i), 1);
+        EXPECT_EQ(stdgpu::popcount(static_cast<std::size_t>(1) << static_cast<std::size_t>(i)), 1);
     }
 }
 
 
 TEST_F(stdgpu_bit, popcount_pow2m1)
 {
-    for (std::size_t i = 0; i < std::numeric_limits<std::size_t>::digits; ++i)
+    for (int i = 0; i < std::numeric_limits<std::size_t>::digits; ++i)
     {
-        EXPECT_EQ(stdgpu::popcount((static_cast<std::size_t>(1) << i) - 1), i);
+        EXPECT_EQ(stdgpu::popcount((static_cast<std::size_t>(1) << static_cast<std::size_t>(i)) - static_cast<std::size_t>(1)), i);
     }
 }
 

--- a/test/stdgpu/cstdlib.cpp
+++ b/test/stdgpu/cstdlib.cpp
@@ -55,7 +55,7 @@ thread_values(const stdgpu::index_t iterations)
     std::size_t seed = test_utils::random_thread_seed();
 
     std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
-    std::uniform_int_distribution<std::size_t> dist_x(1, std::numeric_limits<long long int>::max());
+    std::uniform_int_distribution<std::size_t> dist_x(1, static_cast<std::size_t>(std::numeric_limits<long long int>::max()));
     std::uniform_int_distribution<int> dist_y(1, std::numeric_limits<std::size_t>::digits);
 
     for (stdgpu::index_t i = 0; i < iterations; ++i)

--- a/test/stdgpu/functional.cpp
+++ b/test/stdgpu/functional.cpp
@@ -120,7 +120,7 @@ check_integer()
         hashes.insert(hasher(i));
     }
 
-    EXPECT_GT(hashes.size(), N * 90 / 100);
+    EXPECT_GT(static_cast<stdgpu::index_t>(hashes.size()), N * 90 / 100);
 }
 
 
@@ -175,7 +175,7 @@ check_integer_random()
         hashes.insert(hasher(dist(rng)));
     }
 
-    EXPECT_GT(hashes.size(), N * 90 / 100);
+    EXPECT_GT(static_cast<stdgpu::index_t>(hashes.size()), N * 90 / 100);
 }
 
 
@@ -237,7 +237,7 @@ check_floating_point_random()
         hashes.insert(hasher(dist(rng)));
     }
 
-    EXPECT_GT(hashes.size(), N * 90 / 100);
+    EXPECT_GT(static_cast<stdgpu::index_t>(hashes.size()), N * 90 / 100);
 }
 
 
@@ -279,7 +279,7 @@ TEST_F(stdgpu_functional, enum)
     hashes.insert(hasher(two));
     hashes.insert(hasher(three));
 
-    EXPECT_GT(hashes.size(), 4 * 90 / 100);
+    EXPECT_GT(static_cast<stdgpu::index_t>(hashes.size()), 4 * 90 / 100);
 }
 
 
@@ -303,7 +303,7 @@ TEST_F(stdgpu_functional, enum_class)
     hashes.insert(hasher(scoped_enum::two));
     hashes.insert(hasher(scoped_enum::three));
 
-    EXPECT_GT(hashes.size(), 4 * 90 / 100);
+    EXPECT_GT(static_cast<stdgpu::index_t>(hashes.size()), 4 * 90 / 100);
 }
 
 

--- a/test/stdgpu/iterator.cpp
+++ b/test/stdgpu/iterator.cpp
@@ -171,10 +171,10 @@ class insert_iterator<unordered_set<int>>;
 
 TEST_F(stdgpu_iterator, size_device_void)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array = createDeviceArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size(reinterpret_cast<void*>(array)), size * sizeof(int));
+    EXPECT_EQ(stdgpu::size(reinterpret_cast<void*>(array)), size * static_cast<stdgpu::index64_t>(sizeof(int)));
 
     destroyDeviceArray<int>(array);
 }
@@ -182,10 +182,10 @@ TEST_F(stdgpu_iterator, size_device_void)
 
 TEST_F(stdgpu_iterator, size_host_void)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array = createHostArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size(reinterpret_cast<void*>(array)), size * sizeof(int));
+    EXPECT_EQ(stdgpu::size(reinterpret_cast<void*>(array)), size * static_cast<stdgpu::index64_t>(sizeof(int)));
 
     destroyHostArray<int>(array);
 }
@@ -194,16 +194,16 @@ TEST_F(stdgpu_iterator, size_host_void)
 TEST_F(stdgpu_iterator, size_nullptr_void)
 {
     int* array = nullptr;
-    EXPECT_EQ(stdgpu::size(reinterpret_cast<void*>(array)), static_cast<std::size_t>(0));
+    EXPECT_EQ(stdgpu::size(reinterpret_cast<void*>(array)), static_cast<stdgpu::index64_t>(0));
 }
 
 
 TEST_F(stdgpu_iterator, size_device)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array = createDeviceArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size(array), static_cast<std::size_t>(size));
+    EXPECT_EQ(stdgpu::size(array), size);
 
     destroyDeviceArray<int>(array);
 }
@@ -211,10 +211,10 @@ TEST_F(stdgpu_iterator, size_device)
 
 TEST_F(stdgpu_iterator, size_host)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array = createHostArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size(array), static_cast<std::size_t>(size));
+    EXPECT_EQ(stdgpu::size(array), size);
 
     destroyHostArray<int>(array);
 }
@@ -223,16 +223,16 @@ TEST_F(stdgpu_iterator, size_host)
 TEST_F(stdgpu_iterator, size_nullptr)
 {
     int* array = nullptr;
-    EXPECT_EQ(stdgpu::size(array), static_cast<std::size_t>(0));
+    EXPECT_EQ(stdgpu::size(array), static_cast<stdgpu::index64_t>(0));
 }
 
 
 TEST_F(stdgpu_iterator, size_device_shifted)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array = createDeviceArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size(array + 24), static_cast<std::size_t>(0));
+    EXPECT_EQ(stdgpu::size(array + 24), static_cast<stdgpu::index64_t>(0));
 
     destroyDeviceArray<int>(array);
 }
@@ -240,10 +240,10 @@ TEST_F(stdgpu_iterator, size_device_shifted)
 
 TEST_F(stdgpu_iterator, size_host_shifted)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array_result = createHostArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size(array_result + 24), static_cast<std::size_t>(0));
+    EXPECT_EQ(stdgpu::size(array_result + 24), static_cast<stdgpu::index64_t>(0));
 
     destroyHostArray<int>(array_result);
 }
@@ -253,7 +253,7 @@ TEST_F(stdgpu_iterator, size_device_wrong_alignment)
 {
     int* array = createDeviceArray<int>(1);
 
-    EXPECT_EQ(stdgpu::size(reinterpret_cast<std::size_t*>(array)), static_cast<std::size_t>(0));
+    EXPECT_EQ(stdgpu::size(reinterpret_cast<std::size_t*>(array)), static_cast<stdgpu::index64_t>(0));
 
     destroyDeviceArray<int>(array);
 }
@@ -263,7 +263,7 @@ TEST_F(stdgpu_iterator, size_host_wrong_alignment)
 {
     int* array_result = createHostArray<int>(1);
 
-    EXPECT_EQ(stdgpu::size(reinterpret_cast<std::size_t*>(array_result)), static_cast<std::size_t>(0));
+    EXPECT_EQ(stdgpu::size(reinterpret_cast<std::size_t*>(array_result)), static_cast<stdgpu::index64_t>(0));
 
     destroyHostArray<int>(array_result);
 }

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -207,7 +207,7 @@ size_bytes<int>(int*);
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_device)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array_device = createDeviceArray<int>(size);
 
     EXPECT_EQ(stdgpu::get_dynamic_memory_type(array_device), stdgpu::dynamic_memory_type::device);
@@ -218,7 +218,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_device)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_host)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array_host = createHostArray<int>(size);
 
     EXPECT_EQ(stdgpu::get_dynamic_memory_type(array_host), stdgpu::dynamic_memory_type::host);
@@ -229,7 +229,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_host)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_managed_on_device)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     const int default_value = 0;
     int* array_managed = createManagedArray<int>(size, default_value, Initialization::DEVICE);
 
@@ -241,7 +241,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_managed_on_device)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_managed_on_host)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     const int default_value = 0;
     int* array_managed = createManagedArray<int>(size, default_value, Initialization::HOST);
 
@@ -276,10 +276,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_nullptr)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_device)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array_device = createDeviceArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size_bytes(array_device), size * sizeof(int));
+    EXPECT_EQ(stdgpu::size_bytes(array_device), size * static_cast<stdgpu::index64_t>(sizeof(int)));
 
     destroyDeviceArray<int>(array_device);
 }
@@ -287,10 +287,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_device)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_host)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array_host = createHostArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size_bytes(array_host), size * sizeof(int));
+    EXPECT_EQ(stdgpu::size_bytes(array_host), size * static_cast<stdgpu::index64_t>(sizeof(int)));
 
     destroyHostArray<int>(array_host);
 }
@@ -298,11 +298,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_host)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_managed_device)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     const int default_value = 0;
     int* array_managed = createManagedArray<int>(size, default_value, Initialization::DEVICE);
 
-    EXPECT_EQ(stdgpu::size_bytes(array_managed), size * sizeof(int));
+    EXPECT_EQ(stdgpu::size_bytes(array_managed), size * static_cast<stdgpu::index64_t>(sizeof(int)));
 
     destroyManagedArray<int>(array_managed);
 }
@@ -310,11 +310,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_managed_device)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_manged_host)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     const int default_value = 0;
     int* array_managed = createManagedArray<int>(size, default_value, Initialization::HOST);
 
-    EXPECT_EQ(stdgpu::size_bytes(array_managed), size * sizeof(int));
+    EXPECT_EQ(stdgpu::size_bytes(array_managed), size * static_cast<stdgpu::index64_t>(sizeof(int)));
 
     destroyManagedArray<int>(array_managed);
 }
@@ -328,10 +328,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_nullptr)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_device_shifted)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array_device = createDeviceArray<int>(size);
 
-    const stdgpu::index_t offset = 24;
+    const stdgpu::index64_t offset = 24;
     EXPECT_EQ(stdgpu::size_bytes(array_device + offset), static_cast<stdgpu::index64_t>(0));
 
     destroyDeviceArray<int>(array_device);
@@ -340,10 +340,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_device_shifted)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_host_shifted)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     int* array_host = createHostArray<int>(size);
 
-    const stdgpu::index_t offset = 24;
+    const stdgpu::index64_t offset = 24;
     EXPECT_EQ(stdgpu::size_bytes(array_host + offset), static_cast<stdgpu::index64_t>(0));
 
     destroyHostArray<int>(array_host);
@@ -352,11 +352,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_host_shifted)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_managed_device_shifted)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     const int default_value = 0;
     int* array_managed = createManagedArray<int>(size, default_value, Initialization::DEVICE);
 
-    const stdgpu::index_t offset = 24;
+    const stdgpu::index64_t offset = 24;
     EXPECT_EQ(stdgpu::size_bytes(array_managed + offset), static_cast<stdgpu::index64_t>(0));
 
     destroyManagedArray<int>(array_managed);
@@ -365,11 +365,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_managed_device_shifted)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, size_bytes_managed_host_shifted)
 {
-    const stdgpu::index_t size = 42;
+    const stdgpu::index64_t size = 42;
     const int default_value = 0;
     int* array_managed = createManagedArray<int>(size, default_value, Initialization::HOST);
 
-    const stdgpu::index_t offset = 24;
+    const stdgpu::index64_t offset = 24;
     EXPECT_EQ(stdgpu::size_bytes(array_managed + offset), static_cast<stdgpu::index64_t>(0));
 
     destroyManagedArray<int>(array_managed);

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -127,6 +127,16 @@ class same_state
 };
 
 
+struct check_flag
+{
+    STDGPU_DEVICE_ONLY bool
+    operator()(const std::uint8_t flag) const
+    {
+        return static_cast<bool>(flag);
+    }
+};
+
+
 bool
 equal(const stdgpu::mutex_array& locks_1,
       const stdgpu::mutex_array& locks_2)
@@ -143,7 +153,7 @@ equal(const stdgpu::mutex_array& locks_1,
                       same_state(locks_1, locks_2));
 
     bool result = thrust::all_of(stdgpu::device_cbegin(equality_flags), stdgpu::device_cend(equality_flags),
-                                 thrust::identity<bool>());
+                                 check_flag());
 
     destroyDeviceArray<std::uint8_t>(equality_flags);
 

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -122,7 +122,7 @@ namespace
             {
                 thrust::default_random_engine rng(static_cast<thrust::default_random_engine::result_type>(_seed));
                 thrust::uniform_real_distribution<std::int16_t> dist(stdgpu::numeric_limits<std::int16_t>::min(), stdgpu::numeric_limits<std::int16_t>::max());
-                rng.discard(static_cast<std::size_t>(3 * n));
+                rng.discard(static_cast<unsigned long long int>(3) * static_cast<unsigned long long int>(n));
 
                 return test_unordered_datastructure::key_type(dist(rng), dist(rng), dist(rng));
             }
@@ -1472,7 +1472,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_one_free
 
     EXPECT_TRUE(tiny_hash_datastructure.valid());
     EXPECT_FALSE(tiny_hash_datastructure.full());
-    EXPECT_EQ(tiny_hash_datastructure.size(), static_cast<size_t>(1));
+    EXPECT_EQ(tiny_hash_datastructure.size(), 1);
 
 
     const stdgpu::index_t N = 100000;
@@ -1568,7 +1568,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, emplace_parallel_while_one_fre
 
     EXPECT_TRUE(tiny_hash_datastructure.valid());
     EXPECT_FALSE(tiny_hash_datastructure.full());
-    EXPECT_EQ(tiny_hash_datastructure.size(), static_cast<size_t>(1));
+    EXPECT_EQ(tiny_hash_datastructure.size(), 1);
 
 
     const stdgpu::index_t N = 100000;
@@ -2165,7 +2165,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_count)
     thrust::for_each(range.begin(), range.end(),
                      for_each_counter(counter, bad_counter, hash_datastructure));
 
-    EXPECT_EQ(hash_datastructure.size(), counter.load());
+    EXPECT_EQ(counter.load(), static_cast<unsigned int>(hash_datastructure.size()));
     EXPECT_EQ(bad_counter.load(), static_cast<unsigned int>(0));
 
     stdgpu::atomic<unsigned int>::destroyDeviceObject(counter);


### PR DESCRIPTION
Although many signed/unsigned warnings have been fixed, there are still a few of these conversion warnings left which are mostly detected by MSVC's `/W3` and `/W4` warning levels. Fix these warnings to make builds under MSVC cleaner.