### PR TITLE
test: Disable unused GMock

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,2 +1,5 @@
+set(BUILD_GMOCK OFF CACHE INTERNAL "")
+set(INSTALL_GTEST OFF CACHE INTERNAL "")
 add_subdirectory(googletest-1.10.0)
+
 add_subdirectory(stdgpu)


### PR DESCRIPTION
GMock is not used by the unit tests, but it is still built by default. Turn off the respective options to disable building it. This slightly improves compilation times.