### PR TITLE
cstdlib: Deprecate sizedivPow2

### DIFF
--- a/src/stdgpu/cstdlib.h
+++ b/src/stdgpu/cstdlib.h
@@ -31,8 +31,9 @@ namespace stdgpu
 
 /**
  * \brief A struct to capture the result of sizedivPow2
+ * \deprecated Use x / y and bit_mod(x, y) directly
  */
-struct sizediv_t
+struct /*[[deprecated(" Use x / y and bit_mod(x, y) directly")]]*/ sizediv_t
 {
     std::size_t quot = {};  /**< The quotient */
     std::size_t rem = {};   /**< The remainder */
@@ -46,7 +47,9 @@ struct sizediv_t
  * \pre y > 0
  * \pre has_single_bit(y)
  * \post result.quot * y + result.rem == x
+ * \deprecated Use x / y and bit_mod(x, y) directly
  */
+[[deprecated(" Use x / y and bit_mod(x, y) directly")]]
 STDGPU_HOST_DEVICE sizediv_t
 sizedivPow2(const std::size_t x,
             const std::size_t y);


### PR DESCRIPTION
The `sizedivPow2` function in the `cstdlib` module resulted from the initial design of the library and its application in `bitset`. As the library evolved over time, it turned out that its design is not very clear and just mixes parts of `cstdlib` and `bit`. Since its last usage in `bitset` has been removed in #145, deprecate `sizedivPow2` as well as `sizediv_t`.