### PR TITLE
ranges: Fix compilation 64-bit index type

### DIFF
--- a/src/stdgpu/impl/ranges_detail.h
+++ b/src/stdgpu/impl/ranges_detail.h
@@ -43,6 +43,7 @@ device_range<T>::device_range(T* p,
 }
 
 
+#if STDGPU_USE_32_BIT_INDEX
 template <typename T>
 STDGPU_HOST_DEVICE
 device_range<T>::device_range(T* p,
@@ -52,6 +53,7 @@ device_range<T>::device_range(T* p,
 {
 
 }
+#endif
 
 
 template <typename T>
@@ -143,6 +145,7 @@ host_range<T>::host_range(T* p,
 }
 
 
+#if STDGPU_USE_32_BIT_INDEX
 template <typename T>
 STDGPU_HOST_DEVICE
 host_range<T>::host_range(T* p,
@@ -152,6 +155,7 @@ host_range<T>::host_range(T* p,
 {
 
 }
+#endif
 
 
 template <typename T>

--- a/src/stdgpu/ranges.h
+++ b/src/stdgpu/ranges.h
@@ -27,6 +27,9 @@
 #include <stdgpu/iterator.h>
 #include <stdgpu/platform.h>
 
+// For compatibility only. Remove this along with deprecated constructors
+#include <stdgpu/config.h>
+
 
 
 namespace stdgpu
@@ -65,6 +68,7 @@ class device_range
         device_range(T* p,
                      index64_t n);
 
+        #if STDGPU_USE_32_BIT_INDEX
         /**
          * \deprecated Replaced by device_range(T*, index64_t)
          * \brief Constructor
@@ -75,6 +79,7 @@ class device_range
         STDGPU_HOST_DEVICE
         device_range(T* p,
                      index_t n);
+        #endif
 
         /**
          * \brief Constructor
@@ -179,6 +184,7 @@ class host_range
         host_range(T* p,
                    index64_t n);
 
+        #if STDGPU_USE_32_BIT_INDEX
         /**
          * \deprecated Replaced by host_range(T*, index64_t)
          * \brief Constructor
@@ -189,6 +195,7 @@ class host_range
         STDGPU_HOST_DEVICE
         host_range(T* p,
                    index_t n);
+        #endif
 
         /**
          * \brief Constructor


### PR DESCRIPTION
In #102, a `index64_t` constructor has been added to the `ranges` classes and the old `index_t` constructors have been deprecated. However, if the latter coincides with the former, i.e. `STDGPU_USE_32_BIT_INDEX` is set to `OFF`, this results in compilation errors due to rereclarations and redefinitions. Fix this error by conditionally enabling the deprecated `index_t` version.