### PR TITLE
README,doc: Add links to documentation and includes in code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ In order to reliably perform tasks on the GPU, stdgpu offers flexible interfaces
 <b>Agnostic code</b>. In the context of the SLAMCast live telepresence system, a simple task is the integration of a range of updated blocks into the duplicate-free set of queued blocks for streaming which can be expressed very conveniently:
 
 ```cpp
+#include <stdgpu/cstddef.h>             // stdgpu::index_t
+#include <stdgpu/iterator.h>            // stdgpu::make_device
+#include <stdgpu/unordered_set.cuh>     // stdgpu::unordered_set
+
 class stream_set
 {
 public:
@@ -105,6 +109,10 @@ private:
 <b>Native code</b>. More complex operations such as the creation of the update set or other complex algorithms can be implemented natively, e.g. in custom CUDA kernels with stdgpu's CUDA backend enabled:
 
 ```cpp
+#include <stdgpu/cstddef.h>             // stdgpu::index_t
+#include <stdgpu/unordered_map.cuh>     // stdgpu::unordered_map
+#include <stdgpu/unordered_set.cuh>     // stdgpu::unordered_set
+
 __global__ void
 compute_update_set(const short3* blocks,
                    const stdgpu::index_t n,

--- a/README.md
+++ b/README.md
@@ -62,18 +62,18 @@ At its heart, stdgpu offers the following GPU data structures and containers:
 
 <table>
 <tr align="center">
-<td><code>atomic</code> &amp; <code>atomic_ref</code><br>Atomic primitive types and references</td>
-<td><code>bitset</code><br>Space-efficient bit array</td>
-<td><code>deque</code><br>Dynamically sized double-ended queue</td>
+<td><a href="https://stotko.github.io/stdgpu/classstdgpu_1_1atomic.html"><code>atomic</code></a> &amp; <a href="https://stotko.github.io/stdgpu/classstdgpu_1_1atomic__ref.html"><code>atomic_ref</code></a><br>Atomic primitive types and references</td>
+<td><a href="https://stotko.github.io/stdgpu/classstdgpu_1_1bitset.html"><code>bitset</code></a><br>Space-efficient bit array</td>
+<td><a href="https://stotko.github.io/stdgpu/classstdgpu_1_1deque.html"><code>deque</code></a><br>Dynamically sized double-ended queue</td>
 </tr>
 <tr align="center">
-<td><code>queue</code> &amp; <code>stack</code><br>Container adapters</td>
-<td><code>unordered_map</code> &amp; <code>unordered_set</code><br>Hashed collection of unique keys and key-value pairs</td>
-<td><code>vector</code><br>Dynamically sized contiguous array</td>
+<td><a href="https://stotko.github.io/stdgpu/classstdgpu_1_1queue.html"><code>queue</code></a> &amp; <a href="https://stotko.github.io/stdgpu/classstdgpu_1_1stack.html"><code>stack</code></a><br>Container adapters</td>
+<td><a href="https://stotko.github.io/stdgpu/classstdgpu_1_1unordered__map.html"><code>unordered_map</code></a> &amp; <a href="https://stotko.github.io/stdgpu/classstdgpu_1_1unordered__set.html"><code>unordered_set</code></a><br>Hashed collection of unique keys and key-value pairs</td>
+<td><a href="https://stotko.github.io/stdgpu/classstdgpu_1_1vector.html"><code>vector</code></a><br>Dynamically sized contiguous array</td>
 </tr>
 </table>
 
-In addition, stdgpu also provides commonly required functionality in `algorithm`, `bit`, `cmath`, `contract`, `cstddef`, `cstlib`, `functional`, `iterator`, `memory`, `mutex`, `ranges`, and `utility` to complement the GPU data structures and to increase their usability and interoperability.
+In addition, stdgpu also provides commonly required functionality in <a href="https://stotko.github.io/stdgpu/algorithm_8h.html">`algorithm`</a>, <a href="https://stotko.github.io/stdgpu/bit_8h.html">`bit`</a>, <a href="https://stotko.github.io/stdgpu/cmath_8h.html">`cmath`</a>, <a href="https://stotko.github.io/stdgpu/contract_8h.html">`contract`</a>, <a href="https://stotko.github.io/stdgpu/cstddef_8h.html">`cstddef`</a>, <a href="https://stotko.github.io/stdgpu/cstdlib_8h.html">`cstlib`</a>, <a href="https://stotko.github.io/stdgpu/functional_8h.html">`functional`</a>, <a href="https://stotko.github.io/stdgpu/iterator_8h.html">`iterator`</a>, <a href="https://stotko.github.io/stdgpu/memory_8h.html">`memory`</a>, <a href="https://stotko.github.io/stdgpu/mutex_8cuh.html">`mutex`</a>, <a href="https://stotko.github.io/stdgpu/ranges_8h.html">`ranges`</a>, <a href="https://stotko.github.io/stdgpu/utility_8h.html">`utility`</a> to complement the GPU data structures and to increase their usability and interoperability.
 
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The following general and backend-specific dependencies (or newer versions) are 
 
 <b>Required for CUDA backend</b>
 
-- CUDA 10.0
+- CUDA Toolkit 10.0
     - (Ubuntu/Windows) https://developer.nvidia.com/cuda-downloads
     - Includes thrust
 

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -17,18 +17,18 @@ At its heart, stdgpu offers the following GPU data structures and containers:
 
 <table>
 <tr align="center">
-<td><code>atomic</code> &amp; <code>atomic_ref</code><br>Atomic primitive types and references</td>
-<td><code>bitset</code><br>Space-efficient bit array</td>
-<td><code>deque</code><br>Dynamically sized double-ended queue</td>
+<td><a href="https://stotko.github.io/stdgpu/classstdgpu_1_1atomic.html"><code>atomic</code></a> &amp; <a href="https://stotko.github.io/stdgpu/classstdgpu_1_1atomic__ref.html"><code>atomic_ref</code></a><br>Atomic primitive types and references</td>
+<td><a href="https://stotko.github.io/stdgpu/classstdgpu_1_1bitset.html"><code>bitset</code></a><br>Space-efficient bit array</td>
+<td><a href="https://stotko.github.io/stdgpu/classstdgpu_1_1deque.html"><code>deque</code></a><br>Dynamically sized double-ended queue</td>
 </tr>
 <tr align="center">
-<td><code>queue</code> &amp; <code>stack</code><br>Container adapters</td>
-<td><code>unordered_map</code> &amp; <code>unordered_set</code><br>Hashed collection of unique keys and key-value pairs</td>
-<td><code>vector</code><br>Dynamically sized contiguous array</td>
+<td><a href="https://stotko.github.io/stdgpu/classstdgpu_1_1queue.html"><code>queue</code></a> &amp; <a href="https://stotko.github.io/stdgpu/classstdgpu_1_1stack.html"><code>stack</code></a><br>Container adapters</td>
+<td><a href="https://stotko.github.io/stdgpu/classstdgpu_1_1unordered__map.html"><code>unordered_map</code></a> &amp; <a href="https://stotko.github.io/stdgpu/classstdgpu_1_1unordered__set.html"><code>unordered_set</code></a><br>Hashed collection of unique keys and key-value pairs</td>
+<td><a href="https://stotko.github.io/stdgpu/classstdgpu_1_1vector.html"><code>vector</code></a><br>Dynamically sized contiguous array</td>
 </tr>
 </table>
 
-In addition, stdgpu also provides commonly required functionality in `algorithm`, `bit`, `cmath`, `contract`, `cstddef`, `cstlib`, `functional`, `iterator`, `memory`, `mutex`, `ranges`, and `utility` to complement the GPU data structures and to increase their usability and interoperability.
+In addition, stdgpu also provides commonly required functionality in <a href="https://stotko.github.io/stdgpu/algorithm_8h.html">`algorithm`</a>, <a href="https://stotko.github.io/stdgpu/bit_8h.html">`bit`</a>, <a href="https://stotko.github.io/stdgpu/cmath_8h.html">`cmath`</a>, <a href="https://stotko.github.io/stdgpu/contract_8h.html">`contract`</a>, <a href="https://stotko.github.io/stdgpu/cstddef_8h.html">`cstddef`</a>, <a href="https://stotko.github.io/stdgpu/cstdlib_8h.html">`cstlib`</a>, <a href="https://stotko.github.io/stdgpu/functional_8h.html">`functional`</a>, <a href="https://stotko.github.io/stdgpu/iterator_8h.html">`iterator`</a>, <a href="https://stotko.github.io/stdgpu/memory_8h.html">`memory`</a>, <a href="https://stotko.github.io/stdgpu/mutex_8cuh.html">`mutex`</a>, <a href="https://stotko.github.io/stdgpu/ranges_8h.html">`ranges`</a>, <a href="https://stotko.github.io/stdgpu/utility_8h.html">`utility`</a> to complement the GPU data structures and to increase their usability and interoperability.
 
 
 \section examples Examples

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -38,6 +38,10 @@ In order to reliably perform tasks on the GPU, stdgpu offers flexible interfaces
 <b>Agnostic code</b>. In the context of the SLAMCast live telepresence system, a simple task is the integration of a range of updated blocks into the duplicate-free set of queued blocks for streaming which can be expressed very conveniently:
 
 \code{.cpp}
+#include <stdgpu/cstddef.h>             // stdgpu::index_t
+#include <stdgpu/iterator.h>            // stdgpu::make_device
+#include <stdgpu/unordered_set.cuh>     // stdgpu::unordered_set
+
 class stream_set
 {
 public:
@@ -60,6 +64,10 @@ private:
 <b>Native code</b>. More complex operations such as the creation of the update set or other complex algorithms can be implemented natively, e.g. in custom CUDA kernels with stdgpu's CUDA backend enabled:
 
 \code{.cpp}
+#include <stdgpu/cstddef.h>             // stdgpu::index_t
+#include <stdgpu/unordered_map.cuh>     // stdgpu::unordered_map
+#include <stdgpu/unordered_set.cuh>     // stdgpu::unordered_set
+
 __global__ void
 compute_update_set(const short3* blocks,
                    const stdgpu::index_t n,

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -126,7 +126,7 @@ The following general and backend-specific dependencies (or newer versions) are 
 
 <b>Required for CUDA backend</b>
 
-- CUDA 10.0
+- CUDA Toolkit 10.0
     - (Ubuntu/Windows) https://developer.nvidia.com/cuda-downloads
     - Includes thrust
 


### PR DESCRIPTION
In #162, the introduction has been extended. Take a step further and add links to the documentation as well as includes in the code snippets. This makes the introduction more accessible and improves navigation speed.