### PR TITLE
limits: Add implementation for non-specialized template and documentation for every type

### DIFF
--- a/src/stdgpu/impl/limits_detail.h
+++ b/src/stdgpu/impl/limits_detail.h
@@ -26,11 +26,65 @@
 namespace stdgpu
 {
 
-template <class T>
-struct numeric_limits
+template <typename T>
+constexpr STDGPU_HOST_DEVICE T
+numeric_limits<T>::min() noexcept
 {
-    static_assert(sizeof(T) != sizeof(T), "stdgpu::numeric_limits : No specialization for type T provided");
-};
+    return T();
+}
+
+template <typename T>
+constexpr STDGPU_HOST_DEVICE T
+numeric_limits<T>::max() noexcept
+{
+    return T();
+}
+
+template <typename T>
+constexpr STDGPU_HOST_DEVICE T
+numeric_limits<T>::lowest() noexcept
+{
+    return T();
+}
+
+template <typename T>
+constexpr STDGPU_HOST_DEVICE T
+numeric_limits<T>::epsilon() noexcept
+{
+    return T();
+}
+
+template <typename T>
+constexpr STDGPU_HOST_DEVICE T
+numeric_limits<T>::round_error() noexcept
+{
+    return T();
+}
+
+template <typename T>
+constexpr STDGPU_HOST_DEVICE T
+numeric_limits<T>::infinity() noexcept
+{
+    return T();
+}
+
+template <typename T>
+constexpr bool numeric_limits<T>::is_specialized;
+
+template <typename T>
+constexpr bool numeric_limits<T>::is_signed;
+
+template <typename T>
+constexpr bool numeric_limits<T>::is_integer;
+
+template <typename T>
+constexpr bool numeric_limits<T>::is_exact;
+
+template <typename T>
+constexpr int numeric_limits<T>::digits;
+
+template <typename T>
+constexpr int numeric_limits<T>::radix;
 
 
 constexpr STDGPU_HOST_DEVICE bool

--- a/src/stdgpu/impl/limits_detail.h
+++ b/src/stdgpu/impl/limits_detail.h
@@ -21,9 +21,6 @@
 #include <cmath>
 #include <cstdint>
 
-#include <stdgpu/compiler.h>
-#include <stdgpu/platform.h>
-
 
 
 namespace stdgpu
@@ -36,332 +33,670 @@ struct numeric_limits
 };
 
 
-template <>
-struct numeric_limits<bool>
+constexpr STDGPU_HOST_DEVICE bool
+numeric_limits<bool>::min() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE bool min() noexcept                         { return false; }
-    static constexpr STDGPU_HOST_DEVICE bool max() noexcept                         { return true; }
-    static constexpr STDGPU_HOST_DEVICE bool lowest() noexcept                      { return false; }
-    static constexpr STDGPU_HOST_DEVICE bool epsilon() noexcept                     { return false; }
-    static constexpr STDGPU_HOST_DEVICE bool round_error() noexcept                 { return false; }
-    static constexpr STDGPU_HOST_DEVICE bool infinity() noexcept                    { return false; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = false;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = 1;
-    static constexpr int radix                                                      = 2;
-};
+    return false;
+}
 
-
-template <>
-struct numeric_limits<char>
+constexpr STDGPU_HOST_DEVICE bool
+numeric_limits<bool>::max() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE char min() noexcept                         { return CHAR_MIN; }
-    static constexpr STDGPU_HOST_DEVICE char max() noexcept                         { return CHAR_MAX; }
-    static constexpr STDGPU_HOST_DEVICE char lowest() noexcept                      { return min(); }
-    static constexpr STDGPU_HOST_DEVICE char epsilon() noexcept                     { return 0; }
-    static constexpr STDGPU_HOST_DEVICE char round_error() noexcept                 { return 0; }
-    static constexpr STDGPU_HOST_DEVICE char infinity() noexcept                    { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = true;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT - static_cast<int>(numeric_limits<char>::is_signed);
-    static constexpr int radix                                                      = 2;
-};
+    return true;
+}
 
-
-template <>
-struct numeric_limits<signed char>
+constexpr STDGPU_HOST_DEVICE bool
+numeric_limits<bool>::lowest() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE signed char min() noexcept                  { return SCHAR_MIN; }
-    static constexpr STDGPU_HOST_DEVICE signed char max() noexcept                  { return SCHAR_MAX; }
-    static constexpr STDGPU_HOST_DEVICE signed char lowest() noexcept               { return min(); }
-    static constexpr STDGPU_HOST_DEVICE signed char epsilon() noexcept              { return 0; }
-    static constexpr STDGPU_HOST_DEVICE signed char round_error() noexcept          { return 0; }
-    static constexpr STDGPU_HOST_DEVICE signed char infinity() noexcept             { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = true;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT - 1;
-    static constexpr int radix                                                      = 2;
-};
+    return false;
+}
 
