### PR TITLE
test: Pass containers by const reference to functors

### DIFF
--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -277,7 +277,7 @@ template <typename T>
 class exchange_sequence
 {
     public:
-        explicit exchange_sequence(stdgpu::atomic<T> value)
+        explicit exchange_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -341,7 +341,7 @@ template <typename T>
 class add_sequence_with_compare_exchange_weak
 {
     public:
-        explicit add_sequence_with_compare_exchange_weak(stdgpu::atomic<T> value)
+        explicit add_sequence_with_compare_exchange_weak(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -366,7 +366,7 @@ template <typename T>
 class add_sequence_with_compare_exchange_strong
 {
     public:
-        explicit add_sequence_with_compare_exchange_strong(stdgpu::atomic<T> value)
+        explicit add_sequence_with_compare_exchange_strong(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -465,7 +465,7 @@ template <typename T>
 class add_sequence
 {
     public:
-        explicit add_sequence(stdgpu::atomic<T> value)
+        explicit add_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -486,7 +486,7 @@ template <typename T>
 class add_equals_sequence
 {
     public:
-        explicit add_equals_sequence(stdgpu::atomic<T> value)
+        explicit add_equals_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -581,7 +581,7 @@ template <typename T>
 class sub_sequence
 {
     public:
-        explicit sub_sequence(stdgpu::atomic<T> value)
+        explicit sub_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -602,7 +602,7 @@ template <typename T>
 class sub_equals_sequence
 {
     public:
-        explicit sub_equals_sequence(stdgpu::atomic<T> value)
+        explicit sub_equals_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -716,7 +716,7 @@ template <typename T>
 class or_sequence
 {
     public:
-        explicit or_sequence(stdgpu::atomic<T> value)
+        explicit or_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -739,7 +739,7 @@ template <typename T>
 class or_equals_sequence
 {
     public:
-        explicit or_equals_sequence(stdgpu::atomic<T> value)
+        explicit or_equals_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -836,7 +836,7 @@ template <typename T>
 class and_sequence
 {
     public:
-        and_sequence(stdgpu::atomic<T> value,
+        and_sequence(const stdgpu::atomic<T>& value,
                      T one_pattern)
             : _value(value),
               _one_pattern(one_pattern)
@@ -862,7 +862,7 @@ template <typename T>
 class and_equals_sequence
 {
     public:
-        and_equals_sequence(stdgpu::atomic<T> value,
+        and_equals_sequence(const stdgpu::atomic<T>& value,
                             T one_pattern)
             : _value(value),
               _one_pattern(one_pattern)
@@ -984,7 +984,7 @@ template <typename T>
 class xor_sequence
 {
     public:
-        explicit xor_sequence(stdgpu::atomic<T> value)
+        explicit xor_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -1007,7 +1007,7 @@ template <typename T>
 class xor_equals_sequence
 {
     public:
-        explicit xor_equals_sequence(stdgpu::atomic<T> value)
+        explicit xor_equals_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -1104,7 +1104,7 @@ template <typename T>
 class min_sequence
 {
     public:
-        explicit min_sequence(stdgpu::atomic<T> value)
+        explicit min_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -1163,7 +1163,7 @@ template <typename T>
 class max_sequence
 {
     public:
-        explicit max_sequence(stdgpu::atomic<T> value)
+        explicit max_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -1222,7 +1222,7 @@ template <typename T>
 class inc_mod_sequence
 {
     public:
-        explicit inc_mod_sequence(stdgpu::atomic<T> value)
+        explicit inc_mod_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -1281,7 +1281,7 @@ template <typename T>
 class dec_mod_dequence
 {
     public:
-        explicit dec_mod_dequence(stdgpu::atomic<T> value)
+        explicit dec_mod_dequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -1340,7 +1340,7 @@ template <typename T>
 class pre_inc_sequence
 {
     public:
-        explicit pre_inc_sequence(stdgpu::atomic<T> value)
+        explicit pre_inc_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -1404,7 +1404,7 @@ template <typename T>
 class post_inc_sequence
 {
     public:
-        explicit post_inc_sequence(stdgpu::atomic<T> value)
+        explicit post_inc_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -1468,7 +1468,7 @@ template <typename T>
 class pre_dec_sequence
 {
     public:
-        explicit pre_dec_sequence(stdgpu::atomic<T> value)
+        explicit pre_dec_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 
@@ -1539,7 +1539,7 @@ template <typename T>
 class post_dec_sequence
 {
     public:
-        explicit post_dec_sequence(stdgpu::atomic<T> value)
+        explicit post_dec_sequence(const stdgpu::atomic<T>& value)
             : _value(value)
         {
 

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -61,7 +61,7 @@ TEST_F(stdgpu_bitset, default_values)
 class set_all_bits
 {
     public:
-        explicit set_all_bits(stdgpu::bitset bitset)
+        explicit set_all_bits(const stdgpu::bitset& bitset)
             : _bitset(bitset)
         {
 
@@ -83,7 +83,7 @@ class set_all_bits
 class reset_all_bits
 {
     public:
-        explicit reset_all_bits(stdgpu::bitset bitset)
+        explicit reset_all_bits(const stdgpu::bitset& bitset)
             : _bitset(bitset)
         {
 
@@ -105,7 +105,7 @@ class reset_all_bits
 class set_and_reset_all_bits
 {
     public:
-        explicit set_and_reset_all_bits(stdgpu::bitset bitset)
+        explicit set_and_reset_all_bits(const stdgpu::bitset& bitset)
             : _bitset(bitset)
         {
 
@@ -132,7 +132,7 @@ class set_and_reset_all_bits
 class flip_all_bits
 {
     public:
-        explicit flip_all_bits(stdgpu::bitset bitset)
+        explicit flip_all_bits(const stdgpu::bitset& bitset)
             : _bitset(bitset)
         {
 
@@ -300,7 +300,7 @@ generate_shuffled_sequence(const stdgpu::index_t size)
 class set_bits
 {
     public:
-        set_bits(stdgpu::bitset bitset,
+        set_bits(const stdgpu::bitset& bitset,
                  stdgpu::index_t* positions,
                  std::uint8_t* set)
             : _bitset(bitset),
@@ -328,7 +328,7 @@ class set_bits
 class reset_bits
 {
     public:
-        reset_bits(stdgpu::bitset bitset,
+        reset_bits(const stdgpu::bitset& bitset,
                    stdgpu::index_t* positions,
                    std::uint8_t* set)
             : _bitset(bitset),
@@ -356,7 +356,7 @@ class reset_bits
 class set_and_reset_bits
 {
     public:
-        set_and_reset_bits(stdgpu::bitset bitset,
+        set_and_reset_bits(const stdgpu::bitset& bitset,
                            stdgpu::index_t* positions,
                            std::uint8_t* set)
             : _bitset(bitset),
@@ -389,7 +389,7 @@ class set_and_reset_bits
 class flip_bits
 {
     public:
-        flip_bits(stdgpu::bitset bitset,
+        flip_bits(const stdgpu::bitset& bitset,
                   stdgpu::index_t* positions,
                   std::uint8_t* set)
             : _bitset(bitset),

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -68,7 +68,7 @@ template <typename T>
 class pop_back_deque
 {
     public:
-        explicit pop_back_deque(stdgpu::deque<T> pool)
+        explicit pop_back_deque(const stdgpu::deque<T>& pool)
             : _pool(pool)
         {
 
@@ -88,7 +88,7 @@ template <typename Pair>
 class pop_back_deque_const_type
 {
     public:
-        explicit pop_back_deque_const_type(stdgpu::deque<Pair> pool)
+        explicit pop_back_deque_const_type(const stdgpu::deque<Pair>& pool)
             : _pool(pool)
         {
 
@@ -109,7 +109,7 @@ template <typename T>
 class push_back_deque
 {
     public:
-        explicit push_back_deque(stdgpu::deque<T> pool)
+        explicit push_back_deque(const stdgpu::deque<T>& pool)
             : _pool(pool)
         {
 
@@ -129,7 +129,7 @@ template <typename Pair>
 class push_back_deque_const_type
 {
     public:
-        push_back_deque_const_type(stdgpu::deque<Pair> pool,
+        push_back_deque_const_type(const stdgpu::deque<Pair>& pool,
                                    const typename Pair::second_type& second)
             : _pool(pool),
               _second(second)
@@ -153,7 +153,7 @@ template <typename T>
 class emplace_back_deque
 {
     public:
-        explicit emplace_back_deque(stdgpu::deque<T> pool)
+        explicit emplace_back_deque(const stdgpu::deque<T>& pool)
             : _pool(pool)
         {
 
@@ -173,7 +173,7 @@ template <typename Pair>
 class emplace_back_deque_const_type
 {
     public:
-        emplace_back_deque_const_type(stdgpu::deque<Pair> pool,
+        emplace_back_deque_const_type(const stdgpu::deque<Pair>& pool,
                                       const typename Pair::second_type& second)
             : _pool(pool),
               _second(second)
@@ -194,7 +194,7 @@ class emplace_back_deque_const_type
 
 
 void
-fill_deque(stdgpu::deque<int> pool)
+fill_deque(stdgpu::deque<int>& pool)
 {
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(static_cast<int>(init)), thrust::counting_iterator<int>(static_cast<int>(pool.capacity() + init)),
@@ -673,7 +673,7 @@ template <typename T>
 class pop_front_deque
 {
     public:
-        explicit pop_front_deque(stdgpu::deque<T> pool)
+        explicit pop_front_deque(const stdgpu::deque<T>& pool)
             : _pool(pool)
         {
 
@@ -693,7 +693,7 @@ template <typename Pair>
 class pop_front_deque_const_type
 {
     public:
-        explicit pop_front_deque_const_type(stdgpu::deque<Pair> pool)
+        explicit pop_front_deque_const_type(const stdgpu::deque<Pair>& pool)
             : _pool(pool)
         {
 
@@ -714,7 +714,7 @@ template <typename T>
 class push_front_deque
 {
     public:
-        explicit push_front_deque(stdgpu::deque<T> pool)
+        explicit push_front_deque(const stdgpu::deque<T>& pool)
             : _pool(pool)
         {
 
@@ -734,7 +734,7 @@ template <typename Pair>
 class push_front_deque_const_type
 {
     public:
-        push_front_deque_const_type(stdgpu::deque<Pair> pool,
+        push_front_deque_const_type(const stdgpu::deque<Pair>& pool,
                                     const typename Pair::second_type& second)
             : _pool(pool),
               _second(second)
@@ -758,7 +758,7 @@ template <typename T>
 class emplace_front_deque
 {
     public:
-        explicit emplace_front_deque(stdgpu::deque<T> pool)
+        explicit emplace_front_deque(const stdgpu::deque<T>& pool)
             : _pool(pool)
         {
 
@@ -778,7 +778,7 @@ template <typename Pair>
 class emplace_front_deque_const_type
 {
     public:
-        emplace_front_deque_const_type(stdgpu::deque<Pair> pool,
+        emplace_front_deque_const_type(const stdgpu::deque<Pair>& pool,
                                        const typename Pair::second_type& second)
             : _pool(pool),
               _second(second)
@@ -1340,8 +1340,8 @@ template <typename T>
 class simultaneous_push_back_and_pop_back_deque
 {
     public:
-        simultaneous_push_back_and_pop_back_deque(stdgpu::deque<T> pool,
-                                                  stdgpu::deque<T> pool_validation)
+        simultaneous_push_back_and_pop_back_deque(const stdgpu::deque<T>& pool,
+                                                  const stdgpu::deque<T>& pool_validation)
             : _pool(pool),
               _pool_validation(pool_validation)
         {
@@ -1406,8 +1406,8 @@ template <typename T>
 class simultaneous_push_front_and_pop_front_deque
 {
     public:
-        simultaneous_push_front_and_pop_front_deque(stdgpu::deque<T> pool,
-                                                    stdgpu::deque<T> pool_validation)
+        simultaneous_push_front_and_pop_front_deque(const stdgpu::deque<T>& pool,
+                                                    const stdgpu::deque<T>& pool_validation)
             : _pool(pool),
               _pool_validation(pool_validation)
         {
@@ -1472,8 +1472,8 @@ template <typename T>
 class simultaneous_push_front_and_pop_back_deque
 {
     public:
-        simultaneous_push_front_and_pop_back_deque(stdgpu::deque<T> pool,
-                                                   stdgpu::deque<T> pool_validation)
+        simultaneous_push_front_and_pop_back_deque(const stdgpu::deque<T>& pool,
+                                                   const stdgpu::deque<T>& pool_validation)
             : _pool(pool),
               _pool_validation(pool_validation)
         {
@@ -1538,8 +1538,8 @@ template <typename T>
 class simultaneous_push_back_and_pop_front_deque
 {
     public:
-        simultaneous_push_back_and_pop_front_deque(stdgpu::deque<T> pool,
-                                                   stdgpu::deque<T> pool_validation)
+        simultaneous_push_back_and_pop_front_deque(const stdgpu::deque<T>& pool,
+                                                   const stdgpu::deque<T>& pool_validation)
             : _pool(pool),
               _pool_validation(pool_validation)
         {
@@ -1603,7 +1603,7 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_front)
 class at_non_const_deque
 {
     public:
-        explicit at_non_const_deque(stdgpu::deque<int> pool)
+        explicit at_non_const_deque(const stdgpu::deque<int>& pool)
             : _pool(pool)
         {
 
@@ -1645,7 +1645,7 @@ TEST_F(stdgpu_deque, at_non_const)
 class access_operator_non_const_deque
 {
     public:
-        explicit access_operator_non_const_deque(stdgpu::deque<int> pool)
+        explicit access_operator_non_const_deque(const stdgpu::deque<int>& pool)
             : _pool(pool)
         {
 

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -57,7 +57,7 @@ TEST_F(stdgpu_mutex, default_values)
 class lock_and_unlock
 {
     public:
-        explicit lock_and_unlock(stdgpu::mutex_array locks)
+        explicit lock_and_unlock(const stdgpu::mutex_array& locks)
             : _locks(locks)
         {
 
@@ -107,8 +107,8 @@ TEST_F(stdgpu_mutex, parallel_lock_and_unlock)
 class same_state
 {
     public:
-        same_state(stdgpu::mutex_array locks_1,
-                   stdgpu::mutex_array locks_2)
+        same_state(const stdgpu::mutex_array& locks_1,
+                   const stdgpu::mutex_array& locks_2)
             : _locks_1(locks_1),
               _locks_2(locks_2)
         {
@@ -164,7 +164,7 @@ equal(const stdgpu::mutex_array& locks_1,
 class lock_single_functor
 {
     public:
-        explicit lock_single_functor(stdgpu::mutex_array locks)
+        explicit lock_single_functor(const stdgpu::mutex_array& locks)
             : _locks(locks)
         {
 
@@ -182,7 +182,7 @@ class lock_single_functor
 
 
 bool
-lock_single(const stdgpu::mutex_array locks,
+lock_single(const stdgpu::mutex_array& locks,
             const stdgpu::index_t n)
 {
     std::uint8_t* result = createDeviceArray<std::uint8_t>(1);
@@ -225,7 +225,7 @@ TEST_F(stdgpu_mutex, single_try_lock_while_locked)
 class lock_multiple_functor
 {
     public:
-        explicit lock_multiple_functor(stdgpu::mutex_array locks)
+        explicit lock_multiple_functor(const stdgpu::mutex_array& locks)
             : _locks(locks)
         {
 
@@ -242,7 +242,7 @@ class lock_multiple_functor
 };
 
 int
-lock_multiple(const stdgpu::mutex_array locks,
+lock_multiple(const stdgpu::mutex_array& locks,
               const stdgpu::index_t n_0,
               const stdgpu::index_t n_1)
 {
@@ -358,7 +358,7 @@ TEST_F(stdgpu_mutex, multiple_try_lock_both_locked)
 class lock_multiple_functor_new_reference
 {
     public:
-        explicit lock_multiple_functor_new_reference(stdgpu::mutex_array locks)
+        explicit lock_multiple_functor_new_reference(const stdgpu::mutex_array& locks)
             : _locks(locks)
         {
 
@@ -377,7 +377,7 @@ class lock_multiple_functor_new_reference
 };
 
 int
-lock_multiple_new_reference(const stdgpu::mutex_array locks,
+lock_multiple_new_reference(const stdgpu::mutex_array& locks,
                             const stdgpu::index_t n_0,
                             const stdgpu::index_t n_1)
 {
@@ -400,7 +400,7 @@ lock_multiple_new_reference(const stdgpu::mutex_array locks,
 class lock_single_functor_new_reference
 {
     public:
-        explicit lock_single_functor_new_reference(stdgpu::mutex_array locks)
+        explicit lock_single_functor_new_reference(const stdgpu::mutex_array& locks)
             : _locks(locks)
         {
 
@@ -418,7 +418,7 @@ class lock_single_functor_new_reference
 };
 
 bool
-lock_single_new_reference(const stdgpu::mutex_array locks,
+lock_single_new_reference(const stdgpu::mutex_array& locks,
                           const stdgpu::index_t n)
 {
     std::uint8_t* result = createDeviceArray<std::uint8_t>(1);

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -77,7 +77,7 @@ namespace
 {
     void
     thread_hash_inside_range(const stdgpu::index_t iterations,
-                             const test_unordered_datastructure hash_datastructure)
+                             const test_unordered_datastructure& hash_datastructure)
     {
         // Generate true random numbers
         size_t seed = test_utils::random_thread_seed();
@@ -135,7 +135,7 @@ namespace
     class count_buckets_hits
     {
         public:
-            count_buckets_hits(test_unordered_datastructure hash_datastructure,
+            count_buckets_hits(const test_unordered_datastructure& hash_datastructure,
                                int* bucket_hits)
                 : _hash_datastructure(hash_datastructure),
                   _bucket_hits(bucket_hits)
@@ -270,8 +270,8 @@ namespace
     class insert_single
     {
         public:
-            insert_single(test_unordered_datastructure hash_datastructure,
-                          test_unordered_datastructure::key_type key,
+            insert_single(const test_unordered_datastructure& hash_datastructure,
+                          const test_unordered_datastructure::key_type& key,
                           stdgpu::index_t* inserted)
                 : _hash_datastructure(hash_datastructure),
                   _key(key),
@@ -316,8 +316,8 @@ namespace
     class erase_single
     {
         public:
-            erase_single(test_unordered_datastructure hash_datastructure,
-                         test_unordered_datastructure::key_type key,
+            erase_single(const test_unordered_datastructure& hash_datastructure,
+                         const test_unordered_datastructure::key_type& key,
                          stdgpu::index_t* erased)
                 : _hash_datastructure(hash_datastructure),
                   _key(key),
@@ -360,8 +360,8 @@ namespace
     class contains_key_functor
     {
         public:
-            contains_key_functor(test_unordered_datastructure hash_datastructure,
-                                 test_unordered_datastructure::key_type key,
+            contains_key_functor(const test_unordered_datastructure& hash_datastructure,
+                                 const test_unordered_datastructure::key_type& key,
                                  stdgpu::index_t* contained)
                 : _hash_datastructure(hash_datastructure),
                   _key(key),
@@ -1067,8 +1067,8 @@ namespace
     class insert_multiple
     {
         public:
-            insert_multiple(test_unordered_datastructure hash_datastructure,
-                            test_unordered_datastructure::key_type key,
+            insert_multiple(const test_unordered_datastructure& hash_datastructure,
+                            const test_unordered_datastructure::key_type& key,
                             stdgpu::index_t* inserted)
                 : _hash_datastructure(hash_datastructure),
                   _key(key),
@@ -1096,8 +1096,8 @@ namespace
     class erase_multiple
     {
         public:
-            erase_multiple(test_unordered_datastructure hash_datastructure,
-                           test_unordered_datastructure::key_type key,
+            erase_multiple(const test_unordered_datastructure& hash_datastructure,
+                           const test_unordered_datastructure::key_type& key,
                            stdgpu::index_t* erased)
                 : _hash_datastructure(hash_datastructure),
                   _key(key),
@@ -1122,8 +1122,8 @@ namespace
 
 
     void
-    insert_key_multiple(test_unordered_datastructure hash_datastructure,
-                        const test_unordered_datastructure::key_type key)
+    insert_key_multiple(test_unordered_datastructure& hash_datastructure,
+                        const test_unordered_datastructure::key_type& key)
     {
         const stdgpu::index_t old_size = hash_datastructure.size();
 
@@ -1145,8 +1145,8 @@ namespace
 
 
     void
-    erase_key_multiple(test_unordered_datastructure hash_datastructure,
-                       const test_unordered_datastructure::key_type key)
+    erase_key_multiple(test_unordered_datastructure& hash_datastructure,
+                       const test_unordered_datastructure::key_type& key)
     {
         const stdgpu::index_t old_size = hash_datastructure.size();
 
@@ -1379,7 +1379,7 @@ namespace
     class insert_keys
     {
         public:
-            insert_keys(test_unordered_datastructure hash_datastructure,
+            insert_keys(const test_unordered_datastructure& hash_datastructure,
                         test_unordered_datastructure::key_type* keys,
                         stdgpu::index_t* inserted)
                 : _hash_datastructure(hash_datastructure),
@@ -1407,7 +1407,7 @@ namespace
     class emplace_keys
     {
         public:
-            emplace_keys(test_unordered_datastructure hash_datastructure,
+            emplace_keys(const test_unordered_datastructure& hash_datastructure,
                          test_unordered_datastructure::key_type* keys,
                          stdgpu::index_t* inserted)
                 : _hash_datastructure(hash_datastructure),
@@ -1435,7 +1435,7 @@ namespace
     class erase_keys
     {
         public:
-            erase_keys(test_unordered_datastructure hash_datastructure,
+            erase_keys(const test_unordered_datastructure& hash_datastructure,
                        test_unordered_datastructure::key_type* keys,
                        stdgpu::index_t* erased)
                 : _hash_datastructure(hash_datastructure),
@@ -1948,7 +1948,7 @@ namespace
     class insert_and_erase_keys
     {
         public:
-            insert_and_erase_keys(test_unordered_datastructure hash_datastructure,
+            insert_and_erase_keys(const test_unordered_datastructure& hash_datastructure,
                                   test_unordered_datastructure::key_type* keys,
                                   stdgpu::index_t* inserted,
                                   stdgpu::index_t* erased)
@@ -2018,7 +2018,7 @@ namespace
     class store_bucket_sizes
     {
         public:
-            store_bucket_sizes(test_unordered_datastructure hash_datastructure,
+            store_bucket_sizes(const test_unordered_datastructure& hash_datastructure,
                                stdgpu::index_t* bucket_sizes)
                 : _hash_datastructure(hash_datastructure),
                   _bucket_sizes(bucket_sizes)
@@ -2041,7 +2041,7 @@ namespace
     class store_counts
     {
         public:
-            store_counts(test_unordered_datastructure hash_datastructure,
+            store_counts(const test_unordered_datastructure& hash_datastructure,
                          test_unordered_datastructure::key_type* keys,
                          stdgpu::index_t* counts)
                 : _hash_datastructure(hash_datastructure),
@@ -2120,8 +2120,8 @@ namespace
     class for_each_counter
     {
         public:
-            for_each_counter(stdgpu::atomic<unsigned int> counter,
-                             stdgpu::atomic<unsigned int> bad_counter,
+            for_each_counter(const stdgpu::atomic<unsigned int>& counter,
+                             const stdgpu::atomic<unsigned int>& bad_counter,
                              const test_unordered_datastructure& hash_datastructure)
                 : _counter(counter),
                   _bad_counter(bad_counter),
@@ -2178,7 +2178,7 @@ namespace
     class insert_vector
     {
         public:
-            explicit insert_vector(stdgpu::vector<test_unordered_datastructure::key_type> keys)
+            explicit insert_vector(const stdgpu::vector<test_unordered_datastructure::key_type>& keys)
                 : _keys(keys)
             {
 
@@ -2233,7 +2233,7 @@ namespace
     class erase_hash
     {
         public:
-            explicit erase_hash(test_unordered_datastructure hash_datastructure)
+            explicit erase_hash(const test_unordered_datastructure& hash_datastructure)
                 : _hash_datastructure(hash_datastructure)
             {
 

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -65,7 +65,7 @@ template <typename T>
 class pop_back_vector
 {
     public:
-        explicit pop_back_vector(stdgpu::vector<T> pool)
+        explicit pop_back_vector(const stdgpu::vector<T>& pool)
             : _pool(pool)
         {
 
@@ -85,7 +85,7 @@ template <typename Pair>
 class pop_back_vector_const_type
 {
     public:
-        explicit pop_back_vector_const_type(stdgpu::vector<Pair> pool)
+        explicit pop_back_vector_const_type(const stdgpu::vector<Pair>& pool)
             : _pool(pool)
         {
 
@@ -106,7 +106,7 @@ template <typename T>
 class push_back_vector
 {
     public:
-        explicit push_back_vector(stdgpu::vector<T> pool)
+        explicit push_back_vector(const stdgpu::vector<T>& pool)
             : _pool(pool)
         {
 
@@ -126,8 +126,8 @@ template <typename Pair>
 class push_back_vector_const_type
 {
     public:
-        explicit push_back_vector_const_type(stdgpu::vector<Pair> pool,
-                                    const typename Pair::second_type& second)
+        explicit push_back_vector_const_type(const stdgpu::vector<Pair>& pool,
+                                             const typename Pair::second_type& second)
             : _pool(pool),
               _second(second)
         {
@@ -150,7 +150,7 @@ template <typename T>
 class emplace_back_vector
 {
     public:
-        explicit emplace_back_vector(stdgpu::vector<T> pool)
+        explicit emplace_back_vector(const stdgpu::vector<T>& pool)
             : _pool(pool)
         {
 
@@ -170,7 +170,7 @@ template <typename Pair>
 class emplace_back_vector_const_type
 {
     public:
-        emplace_back_vector_const_type(stdgpu::vector<Pair> pool,
+        emplace_back_vector_const_type(const stdgpu::vector<Pair>& pool,
                                        const typename Pair::second_type& second)
             : _pool(pool),
               _second(second)
@@ -191,7 +191,7 @@ class emplace_back_vector_const_type
 
 
 void
-fill_vector(stdgpu::vector<int> pool)
+fill_vector(stdgpu::vector<int>& pool)
 {
     const stdgpu::index_t init = 1;
     thrust::for_each(thrust::counting_iterator<int>(static_cast<int>(init)), thrust::counting_iterator<int>(static_cast<int>(pool.capacity() + init)),
@@ -716,8 +716,8 @@ template <typename T>
 class simultaneous_push_back_and_pop_back_vector
 {
     public:
-        simultaneous_push_back_and_pop_back_vector(stdgpu::vector<T> pool,
-                                                   stdgpu::vector<T> pool_validation)
+        simultaneous_push_back_and_pop_back_vector(const stdgpu::vector<T>& pool,
+                                                   const stdgpu::vector<T>& pool_validation)
             : _pool(pool),
               _pool_validation(pool_validation)
         {
@@ -781,7 +781,7 @@ TEST_F(stdgpu_vector, simultaneous_push_back_and_pop_back)
 class at_non_const_vector
 {
     public:
-        explicit at_non_const_vector(stdgpu::vector<int> pool)
+        explicit at_non_const_vector(const stdgpu::vector<int>& pool)
             : _pool(pool)
         {
 
@@ -823,7 +823,7 @@ TEST_F(stdgpu_vector, at_non_const)
 class access_operator_non_const_vector
 {
     public:
-        explicit access_operator_non_const_vector(stdgpu::vector<int> pool)
+        explicit access_operator_non_const_vector(const stdgpu::vector<int>& pool)
             : _pool(pool)
         {
 


### PR DESCRIPTION
In comparison to the `src` code, variables are often passed by value in the `test` code. This may impact the performance and only works since containers perform shallow copy rather than deep copy. Pass all containers by const reference rather than by value to fix these potential performances issues and make a possible future transition to deep copy easier.