### PR TITLE
doc: Cleanup unnecessary documentation

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -651,7 +651,7 @@ ENABLED_SECTIONS       =
 # documentation regardless of this setting.
 # Minimum value: 0, maximum value: 10000, default value: 30.
 
-MAX_INITIALIZER_LINES  = 30
+MAX_INITIALIZER_LINES  = 0
 
 # Set the SHOW_USED_FILES tag to NO to disable the list of files generated at
 # the bottom of the documentation of classes and structs. If set to YES, the

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2214,7 +2214,7 @@ DOT_FONTPATH           =
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CLASS_GRAPH            = YES
+CLASS_GRAPH            = NO
 
 # If the COLLABORATION_GRAPH tag is set to YES then doxygen will generate a
 # graph for each documented class showing the direct and indirect implementation

--- a/src/stdgpu/attribute.h
+++ b/src/stdgpu/attribute.h
@@ -29,7 +29,6 @@ namespace stdgpu
 
 /**
  * \def STDGPU_HAS_CPP_ATTRIBUTE
- * \hideinitializer
  * \brief Checks whether the requested attribute is defined
  * \param[in] name The name of the requested C++ attribute
  * \return True if the attribute is defined, false otherwise or if the compiler does not support this check
@@ -43,7 +42,6 @@ namespace stdgpu
 
 /**
  * \def STDGPU_MAYBE_UNUSED
- * \hideinitializer
  * \brief Suppresses compiler warnings caused by variables that are or might be unused
  */
 #if STDGPU_HAS_CPP_ATTRIBUTE(maybe_unused) && (STDGPU_HAS_CXX_17 || STDGPU_HOST_COMPILER != STDGPU_HOST_COMPILER_CLANG) // Clang outputs a warning if C++17 is not present
@@ -59,7 +57,6 @@ namespace stdgpu
 
 /**
  * \def STDGPU_FALLTHROUGH
- * \hideinitializer
  * \brief Suppresses compiler warnings caused by implicit fallthrough
  */
 #if STDGPU_HAS_CPP_ATTRIBUTE(fallthrough) && (STDGPU_HAS_CXX_17 || STDGPU_HOST_COMPILER != STDGPU_HOST_COMPILER_CLANG)  // Clang outputs a warning if C++17 is not present
@@ -75,7 +72,6 @@ namespace stdgpu
 
 /**
  * \def STDGPU_NODISCARD
- * \hideinitializer
  * \brief Encourages compiler warnings or errors if the function return value is unused
  */
 #if STDGPU_HAS_CPP_ATTRIBUTE(nodiscard) && (STDGPU_HAS_CXX_17 || STDGPU_HOST_COMPILER != STDGPU_HOST_COMPILER_CLANG)    // Clang outputs a warning if C++17 is not present