-
-template <>
-struct numeric_limits<unsigned char>
+constexpr STDGPU_HOST_DEVICE bool
+numeric_limits<bool>::epsilon() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE unsigned char min() noexcept                { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned char max() noexcept                { return UCHAR_MAX; }
-    static constexpr STDGPU_HOST_DEVICE unsigned char lowest() noexcept             { return min(); }
-    static constexpr STDGPU_HOST_DEVICE unsigned char epsilon() noexcept            { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned char round_error() noexcept        { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned char infinity() noexcept           { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = false;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT;
-    static constexpr int radix                                                      = 2;
-};
+    return false;
+}
 
-
-template <>
-struct numeric_limits<wchar_t>
+constexpr STDGPU_HOST_DEVICE bool
+numeric_limits<bool>::round_error() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE wchar_t min() noexcept                      { return WCHAR_MIN; }
-    static constexpr STDGPU_HOST_DEVICE wchar_t max() noexcept                      { return WCHAR_MAX; }
-    static constexpr STDGPU_HOST_DEVICE wchar_t lowest() noexcept                   { return min(); }
-    static constexpr STDGPU_HOST_DEVICE wchar_t epsilon() noexcept                  { return 0; }
-    static constexpr STDGPU_HOST_DEVICE wchar_t round_error() noexcept              { return 0; }
-    static constexpr STDGPU_HOST_DEVICE wchar_t infinity() noexcept                 { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    #if STDGPU_HOST_COMPILER == STDGPU_HOST_COMPILER_MSVC
-        static constexpr bool is_signed                                             = false;
-    #else
-        static constexpr bool is_signed                                             = true;
-    #endif
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT * sizeof(wchar_t) - static_cast<int>(numeric_limits<wchar_t>::is_signed);
-    static constexpr int radix                                                      = 2;
-};
+    return false;
+}
 
-
-template <>
-struct numeric_limits<char16_t>
+constexpr STDGPU_HOST_DEVICE bool
+numeric_limits<bool>::infinity() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE char16_t min() noexcept                     { return 0; }
-    static constexpr STDGPU_HOST_DEVICE char16_t max() noexcept                     { return UINT_LEAST16_MAX; }
-    static constexpr STDGPU_HOST_DEVICE char16_t lowest() noexcept                  { return min(); }
-    static constexpr STDGPU_HOST_DEVICE char16_t epsilon() noexcept                 { return 0; }
-    static constexpr STDGPU_HOST_DEVICE char16_t round_error() noexcept             { return 0; }
-    static constexpr STDGPU_HOST_DEVICE char16_t infinity() noexcept                { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = false;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT * sizeof(char16_t);
-    static constexpr int radix                                                      = 2;
-};
+    return false;
+}
 
 
-template <>
-struct numeric_limits<char32_t>
+constexpr STDGPU_HOST_DEVICE char
+numeric_limits<char>::min() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE char32_t min() noexcept                     { return 0; }
-    static constexpr STDGPU_HOST_DEVICE char32_t max() noexcept                     { return UINT_LEAST32_MAX; }
-    static constexpr STDGPU_HOST_DEVICE char32_t lowest() noexcept                  { return min(); }
-    static constexpr STDGPU_HOST_DEVICE char32_t epsilon() noexcept                 { return 0; }
-    static constexpr STDGPU_HOST_DEVICE char32_t round_error() noexcept             { return 0; }
-    static constexpr STDGPU_HOST_DEVICE char32_t infinity() noexcept                { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = false;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT * sizeof(char32_t);
-    static constexpr int radix                                                      = 2;
-};
+    return CHAR_MIN;
+}
 
-
-template <>
-struct numeric_limits<short>
+constexpr STDGPU_HOST_DEVICE char
+numeric_limits<char>::max() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE short min() noexcept                        { return SHRT_MIN; }
-    static constexpr STDGPU_HOST_DEVICE short max() noexcept                        { return SHRT_MAX; }
-    static constexpr STDGPU_HOST_DEVICE short lowest() noexcept                     { return min(); }
-    static constexpr STDGPU_HOST_DEVICE short epsilon() noexcept                    { return 0; }
-    static constexpr STDGPU_HOST_DEVICE short round_error() noexcept                { return 0; }
-    static constexpr STDGPU_HOST_DEVICE short infinity() noexcept                   { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = true;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT * sizeof(short) - 1;
-    static constexpr int radix                                                      = 2;
-};
+    return CHAR_MAX;
+}
 
