### PR TITLE
doc: Fix several minor documentation bugs

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -846,7 +846,8 @@ EXCLUDE_SYMLINKS       = NO
 
 EXCLUDE_PATTERNS       = */impl/* \
                          */cuda/* \
-                         */openmp/*
+                         */openmp/* \
+                         */hip/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -858,8 +858,7 @@ EXCLUDE_PATTERNS       = */impl/* \
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = *_H \
-                         detail
+EXCLUDE_SYMBOLS        = detail
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -536,7 +536,7 @@ HIDE_COMPOUND_REFERENCE= NO
 # the files that are included by a file in the documentation of that file.
 # The default value is: YES.
 
-SHOW_INCLUDE_FILES     = YES
+SHOW_INCLUDE_FILES     = NO
 
 # If the SHOW_GROUPED_MEMB_INC tag is set to YES then Doxygen will add for each
 # grouped member an include statement to the documentation, telling the reader

--- a/src/stdgpu/config.h.in
+++ b/src/stdgpu/config.h.in
@@ -25,6 +25,9 @@
 
 
 
+/**
+ * \brief Namespace containing all defined classes and functions
+ */
 namespace stdgpu
 {
 

--- a/src/stdgpu/config.h.in
+++ b/src/stdgpu/config.h.in
@@ -14,7 +14,9 @@
  */
 
 #ifndef STDGPU_CONFIG_H
+//! @cond Doxygen_Suppress
 #define STDGPU_CONFIG_H
+//! @endcond
 
 /**
  * \file stdgpu/config.h.in

--- a/src/stdgpu/cuda/atomic.cuh
+++ b/src/stdgpu/cuda/atomic.cuh
@@ -29,6 +29,7 @@ namespace cuda
 
 /**
  * \brief Atomically exchanges the stored value with the given argument
+ * \param[in] address A pointer to a value
  * \param[in] desired The desired argument to store
  * \return The old value
  */
@@ -39,6 +40,7 @@ atomic_exchange(T* address,
 
 /**
  * \brief Atomically exchanges the stored value with the given argument if it equals the expected value
+ * \param[in] address A pointer to a value
  * \param[in] expected The expected stored value
  * \param[in] desired The desired argument to store
  * \return The old value
@@ -51,6 +53,7 @@ atomic_compare_exchange(T* address,
 
 /**
  * \brief Atomically computes and stores the addition of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of addition
  * \return The old value
  */
@@ -61,6 +64,7 @@ atomic_fetch_add(T* address,
 
 /**
  * \brief Atomically computes and stores the subtraction of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of subtraction
  * \return The old value
  */
@@ -71,6 +75,7 @@ atomic_fetch_sub(T* address,
 
 /**
  * \brief Atomically computes and stores the bitwise AND of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of bitwise AND
  * \return The old value
  */
@@ -81,6 +86,7 @@ atomic_fetch_and(T* address,
 
 /**
  * \brief Atomically computes and stores the bitwise OR of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of bitwise OR
  * \return The old value
  */
@@ -91,6 +97,7 @@ atomic_fetch_or(T* address,
 
 /**
  * \brief Atomically computes and stores the bitwise XOR of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of bitwise XOR
  * \return The old value
  */
@@ -101,6 +108,7 @@ atomic_fetch_xor(T* address,
 
 /**
  * \brief Atomically computes and stores the minimum of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of minimum
  * \return The old value
  */
@@ -111,6 +119,7 @@ atomic_fetch_min(T* address,
 
 /**
  * \brief Atomically computes and stores the maximum of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of maximum
  * \return The old value
  */
@@ -121,6 +130,7 @@ atomic_fetch_max(T* address,
 
 /**
  * \brief Atomically computes and stores the incrementation of the value and modulus with arg
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
@@ -131,6 +141,7 @@ atomic_fetch_inc_mod(T* address,
 
 /**
  * \brief Atomically computes and stores the decrementation of the value and modulus with arg
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of modulus
  * \return The old value
  */

--- a/src/stdgpu/hip/atomic.h
+++ b/src/stdgpu/hip/atomic.h
@@ -29,6 +29,7 @@ namespace hip
 
 /**
  * \brief Atomically exchanges the stored value with the given argument
+ * \param[in] address A pointer to a value
  * \param[in] desired The desired argument to store
  * \return The old value
  */
@@ -39,6 +40,7 @@ atomic_exchange(T* address,
 
 /**
  * \brief Atomically exchanges the stored value with the given argument if it equals the expected value
+ * \param[in] address A pointer to a value
  * \param[in] expected The expected stored value
  * \param[in] desired The desired argument to store
  * \return The old value
@@ -51,6 +53,7 @@ atomic_compare_exchange(T* address,
 
 /**
  * \brief Atomically computes and stores the addition of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of addition
  * \return The old value
  */
@@ -61,6 +64,7 @@ atomic_fetch_add(T* address,
 
 /**
  * \brief Atomically computes and stores the subtraction of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of subtraction
  * \return The old value
  */
@@ -71,6 +75,7 @@ atomic_fetch_sub(T* address,
 
 /**
  * \brief Atomically computes and stores the bitwise AND of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of bitwise AND
  * \return The old value
  */
@@ -81,6 +86,7 @@ atomic_fetch_and(T* address,
 
 /**
  * \brief Atomically computes and stores the bitwise OR of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of bitwise OR
  * \return The old value
  */
@@ -91,6 +97,7 @@ atomic_fetch_or(T* address,
 
 /**
  * \brief Atomically computes and stores the bitwise XOR of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of bitwise XOR
  * \return The old value
  */
@@ -101,6 +108,7 @@ atomic_fetch_xor(T* address,
 
 /**
  * \brief Atomically computes and stores the minimum of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of minimum
  * \return The old value
  */
@@ -111,6 +119,7 @@ atomic_fetch_min(T* address,
 
 /**
  * \brief Atomically computes and stores the maximum of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of maximum
  * \return The old value
  */
@@ -121,6 +130,7 @@ atomic_fetch_max(T* address,
 
 /**
  * \brief Atomically computes and stores the incrementation of the value and modulus with arg
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
@@ -131,6 +141,7 @@ atomic_fetch_inc_mod(T* address,
 
 /**
  * \brief Atomically computes and stores the decrementation of the value and modulus with arg
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of modulus
  * \return The old value
  */

--- a/src/stdgpu/openmp/atomic.h
+++ b/src/stdgpu/openmp/atomic.h
@@ -29,6 +29,7 @@ namespace openmp
 
 /**
  * \brief Atomically exchanges the stored value with the given argument
+ * \param[in] address A pointer to a value
  * \param[in] desired The desired argument to store
  * \return The old value
  */
@@ -39,6 +40,7 @@ atomic_exchange(T* address,
 
 /**
  * \brief Atomically exchanges the stored value with the given argument if it equals the expected value
+ * \param[in] address A pointer to a value
  * \param[in] expected The expected stored value
  * \param[in] desired The desired argument to store
  * \return The old value
@@ -51,6 +53,7 @@ atomic_compare_exchange(T* address,
 
 /**
  * \brief Atomically computes and stores the addition of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of addition
  * \return The old value
  */
@@ -61,6 +64,7 @@ atomic_fetch_add(T* address,
 
 /**
  * \brief Atomically computes and stores the subtraction of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of subtraction
  * \return The old value
  */
@@ -71,6 +75,7 @@ atomic_fetch_sub(T* address,
 
 /**
  * \brief Atomically computes and stores the bitwise AND of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of bitwise AND
  * \return The old value
  */
@@ -81,6 +86,7 @@ atomic_fetch_and(T* address,
 
 /**
  * \brief Atomically computes and stores the bitwise OR of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of bitwise OR
  * \return The old value
  */
@@ -91,6 +97,7 @@ atomic_fetch_or(T* address,
 
 /**
  * \brief Atomically computes and stores the bitwise XOR of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of bitwise XOR
  * \return The old value
  */
@@ -101,6 +108,7 @@ atomic_fetch_xor(T* address,
 
 /**
  * \brief Atomically computes and stores the minimum of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of minimum
  * \return The old value
  */
@@ -111,6 +119,7 @@ atomic_fetch_min(T* address,
 
 /**
  * \brief Atomically computes and stores the maximum of the stored value and the given argument
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of maximum
  * \return The old value
  */
@@ -121,6 +130,7 @@ atomic_fetch_max(T* address,
 
 /**
  * \brief Atomically computes and stores the incrementation of the value and modulus with arg
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
@@ -131,6 +141,7 @@ atomic_fetch_inc_mod(T* address,
 
 /**
  * \brief Atomically computes and stores the decrementation of the value and modulus with arg
+ * \param[in] address A pointer to a value
  * \param[in] arg The other argument of modulus
  * \return The old value
  */


### PR DESCRIPTION
Unfortunately, many links in the documentation are not working and some symbols are still missing. Fix these issues by adjusting the doxygen's configuration and adding the missing documentation.