--- a/src/stdgpu/compiler.h
+++ b/src/stdgpu/compiler.h
@@ -26,45 +26,37 @@ namespace stdgpu
 {
 
 /**
- * \hideinitializer
  * \brief Host compiler: Unknown
  */
 #define STDGPU_HOST_COMPILER_UNKNOWN 10
 /**
- * \hideinitializer
  * \brief Host compiler: GCC
  */
 #define STDGPU_HOST_COMPILER_GCC     11
 /**
- * \hideinitializer
  * \brief Host compiler: Clang
  */
 #define STDGPU_HOST_COMPILER_CLANG   12
 /**
- * \hideinitializer
  * \brief Host compiler: Microsoft Visual C++
  */
 #define STDGPU_HOST_COMPILER_MSVC    13
 
 /**
- * \hideinitializer
  * \brief Device compiler: Unknown
  */
 #define STDGPU_DEVICE_COMPILER_UNKNOWN 20
 /**
- * \hideinitializer
  * \brief Device compiler: NVCC
  */
 #define STDGPU_DEVICE_COMPILER_NVCC    21
 /**
- * \hideinitializer
  * \brief Device compiler: HCC
  */
 #define STDGPU_DEVICE_COMPILER_HCC     22
 
 /**
  * \def STDGPU_HOST_COMPILER
- * \hideinitializer
  * \brief The detected host compiler
  */
 #if defined(__GNUC__) && !defined(__clang__)
@@ -79,7 +71,6 @@ namespace stdgpu
 
 /**
  * \def STDGPU_DEVICE_COMPILER
- * \hideinitializer
  * \brief The detected device compiler
  */
 #if defined(__NVCC__)
@@ -93,7 +84,6 @@ namespace stdgpu
 
 /**
  * \def STDGPU_HAS_CXX_17
- * \hideinitializer
  * \brief Indicator of C++17 availability
  */
 #if defined(__cplusplus) && __cplusplus >= 201703L

--- a/src/stdgpu/config.h.in
+++ b/src/stdgpu/config.h.in
@@ -32,44 +32,36 @@ namespace stdgpu
 {
 
 /**
- * \hideinitializer
  * \brief Major version component of stdgpu library
  */
 #define STDGPU_VERSION_MAJOR @stdgpu_VERSION_MAJOR@
 /**
- * \hideinitializer
  * \brief Minor version component of stdgpu library
  */
 #define STDGPU_VERSION_MINOR @stdgpu_VERSION_MINOR@
 /**
- * \hideinitializer
  * \brief Patch version component of stdgpu library
  */
 #define STDGPU_VERSION_PATCH @stdgpu_VERSION_PATCH@
 /**
- * \hideinitializer
  * \brief Version string of stdgpu library
  */
 #define STDGPU_VERSION_STRING "@stdgpu_VERSION@"
 
 
 /**
- * \hideinitializer
  * \brief Selected backend
  */
 #define STDGPU_BACKEND @STDGPU_BACKEND@
 /**
- * \hideinitializer
  * \brief Directory of selected backend
  */
 #define STDGPU_BACKEND_DIRECTORY @STDGPU_BACKEND_DIRECTORY@
 /**
- * \hideinitializer
  * \brief Namespace of selected backend
  */
 #define STDGPU_BACKEND_NAMESPACE @STDGPU_BACKEND_NAMESPACE@
 /**
- * \hideinitializer
  * \brief Macro namespace of selected backend
  */
 #define STDGPU_BACKEND_MACRO_NAMESPACE @STDGPU_BACKEND_MACRO_NAMESPACE@
@@ -77,7 +69,6 @@ namespace stdgpu
 
 /**
  * \def STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING
- * \hideinitializer
  * \brief Library option to enable warnings when falling back to use auxiliary arrays
  */
 // Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
@@ -88,7 +79,6 @@ namespace stdgpu
 
 /**
  * \def STDGPU_ENABLE_CONTRACT_CHECKS
- * \hideinitializer
  * \brief Library option to enable contract checks
  */
 // Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
@@ -99,7 +89,6 @@ namespace stdgpu
 
 /**
  * \def STDGPU_ENABLE_MANAGED_ARRAY_WARNING
- * \hideinitializer
  * \brief Library option to enable warnings when device initialization of managed memory can only be performed on the host
  */
 // Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
@@ -110,7 +99,6 @@ namespace stdgpu
 
 /**
  * \def STDGPU_USE_32_BIT_INDEX
- * \hideinitializer
  * \brief Library option to use 32-bit integers rather than 64-bit to define index_t
  */
 // Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
@@ -121,7 +109,6 @@ namespace stdgpu
 
 /**
  * \def STDGPU_USE_FAST_DESTROY
- * \hideinitializer
  * \brief Library option to use fast destruction of arrays
  */
 // Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
@@ -132,7 +119,6 @@ namespace stdgpu
 
 /**
  * \def STDGPU_USE_FIBONACCI_HASHING
- * \hideinitializer
  * \brief Library option to use Fibonacci Hashing to compute the bucket from the hash value
  */
 // Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01

--- a/src/stdgpu/contract.h
+++ b/src/stdgpu/contract.h
@@ -35,17 +35,14 @@ namespace stdgpu
 
 /**
  * \def STDGPU_EXPECTS(condition)
- * \hideinitializer
  * \brief A macro to define pre-conditions for both host and device
  */
 /**
  * \def STDGPU_ENSURES(condition)
- * \hideinitializer
  * \brief A macro to define post-conditions for both host and device
  */
 /**
  * \def STDGPU_ASSERT(condition)
- * \hideinitializer
  * \brief A macro to define in-body conditions for both host and device
  */
 

--- a/src/stdgpu/cstddef.h
+++ b/src/stdgpu/cstddef.h
@@ -37,7 +37,6 @@ using index64_t = std::ptrdiff_t;       /**< std::ptrdiff_t */
 
 /**
  * \typedef index_t
- * \hideinitializer
  * \brief index32_t if STDGPU_USE_32_BIT_INDEX is set, index64_t otherwise
  */
 #if STDGPU_USE_32_BIT_INDEX
@@ -48,20 +47,17 @@ using index64_t = std::ptrdiff_t;       /**< std::ptrdiff_t */
 
 
 /**
- * \hideinitializer
  * \brief Format constant for index32_t
  */
 #define STDGPU_PRIINDEX32 PRIdLEAST32
 
 /**
- * \hideinitializer
  * \brief Format constant for index64_t
  */
 #define STDGPU_PRIINDEX64 "td"
 
 /**
  * \def STDGPU_PRIINDEX
- * \hideinitializer
  * \brief STDGPU_PRIINDEX32 if STDGPU_USE_32_BIT_INDEX is set, STDGPU_PRIINDEX32 otherwise
  */
 #if STDGPU_USE_32_BIT_INDEX
@@ -73,7 +69,6 @@ using index64_t = std::ptrdiff_t;       /**< std::ptrdiff_t */
 
 /**
  * \def STDGPU_FUNC
- * \hideinitializer
  * \brief A macro for getting the name of the function where this macro is expanded
  */
 #if STDGPU_HOST_COMPILER == STDGPU_HOST_COMPILER_GCC || STDGPU_HOST_COMPILER == STDGPU_HOST_COMPILER_CLANG

--- a/src/stdgpu/cuda/platform.h
+++ b/src/stdgpu/cuda/platform.h
@@ -28,7 +28,6 @@ namespace cuda
 
 /**
  * \def STDGPU_CUDA_HOST_DEVICE
- * \hideinitializer
  * \brief Platform-independent host device function annotation
  */
 #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC
@@ -40,7 +39,6 @@ namespace cuda
 
 /**
  * \def STDGPU_CUDA_DEVICE_ONLY
- * \hideinitializer
  * \brief Platform-independent device function annotation
  */
 #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC
@@ -53,7 +51,6 @@ namespace cuda
 
 /**
  * \def STDGPU_CUDA_CONSTANT
- * \hideinitializer
  * \brief Platform-independent constant variable annotation
  */
 #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC
@@ -65,7 +62,6 @@ namespace cuda
 
 /**
  * \def STDGPU_CUDA_IS_DEVICE_CODE
- * \hideinitializer
  * \brief Platform-independent device code detection
  */
 #if defined(__CUDA_ARCH__)
@@ -77,7 +73,6 @@ namespace cuda
 
 /**
  * \def STDGPU_CUDA_IS_DEVICE_COMPILED
- * \hideinitializer
  * \brief Platform-independent device compilation detection
  */
 #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC

--- a/src/stdgpu/functional.h
+++ b/src/stdgpu/functional.h
@@ -30,12 +30,10 @@
 namespace stdgpu
 {
 
-/**
- * \brief A functor to compute hash values
- * \tparam Key The key type
- */
+//! @cond Doxygen_Suppress
 template <typename Key>
 struct hash;
+//! @endcond
 
 /**
  * \brief A specialization for bool
@@ -312,7 +310,7 @@ struct hash<long double>
  * \brief A specialization for all kinds of enums
  * \tparam E An enumeration
  */
-template<class E>
+template <typename E>
 struct hash
 {
 public:

--- a/src/stdgpu/hip/platform.h
+++ b/src/stdgpu/hip/platform.h
@@ -31,7 +31,6 @@ namespace hip
 
 /**
  * \def STDGPU_HIP_HOST_DEVICE
- * \hideinitializer
  * \brief Platform-independent host device function annotation
  */
 #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_HCC
@@ -43,7 +42,6 @@ namespace hip
 
 /**
  * \def STDGPU_HIP_DEVICE_ONLY
- * \hideinitializer
  * \brief Platform-independent device function annotation
  */
 #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_HCC
@@ -56,7 +54,6 @@ namespace hip
 
 /**
  * \def STDGPU_HIP_CONSTANT
- * \hideinitializer
  * \brief Platform-independent constant variable annotation
  */
 #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_HCC
@@ -68,7 +65,6 @@ namespace hip
 
 /**
  * \def STDGPU_HIP_IS_DEVICE_CODE
- * \hideinitializer
  * \brief Platform-independent device code detection
  */
 #if defined(__HIP_DEVICE_COMPILE__)
@@ -80,7 +76,6 @@ namespace hip
 
 /**
  * \def STDGPU_HIP_IS_DEVICE_COMPILED
- * \hideinitializer
  * \brief Platform-independent device compilation detection
  */
 #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_HCC

--- a/src/stdgpu/impl/functional_detail.h
+++ b/src/stdgpu/impl/functional_detail.h
@@ -69,7 +69,7 @@ hash<long double>::operator()(const long double& key) const
 }
 
 
-template<class E>
+template <typename E>
 inline STDGPU_HOST_DEVICE std::size_t
 hash<E>::operator()(const E& key) const
 {

--- a/src/stdgpu/iterator.h
+++ b/src/stdgpu/iterator.h
@@ -47,36 +47,32 @@ using host_ptr = thrust::pointer<T, thrust::host_system_tag>;
 } // namespace stdgpu
 
 
+//! @cond Doxygen_Suppress
 namespace std
 {
 
-/**
- * \brief Partial specialization required to support STL algorithms
- */
 template <typename T>
 struct iterator_traits<stdgpu::device_ptr<T>>
 {
-    using difference_type   = typename std::iterator_traits<T*>::difference_type;       /**< typename std::iterator_traits<T*>::difference_type */
-    using value_type        = typename std::iterator_traits<T*>::value_type;            /**< typename std::iterator_traits<T*>::value_type */
-    using pointer           = typename std::iterator_traits<T*>::pointer;               /**< typename std::iterator_traits<T*>::pointer */
-    using reference         = typename std::iterator_traits<T*>::reference;             /**< typename std::iterator_traits<T*>::reference */
-    using iterator_category = typename stdgpu::device_ptr<T>::iterator_category;        /**< typename stdgpu::device_ptr<T>::iterator_category */
+    using difference_type   = typename std::iterator_traits<T*>::difference_type;
+    using value_type        = typename std::iterator_traits<T*>::value_type;
+    using pointer           = typename std::iterator_traits<T*>::pointer;
+    using reference         = typename std::iterator_traits<T*>::reference;
+    using iterator_category = typename stdgpu::device_ptr<T>::iterator_category;
 };
 
-/**
- * \brief Partial specialization required to support STL algorithms
- */
 template <typename T>
 struct iterator_traits<stdgpu::host_ptr<T>>
 {
-    using difference_type   = typename std::iterator_traits<T*>::difference_type;       /**< typename std::iterator_traits<T*>::difference_type */
-    using value_type        = typename std::iterator_traits<T*>::value_type;            /**< typename std::iterator_traits<T*>::value_type */
-    using pointer           = typename std::iterator_traits<T*>::pointer;               /**< typename std::iterator_traits<T*>::pointer */
-    using reference         = typename std::iterator_traits<T*>::reference;             /**< typename std::iterator_traits<T*>::reference */
-    using iterator_category = typename stdgpu::host_ptr<T>::iterator_category;          /**< typename stdgpu::host_ptr<T>::iterator_category */
+    using difference_type   = typename std::iterator_traits<T*>::difference_type;
+    using value_type        = typename std::iterator_traits<T*>::value_type;
+    using pointer           = typename std::iterator_traits<T*>::pointer;
+    using reference         = typename std::iterator_traits<T*>::reference;
+    using iterator_category = typename stdgpu::host_ptr<T>::iterator_category;
 };
 
 } // namespace std
+//! @endcond
 
 
 namespace stdgpu
@@ -395,24 +391,12 @@ device_cend(const C& device_container) -> decltype(device_end(device_container))
 namespace detail
 {
 
-/**
- * \brief Base class of back_insert_iterator
- * \tparam Container The type of the container
- */
 template <typename Container>
 struct back_insert_iterator_base;
 
-/**
- * \brief Base class of front_insert_iterator
- * \tparam Container The type of the container
- */
 template <typename Container>
 struct front_insert_iterator_base;
 
-/**
- * \brief Base class of insert_iterator
- * \tparam Container The type of the container
- */
 template <typename Container>
 struct insert_iterator_base;
 
@@ -430,9 +414,11 @@ class back_insert_iterator
     public:
         using container_type = Container;       /**< Container */
 
-        using super_t = typename detail::back_insert_iterator_base<Container>::type;    /**< typename detail::back_insert_iterator_base<Container>::type */
+        //! @cond Doxygen_Suppress
+        using super_t = typename detail::back_insert_iterator_base<Container>::type;
 
-        friend class thrust::iterator_core_access;      /**< Friend declaration for base implementation */
+        friend class thrust::iterator_core_access;
+        //! @endcond
 
         /**
          * \brief Constructor
@@ -469,9 +455,11 @@ class front_insert_iterator
     public:
         using container_type = Container;       /**< Container */
 
-        using super_t = typename detail::front_insert_iterator_base<Container>::type;   /**< typename detail::front_insert_iterator_base<Container>::type */
+        //! @cond Doxygen_Suppress
+        using super_t = typename detail::front_insert_iterator_base<Container>::type;
 
-        friend class thrust::iterator_core_access;      /**< Friend declaration for base implementation */
+        friend class thrust::iterator_core_access;
+        //! @endcond
 
         /**
          * \brief Constructor
@@ -511,9 +499,11 @@ class insert_iterator
     public:
         using container_type = Container;       /**< Container */
 
-        using super_t = typename detail::insert_iterator_base<Container>::type;     /**< typename detail::insert_iterator_base<Container>::type */
+        //! @cond Doxygen_Suppress
+        using super_t = typename detail::insert_iterator_base<Container>::type;
 
-        friend class thrust::iterator_core_access;      /**< Friend declaration for base implementation */
+        friend class thrust::iterator_core_access;
+        //! @endcond
 
         /**
          * \brief Constructor

--- a/src/stdgpu/limits.h
+++ b/src/stdgpu/limits.h
@@ -81,37 +81,31 @@ struct numeric_limits
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = false;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = 0;
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 0;
@@ -167,37 +161,31 @@ struct numeric_limits<bool>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = 1;
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -253,38 +241,32 @@ struct numeric_limits<char>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      * \note implementation-defined
      */
     static constexpr bool is_signed = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT - static_cast<int>(numeric_limits<char>::is_signed);
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -340,37 +322,31 @@ struct numeric_limits<signed char>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT - 1;
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -426,37 +402,31 @@ struct numeric_limits<unsigned char>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT;
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -512,14 +482,12 @@ struct numeric_limits<wchar_t>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
      * \var is_signed
-     * \hideinitializer
      * \brief Whether the type is signed
      * \note implementation-defined
      */
@@ -530,25 +498,21 @@ struct numeric_limits<wchar_t>
     #endif
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT * sizeof(wchar_t) - static_cast<int>(numeric_limits<wchar_t>::is_signed);
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -604,37 +568,31 @@ struct numeric_limits<char16_t>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT * sizeof(char16_t);
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -690,37 +648,31 @@ struct numeric_limits<char32_t>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT * sizeof(char32_t);
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -776,37 +728,31 @@ struct numeric_limits<short>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT * sizeof(short) - 1;
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -862,37 +808,31 @@ struct numeric_limits<unsigned short>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT * sizeof(unsigned short);
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -948,37 +888,31 @@ struct numeric_limits<int>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT * sizeof(int) - 1;
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -1034,37 +968,31 @@ struct numeric_limits<unsigned int>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT * sizeof(unsigned int);
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -1120,37 +1048,31 @@ struct numeric_limits<long>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT * sizeof(long) - 1;
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -1206,37 +1128,31 @@ struct numeric_limits<unsigned long>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT * sizeof(unsigned long);
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -1292,37 +1208,31 @@ struct numeric_limits<long long>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT * sizeof(long long) - 1;
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -1378,37 +1288,31 @@ struct numeric_limits<unsigned long long>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = true;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = CHAR_BIT * sizeof(unsigned long long);
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = 2;
@@ -1464,37 +1368,31 @@ struct numeric_limits<float>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = false;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = FLT_MANT_DIG;
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = FLT_RADIX;
@@ -1550,37 +1448,31 @@ struct numeric_limits<double>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = false;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = DBL_MANT_DIG;
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = FLT_RADIX;
@@ -1636,37 +1528,31 @@ struct numeric_limits<long double>
     infinity() noexcept;
 
     /**
-     * \hideinitializer
      * \brief Whether the traits of the type are specialized
      */
     static constexpr bool is_specialized = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is signed
      */
     static constexpr bool is_signed = true;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is an integer
      */
     static constexpr bool is_integer = false;
 
     /**
-     * \hideinitializer
      * \brief Whether the type is exact
      */
     static constexpr bool is_exact = false;
 
     /**
-     * \hideinitializer
      * \brief Number of radix digits
      */
     static constexpr int digits = LDBL_MANT_DIG;
 
     /**
-     * \hideinitializer
      * \brief Integer base
      */
     static constexpr int radix = FLT_RADIX;

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -294,7 +294,11 @@ struct safe_device_allocator
 {
     using value_type = T;       /**< T */
 
-    constexpr static dynamic_memory_type memory_type = dynamic_memory_type::device;         /**< dynamic_memory_type::device */
+    /**
+     * \hideinitializer
+     * \brief Dynamic memory type of allocations
+     */
+    constexpr static dynamic_memory_type memory_type = dynamic_memory_type::device;
 
     /**
      * \brief Allocates a memory block of the given size
@@ -324,7 +328,11 @@ struct safe_host_allocator
 {
     using value_type = T;       /**< T */
 
-    constexpr static dynamic_memory_type memory_type = dynamic_memory_type::host;           /**< dynamic_memory_type::host */
+    /**
+     * \hideinitializer
+     * \brief Dynamic memory type of allocations
+     */
+    constexpr static dynamic_memory_type memory_type = dynamic_memory_type::host;
 
     /**
      * \brief Allocates a memory block of the given size
@@ -354,7 +362,11 @@ struct safe_managed_allocator
 {
     using value_type = T;       /**< T */
 
-    constexpr static dynamic_memory_type memory_type = dynamic_memory_type::managed;        /**< dynamic_memory_type::managed */
+    /**
+     * \hideinitializer
+     * \brief Dynamic memory type of allocations
+     */
+    constexpr static dynamic_memory_type memory_type = dynamic_memory_type::managed;
 
     /**
      * \brief Allocates a memory block of the given size

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -295,7 +295,6 @@ struct safe_device_allocator
     using value_type = T;       /**< T */
 
     /**
-     * \hideinitializer
      * \brief Dynamic memory type of allocations
      */
     constexpr static dynamic_memory_type memory_type = dynamic_memory_type::device;
@@ -329,7 +328,6 @@ struct safe_host_allocator
     using value_type = T;       /**< T */
 
     /**
-     * \hideinitializer
      * \brief Dynamic memory type of allocations
      */
     constexpr static dynamic_memory_type memory_type = dynamic_memory_type::host;
@@ -363,7 +361,6 @@ struct safe_managed_allocator
     using value_type = T;       /**< T */
 
     /**
-     * \hideinitializer
      * \brief Dynamic memory type of allocations
      */
     constexpr static dynamic_memory_type memory_type = dynamic_memory_type::managed;

--- a/src/stdgpu/openmp/platform.h
+++ b/src/stdgpu/openmp/platform.h
@@ -25,7 +25,6 @@ namespace openmp
 
 /**
  * \def STDGPU_OPENMP_HOST_DEVICE
- * \hideinitializer
  * \brief Platform-independent host device function annotation
  */
 #define STDGPU_OPENMP_HOST_DEVICE
@@ -33,7 +32,6 @@ namespace openmp
 
 /**
  * \def STDGPU_OPENMP_DEVICE_ONLY
- * \hideinitializer
  * \brief Platform-independent device function annotation
  */
 #define STDGPU_OPENMP_DEVICE_ONLY
@@ -41,7 +39,6 @@ namespace openmp
 
 /**
  * \def STDGPU_OPENMP_CONSTANT
- * \hideinitializer
  * \brief Platform-independent constant variable annotation
  */
 #define STDGPU_OPENMP_CONSTANT
@@ -49,7 +46,6 @@ namespace openmp
 
 /**
  * \def STDGPU_OPENMP_IS_DEVICE_CODE
- * \hideinitializer
  * \brief Platform-independent device code detection
  */
 #define STDGPU_OPENMP_IS_DEVICE_CODE 0
@@ -57,7 +53,6 @@ namespace openmp
 
 /**
  * \def STDGPU_OPENMP_IS_DEVICE_COMPILED
- * \hideinitializer
  * \brief Platform-independent device compilation detection
  */
 #define STDGPU_OPENMP_IS_DEVICE_COMPILED 1

--- a/src/stdgpu/platform.h
+++ b/src/stdgpu/platform.h
@@ -38,17 +38,14 @@ namespace stdgpu
 {
 
 /**
- * \hideinitializer
  * \brief Backend: CUDA
  */
 #define STDGPU_BACKEND_CUDA   100
 /**
- * \hideinitializer
  * \brief Backend: OpenMP
  */
 #define STDGPU_BACKEND_OPENMP 101
 /**
- * \hideinitializer
  * \brief Backend: HIP
  */
 #define STDGPU_BACKEND_HIP    102
@@ -71,7 +68,6 @@ namespace detail
 
 /**
  * \def STDGPU_HOST_DEVICE
- * \hideinitializer
  * \brief Platform-independent host device function annotation
  */
 #define STDGPU_HOST_DEVICE STDGPU_DETAIL_CAT3(STDGPU_, STDGPU_BACKEND_MACRO_NAMESPACE, _HOST_DEVICE)
@@ -79,7 +75,6 @@ namespace detail
 
 /**
  * \def STDGPU_DEVICE_ONLY
- * \hideinitializer
  * \brief Platform-independent device function annotation
  */
 #define STDGPU_DEVICE_ONLY STDGPU_DETAIL_CAT3(STDGPU_, STDGPU_BACKEND_MACRO_NAMESPACE, _DEVICE_ONLY)
@@ -87,19 +82,16 @@ namespace detail
 
 /**
  * \def STDGPU_CONSTANT
- * \hideinitializer
  * \brief Platform-independent constant variable annotation
  */
 #define STDGPU_CONSTANT STDGPU_DETAIL_CAT3(STDGPU_, STDGPU_BACKEND_MACRO_NAMESPACE, _CONSTANT)
 
 
 /**
- * \hideinitializer
  * \brief Code path: Host
  */
 #define STDGPU_CODE_HOST   1000
 /**
- * \hideinitializer
  * \brief Code path: Device
  */
 #define STDGPU_CODE_DEVICE 1001
@@ -117,7 +109,6 @@ namespace detail
 
 /**
  * \def STDGPU_CODE
- * \hideinitializer
  * \brief The code path
  */
 #if STDGPU_DETAIL_IS_DEVICE_CODE


### PR DESCRIPTION
We strive for documenting every class, member, and function to provide an as complete documentation as possible. However, some internal implementation details were documented as well. Remove all unnecessary documentation to avoid confusion.