-
-template <>
-struct numeric_limits<unsigned short>
+constexpr STDGPU_HOST_DEVICE char
+numeric_limits<char>::lowest() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE unsigned short min() noexcept               { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned short max() noexcept               { return USHRT_MAX; }
-    static constexpr STDGPU_HOST_DEVICE unsigned short lowest() noexcept            { return min(); }
-    static constexpr STDGPU_HOST_DEVICE unsigned short epsilon() noexcept           { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned short round_error() noexcept       { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned short infinity() noexcept          { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = false;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT * sizeof(short);
-    static constexpr int radix                                                      = 2;
-};
+    return min();
+}
 
-
-template <>
-struct numeric_limits<int>
+constexpr STDGPU_HOST_DEVICE char
+numeric_limits<char>::epsilon() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE int min() noexcept                          { return INT_MIN; }
-    static constexpr STDGPU_HOST_DEVICE int max() noexcept                          { return INT_MAX; }
-    static constexpr STDGPU_HOST_DEVICE int lowest() noexcept                       { return min(); }
-    static constexpr STDGPU_HOST_DEVICE int epsilon() noexcept                      { return 0; }
-    static constexpr STDGPU_HOST_DEVICE int round_error() noexcept                  { return 0; }
-    static constexpr STDGPU_HOST_DEVICE int infinity() noexcept                     { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = true;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT * sizeof(int) - 1;
-    static constexpr int radix                                                      = 2;
-};
+    return 0;
+}
 
-
-template <>
-struct numeric_limits<unsigned int>
+constexpr STDGPU_HOST_DEVICE char
+numeric_limits<char>::round_error() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE unsigned int min() noexcept                 { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned int max() noexcept                 { return UINT_MAX; }
-    static constexpr STDGPU_HOST_DEVICE unsigned int lowest() noexcept              { return min(); }
-    static constexpr STDGPU_HOST_DEVICE unsigned int epsilon() noexcept             { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned int round_error() noexcept         { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned int infinity() noexcept            { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = false;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT * sizeof(int);
-    static constexpr int radix                                                      = 2;
-};
+    return 0;
+}
 
-
-template <>
-struct numeric_limits<long>
+constexpr STDGPU_HOST_DEVICE char
+numeric_limits<char>::infinity() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE long min() noexcept                         { return LONG_MIN; }
-    static constexpr STDGPU_HOST_DEVICE long max() noexcept                         { return LONG_MAX; }
-    static constexpr STDGPU_HOST_DEVICE long lowest() noexcept                      { return min(); }
-    static constexpr STDGPU_HOST_DEVICE long epsilon() noexcept                     { return 0; }
-    static constexpr STDGPU_HOST_DEVICE long round_error() noexcept                 { return 0; }
-    static constexpr STDGPU_HOST_DEVICE long infinity() noexcept                    { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = true;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT * sizeof(long) - 1;
-    static constexpr int radix                                                      = 2;
-};
+    return 0;
+}
 
 
-template <>
-struct numeric_limits<unsigned long>
+constexpr STDGPU_HOST_DEVICE signed char
+numeric_limits<signed char>::min() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE unsigned long min() noexcept                { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned long max() noexcept                { return ULONG_MAX; }
-    static constexpr STDGPU_HOST_DEVICE unsigned long lowest() noexcept             { return min(); }
-    static constexpr STDGPU_HOST_DEVICE unsigned long epsilon() noexcept            { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned long round_error() noexcept        { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned long infinity() noexcept           { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = false;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT * sizeof(long);
-    static constexpr int radix                                                      = 2;
-};
+    return SCHAR_MIN;
+}
 
-
-template <>
-struct numeric_limits<long long>
+constexpr STDGPU_HOST_DEVICE signed char
+numeric_limits<signed char>::max() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE long long min() noexcept                    { return LLONG_MIN; }
-    static constexpr STDGPU_HOST_DEVICE long long max() noexcept                    { return LLONG_MAX; }
-    static constexpr STDGPU_HOST_DEVICE long long lowest() noexcept                 { return min(); }
-    static constexpr STDGPU_HOST_DEVICE long long epsilon() noexcept                { return 0; }
-    static constexpr STDGPU_HOST_DEVICE long long round_error() noexcept            { return 0; }
-    static constexpr STDGPU_HOST_DEVICE long long infinity() noexcept               { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = true;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT * sizeof(long long) - 1;
-    static constexpr int radix                                                      = 2;
-};
+    return SCHAR_MAX;
+}
 
-
-template <>
-struct numeric_limits<unsigned long long>
+constexpr STDGPU_HOST_DEVICE signed char
+numeric_limits<signed char>::lowest() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE unsigned long long min() noexcept           { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned long long max() noexcept           { return ULLONG_MAX; }
-    static constexpr STDGPU_HOST_DEVICE unsigned long long lowest() noexcept        { return min(); }
-    static constexpr STDGPU_HOST_DEVICE unsigned long long epsilon() noexcept       { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned long long round_error() noexcept   { return 0; }
-    static constexpr STDGPU_HOST_DEVICE unsigned long long infinity() noexcept      { return 0; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = false;
-    static constexpr bool is_integer                                                = true;
-    static constexpr bool is_exact                                                  = true;
-    static constexpr int digits                                                     = CHAR_BIT * sizeof(long long);
-    static constexpr int radix                                                      = 2;
-};
+    return min();
+}
 
-
-template <>
-struct numeric_limits<float>
+constexpr STDGPU_HOST_DEVICE signed char
+numeric_limits<signed char>::epsilon() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE float min() noexcept                        { return FLT_MIN; }
-    static constexpr STDGPU_HOST_DEVICE float max() noexcept                        { return FLT_MAX; }
-    static constexpr STDGPU_HOST_DEVICE float lowest() noexcept                     { return -FLT_MAX; }
-    static constexpr STDGPU_HOST_DEVICE float epsilon() noexcept                    { return FLT_EPSILON; }
-    static constexpr STDGPU_HOST_DEVICE float round_error() noexcept                { return 0.5F; } // NOLINT(readability-magic-numbers)
-    static constexpr STDGPU_HOST_DEVICE float infinity() noexcept                   { return HUGE_VALF; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = true;
-    static constexpr bool is_integer                                                = false;
-    static constexpr bool is_exact                                                  = false;
-    static constexpr int digits                                                     = FLT_MANT_DIG;
-    static constexpr int radix                                                      = FLT_RADIX;
-};
+    return 0;
+}
 
-
-template <>
-struct numeric_limits<double>
+constexpr STDGPU_HOST_DEVICE signed char
+numeric_limits<signed char>::round_error() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE double min() noexcept                       { return DBL_MIN; }
-    static constexpr STDGPU_HOST_DEVICE double max() noexcept                       { return DBL_MAX; }
-    static constexpr STDGPU_HOST_DEVICE double lowest() noexcept                    { return -DBL_MAX; }
-    static constexpr STDGPU_HOST_DEVICE double epsilon() noexcept                   { return DBL_EPSILON; }
-    static constexpr STDGPU_HOST_DEVICE double round_error() noexcept               { return 0.5; } // NOLINT(readability-magic-numbers)
-    static constexpr STDGPU_HOST_DEVICE double infinity() noexcept                  { return HUGE_VAL; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = true;
-    static constexpr bool is_integer                                                = false;
-    static constexpr bool is_exact                                                  = false;
-    static constexpr int digits                                                     = DBL_MANT_DIG;
-    static constexpr int radix                                                      = FLT_RADIX;
-};
+    return 0;
+}
 
-
-template <>
-struct numeric_limits<long double>
+constexpr STDGPU_HOST_DEVICE signed char
+numeric_limits<signed char>::infinity() noexcept
 {
-    static constexpr STDGPU_HOST_DEVICE long double min() noexcept                  { return LDBL_MIN; }
-    static constexpr STDGPU_HOST_DEVICE long double max() noexcept                  { return LDBL_MAX; }
-    static constexpr STDGPU_HOST_DEVICE long double lowest() noexcept               { return -LDBL_MAX; }
-    static constexpr STDGPU_HOST_DEVICE long double epsilon() noexcept              { return LDBL_EPSILON; }
-    static constexpr STDGPU_HOST_DEVICE long double round_error() noexcept          { return 0.5L; } // NOLINT(readability-magic-numbers)
-    static constexpr STDGPU_HOST_DEVICE long double infinity() noexcept             { return HUGE_VALL; }
-    static constexpr bool is_specialized                                            = true;
-    static constexpr bool is_signed                                                 = true;
-    static constexpr bool is_integer                                                = false;
-    static constexpr bool is_exact                                                  = false;
-    static constexpr int digits                                                     = LDBL_MANT_DIG;
-    static constexpr int radix                                                      = FLT_RADIX;
-};
+    return 0;
+}
+
+
+constexpr STDGPU_HOST_DEVICE unsigned char
+numeric_limits<unsigned char>::min() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned char
+numeric_limits<unsigned char>::max() noexcept
+{
+    return UCHAR_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned char
+numeric_limits<unsigned char>::lowest() noexcept
+{
+    return min();
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned char
+numeric_limits<unsigned char>::epsilon() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned char
+numeric_limits<unsigned char>::round_error() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned char
+numeric_limits<unsigned char>::infinity() noexcept
+{
+    return 0;
+}
+
+
+constexpr STDGPU_HOST_DEVICE wchar_t
+numeric_limits<wchar_t>::min() noexcept
+{
+    return WCHAR_MIN;
+}
+
+constexpr STDGPU_HOST_DEVICE wchar_t
+numeric_limits<wchar_t>::max() noexcept
+{
+    return WCHAR_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE wchar_t
+numeric_limits<wchar_t>::lowest() noexcept
+{
+    return min();
+}
+
+constexpr STDGPU_HOST_DEVICE wchar_t
+numeric_limits<wchar_t>::epsilon() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE wchar_t
+numeric_limits<wchar_t>::round_error() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE wchar_t
+numeric_limits<wchar_t>::infinity() noexcept
+{
+    return 0;
+}
+
+
+constexpr STDGPU_HOST_DEVICE char16_t
+numeric_limits<char16_t>::min() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE char16_t
+numeric_limits<char16_t>::max() noexcept
+{
+    return UINT_LEAST16_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE char16_t
+numeric_limits<char16_t>::lowest() noexcept
+{
+    return min();
+}
+
+constexpr STDGPU_HOST_DEVICE char16_t
+numeric_limits<char16_t>::epsilon() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE char16_t
+numeric_limits<char16_t>::round_error() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE char16_t
+numeric_limits<char16_t>::infinity() noexcept
+{
+    return 0;
+}
+
+
+constexpr STDGPU_HOST_DEVICE char32_t
+numeric_limits<char32_t>::min() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE char32_t
+numeric_limits<char32_t>::max() noexcept
+{
+    return UINT_LEAST32_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE char32_t
+numeric_limits<char32_t>::lowest() noexcept
+{
+    return min();
+}
+
+constexpr STDGPU_HOST_DEVICE char32_t
+numeric_limits<char32_t>::epsilon() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE char32_t
+numeric_limits<char32_t>::round_error() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE char32_t
+numeric_limits<char32_t>::infinity() noexcept
+{
+    return 0;
+}
+
+
+constexpr STDGPU_HOST_DEVICE short
+numeric_limits<short>::min() noexcept
+{
+    return SHRT_MIN;
+}
+
+constexpr STDGPU_HOST_DEVICE short
+numeric_limits<short>::max() noexcept
+{
+    return SHRT_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE short
+numeric_limits<short>::lowest() noexcept
+{
+    return min();
+}
+
+constexpr STDGPU_HOST_DEVICE short
+numeric_limits<short>::epsilon() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE short
+numeric_limits<short>::round_error() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE short
+numeric_limits<short>::infinity() noexcept
+{
+    return 0;
+}
+
+
+constexpr STDGPU_HOST_DEVICE unsigned short
+numeric_limits<unsigned short>::min() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned short
+numeric_limits<unsigned short>::max() noexcept
+{
+    return USHRT_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned short
+numeric_limits<unsigned short>::lowest() noexcept
+{
+    return min();
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned short
+numeric_limits<unsigned short>::epsilon() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned short
+numeric_limits<unsigned short>::round_error() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned short
+numeric_limits<unsigned short>::infinity() noexcept
+{
+    return 0;
+}
+
+
+constexpr STDGPU_HOST_DEVICE int
+numeric_limits<int>::min() noexcept
+{
+    return INT_MIN;
+}
+
+constexpr STDGPU_HOST_DEVICE int
+numeric_limits<int>::max() noexcept
+{
+    return INT_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE int
+numeric_limits<int>::lowest() noexcept
+{
+    return min();
+}
+
+constexpr STDGPU_HOST_DEVICE int
+numeric_limits<int>::epsilon() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE int
+numeric_limits<int>::round_error() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE int
+numeric_limits<int>::infinity() noexcept
+{
+    return 0;
+}
+
+
+constexpr STDGPU_HOST_DEVICE unsigned int
+numeric_limits<unsigned int>::min() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned int
+numeric_limits<unsigned int>::max() noexcept
+{
+    return UINT_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned int
+numeric_limits<unsigned int>::lowest() noexcept
+{
+    return min();
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned int
+numeric_limits<unsigned int>::epsilon() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned int
+numeric_limits<unsigned int>::round_error() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned int
+numeric_limits<unsigned int>::infinity() noexcept
+{
+    return 0;
+}
+
+
+constexpr STDGPU_HOST_DEVICE long
+numeric_limits<long>::min() noexcept
+{
+    return LONG_MIN;
+}
+
+constexpr STDGPU_HOST_DEVICE long
+numeric_limits<long>::max() noexcept
+{
+    return LONG_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE long
+numeric_limits<long>::lowest() noexcept
+{
+    return min();
+}
+
+constexpr STDGPU_HOST_DEVICE long
+numeric_limits<long>::epsilon() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE long
+numeric_limits<long>::round_error() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE long
+numeric_limits<long>::infinity() noexcept
+{
+    return 0;
+}
+
+
+constexpr STDGPU_HOST_DEVICE unsigned long
+numeric_limits<unsigned long>::min() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned long
+numeric_limits<unsigned long>::max() noexcept
+{
+    return ULONG_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned long
+numeric_limits<unsigned long>::lowest() noexcept
+{
+    return min();
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned long
+numeric_limits<unsigned long>::epsilon() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned long
+numeric_limits<unsigned long>::round_error() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned long
+numeric_limits<unsigned long>::infinity() noexcept
+{
+    return 0;
+}
+
+
+constexpr STDGPU_HOST_DEVICE long long
+numeric_limits<long long>::min() noexcept
+{
+    return LLONG_MIN;
+}
+
+constexpr STDGPU_HOST_DEVICE long long
+numeric_limits<long long>::max() noexcept
+{
+    return LLONG_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE long long
+numeric_limits<long long>::lowest() noexcept
+{
+    return min();
+}
+
+constexpr STDGPU_HOST_DEVICE long long
+numeric_limits<long long>::epsilon() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE long long
+numeric_limits<long long>::round_error() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE long long
+numeric_limits<long long>::infinity() noexcept
+{
+    return 0;
+}
+
+
+constexpr STDGPU_HOST_DEVICE unsigned long long
+numeric_limits<unsigned long long>::min() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned long long
+numeric_limits<unsigned long long>::max() noexcept
+{
+    return ULLONG_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned long long
+numeric_limits<unsigned long long>::lowest() noexcept
+{
+    return min();
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned long long
+numeric_limits<unsigned long long>::epsilon() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned long long
+numeric_limits<unsigned long long>::round_error() noexcept
+{
+    return 0;
+}
+
+constexpr STDGPU_HOST_DEVICE unsigned long long
+numeric_limits<unsigned long long>::infinity() noexcept
+{
+    return 0;
+}
+
+
+constexpr STDGPU_HOST_DEVICE float
+numeric_limits<float>::min() noexcept
+{
+    return FLT_MIN;
+}
+
+constexpr STDGPU_HOST_DEVICE float
+numeric_limits<float>::max() noexcept
+{
+    return FLT_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE float
+numeric_limits<float>::lowest() noexcept
+{
+    return -FLT_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE float
+numeric_limits<float>::epsilon() noexcept
+{
+    return FLT_EPSILON;
+}
+
+constexpr STDGPU_HOST_DEVICE float
+numeric_limits<float>::round_error() noexcept
+{
+    return 0.5F; // NOLINT(readability-magic-numbers)
+}
+
+constexpr STDGPU_HOST_DEVICE float
+numeric_limits<float>::infinity() noexcept
+{
+    return HUGE_VALF;
+}
+
+
+constexpr STDGPU_HOST_DEVICE double
+numeric_limits<double>::min() noexcept
+{
+    return DBL_MIN;
+}
+
+constexpr STDGPU_HOST_DEVICE double
+numeric_limits<double>::max() noexcept
+{
+    return DBL_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE double
+numeric_limits<double>::lowest() noexcept
+{
+    return -DBL_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE double
+numeric_limits<double>::epsilon() noexcept
+{
+    return DBL_EPSILON;
+}
+
+constexpr STDGPU_HOST_DEVICE double
+numeric_limits<double>::round_error() noexcept
+{
+    return 0.5; // NOLINT(readability-magic-numbers)
+}
+
+constexpr STDGPU_HOST_DEVICE double
+numeric_limits<double>::infinity() noexcept
+{
+    return HUGE_VAL;
+}
+
+
+constexpr STDGPU_HOST_DEVICE long double
+numeric_limits<long double>::min() noexcept
+{
+    return LDBL_MIN;
+}
+
+constexpr STDGPU_HOST_DEVICE long double
+numeric_limits<long double>::max() noexcept
+{
+    return LDBL_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE long double
+numeric_limits<long double>::lowest() noexcept
+{
+    return -LDBL_MAX;
+}
+
+constexpr STDGPU_HOST_DEVICE long double
+numeric_limits<long double>::epsilon() noexcept
+{
+    return LDBL_EPSILON;
+}
+
+constexpr STDGPU_HOST_DEVICE long double
+numeric_limits<long double>::round_error() noexcept
+{
+    return 0.5L; // NOLINT(readability-magic-numbers)
+}
+
+constexpr STDGPU_HOST_DEVICE long double
+numeric_limits<long double>::infinity() noexcept
+{
+    return HUGE_VALL;
+}
 
 } // namespace stdgpu
 

--- a/src/stdgpu/limits.h
+++ b/src/stdgpu/limits.h
@@ -20,6 +20,12 @@
  * \file stdgpu/limits.h
  */
 
+#include <cfloat>
+#include <climits>
+
+#include <stdgpu/compiler.h>
+#include <stdgpu/platform.h>
+
 
 
 namespace stdgpu
@@ -37,109 +43,1555 @@ struct numeric_limits;
  * \brief Specialization for bool
  */
 template <>
-struct numeric_limits<bool>;
+struct numeric_limits<bool>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE bool
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE bool
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE bool
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE bool
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE bool
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE bool
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = 1;
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for char
  */
 template <>
-struct numeric_limits<char>;
+struct numeric_limits<char>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE char
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE char
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE char
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE char
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE char
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE char
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     * \note implementation-defined
+     */
+    static constexpr bool is_signed = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT - static_cast<int>(numeric_limits<char>::is_signed);
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for signed char
  */
 template <>
-struct numeric_limits<signed char>;
+struct numeric_limits<signed char>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE signed char
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE signed char
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE signed char
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE signed char
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE signed char
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE signed char
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT - 1;
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for unsigned char
  */
 template <>
-struct numeric_limits<unsigned char>;
+struct numeric_limits<unsigned char>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned char
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned char
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned char
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned char
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned char
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned char
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT;
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for wchar_t
  */
 template <>
-struct numeric_limits<wchar_t>;
+struct numeric_limits<wchar_t>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE wchar_t
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE wchar_t
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE wchar_t
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE wchar_t
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE wchar_t
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE wchar_t
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \var is_signed
+     * \hideinitializer
+     * \brief Whether the type is signed
+     * \note implementation-defined
+     */
+    #if STDGPU_HOST_COMPILER == STDGPU_HOST_COMPILER_MSVC
+        static constexpr bool is_signed = false;
+    #else
+        static constexpr bool is_signed = true;
+    #endif
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT * sizeof(wchar_t) - static_cast<int>(numeric_limits<wchar_t>::is_signed);
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for char16_t
  */
 template <>
-struct numeric_limits<char16_t>;
+struct numeric_limits<char16_t>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE char16_t
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE char16_t
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE char16_t
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE char16_t
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE char16_t
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE char16_t
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT * sizeof(char16_t);
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for char32_t
  */
 template <>
-struct numeric_limits<char32_t>;
+struct numeric_limits<char32_t>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE char32_t
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE char32_t
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE char32_t
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE char32_t
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE char32_t
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE char32_t
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT * sizeof(char32_t);
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for short
  */
 template <>
-struct numeric_limits<short>;
+struct numeric_limits<short>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE short
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE short
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE short
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE short
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE short
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE short
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT * sizeof(short) - 1;
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for unsigned short
  */
 template <>
-struct numeric_limits<unsigned short>;
+struct numeric_limits<unsigned short>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned short
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned short
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned short
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned short
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned short
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned short
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT * sizeof(unsigned short);
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for int
  */
 template <>
-struct numeric_limits<int>;
+struct numeric_limits<int>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE int
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE int
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE int
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE int
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE int
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE int
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT * sizeof(int) - 1;
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for unsigned int
  */
 template <>
-struct numeric_limits<unsigned int>;
+struct numeric_limits<unsigned int>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned int
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned int
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned int
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned int
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned int
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned int
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT * sizeof(unsigned int);
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for long
  */
 template <>
-struct numeric_limits<long>;
+struct numeric_limits<long>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE long
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE long
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE long
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE long
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE long
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE long
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT * sizeof(long) - 1;
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for unsigned long
  */
 template <>
-struct numeric_limits<unsigned long>;
+struct numeric_limits<unsigned long>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned long
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned long
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned long
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned long
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned long
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned long
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT * sizeof(unsigned long);
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for long long
  */
 template <>
-struct numeric_limits<long long>;
+struct numeric_limits<long long>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE long long
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE long long
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE long long
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE long long
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE long long
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE long long
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT * sizeof(long long) - 1;
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for unsigned long long
  */
 template <>
-struct numeric_limits<unsigned long long>;
+struct numeric_limits<unsigned long long>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned long long
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned long long
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned long long
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned long long
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned long long
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE unsigned long long
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = true;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = CHAR_BIT * sizeof(unsigned long long);
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 2;
+};
+
 
 /**
  * \brief Specialization for float
  */
 template <>
-struct numeric_limits<float>;
+struct numeric_limits<float>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE float
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE float
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE float
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE float
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE float
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE float
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = false;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = FLT_MANT_DIG;
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = FLT_RADIX;
+};
+
 
 /**
  * \brief Specialization for double
  */
 template <>
-struct numeric_limits<double>;
+struct numeric_limits<double>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE double
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE double
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE double
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE double
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE double
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE double
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = false;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = DBL_MANT_DIG;
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = FLT_RADIX;
+};
+
 
 /**
  * \brief Specialization for long double
  */
 template <>
-struct numeric_limits<long double>;
+struct numeric_limits<long double>
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE long double
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE long double
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE long double
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE long double
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE long double
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE long double
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = true;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = false;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = LDBL_MANT_DIG;
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = FLT_RADIX;
+};
 
 } // namespace stdgpu
 

--- a/src/stdgpu/limits.h
+++ b/src/stdgpu/limits.h
@@ -32,11 +32,90 @@ namespace stdgpu
 {
 
 /**
- * \brief Generic declaration
+ * \brief Generic traits
  * \tparam T The type for which limits should be specified
  */
 template <class T>
-struct numeric_limits;
+struct numeric_limits
+{
+    /**
+     * \brief Smallest representable finite value
+     * \return Smallest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE T
+    min() noexcept;
+
+    /**
+     * \brief Largest representable finite value
+     * \return Largest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE T
+    max() noexcept;
+
+    /**
+     * \brief Lowest representable finite value
+     * \return Lowest representable finite value
+     */
+    static constexpr STDGPU_HOST_DEVICE T
+    lowest() noexcept;
+
+    /**
+     * \brief Machine epsilon
+     * \return Machine epsilon
+     */
+    static constexpr STDGPU_HOST_DEVICE T
+    epsilon() noexcept;
+
+    /**
+     * \brief Maximum round error
+     * \return Maximum round error
+     */
+    static constexpr STDGPU_HOST_DEVICE T
+    round_error() noexcept;
+
+    /**
+     * \brief Infinity value
+     * \return Infinity value
+     */
+    static constexpr STDGPU_HOST_DEVICE T
+    infinity() noexcept;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the traits of the type are specialized
+     */
+    static constexpr bool is_specialized = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is signed
+     */
+    static constexpr bool is_signed = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is an integer
+     */
+    static constexpr bool is_integer = false;
+
+    /**
+     * \hideinitializer
+     * \brief Whether the type is exact
+     */
+    static constexpr bool is_exact = false;
+
+    /**
+     * \hideinitializer
+     * \brief Number of radix digits
+     */
+    static constexpr int digits = 0;
+
+    /**
+     * \hideinitializer
+     * \brief Integer base
+     */
+    static constexpr int radix = 0;
+};
 
 
 /**

--- a/test/stdgpu/limits.cpp
+++ b/test/stdgpu/limits.cpp
@@ -18,6 +18,7 @@
 #include <limits>
 
 #include <stdgpu/limits.h>
+#include <stdgpu/platform.h>
 
 
 
@@ -228,4 +229,22 @@ TEST_F(stdgpu_limits, long_double)
     check<long double>();
 }
 
+
+class NonArithmeticType
+{
+    public:
+        inline STDGPU_HOST_DEVICE bool
+        operator==(const NonArithmeticType& other) const
+        {
+            return x == other.x;
+        }
+
+    private:
+        int x = 0;
+};
+
+TEST_F(stdgpu_limits, NonArithmeticType)
+{
+    check<NonArithmeticType>();
+}
 


### PR DESCRIPTION
In contrast to `hash` from `functional`, the `numeric_limits` traits do not have a proper documentation since the declaration is completely hidden. Move the member declarations out of the implementation and add the respective documentation. Furthermore, add the implementation for the non-specialized template as well as a respective test.