### PR TITLE
doc: Group all class and function definitions into modules

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -352,14 +352,14 @@ IDL_PROPERTY_SUPPORT   = YES
 # all members of a group must be documented explicitly.
 # The default value is: NO.
 
-DISTRIBUTE_GROUP_DOC   = NO
+DISTRIBUTE_GROUP_DOC   = YES
 
 # If one adds a struct or class to a group and this option is enabled, then also
 # any nested class or struct is added to the same group. By default this option
 # is disabled and one has to add nested compounds explicitly via \ingroup.
 # The default value is: NO.
 
-GROUP_NESTED_COMPOUNDS = NO
+GROUP_NESTED_COMPOUNDS = YES
 
 # Set the SUBGROUPING tag to YES to allow class member groups of the same type
 # (for instance a group of public functions) to be put as a subgroup of that

--- a/doc/stdgpu/modules.doxy
+++ b/doc/stdgpu/modules.doxy
@@ -1,0 +1,9 @@
+/**
+
+\defgroup data_structures Data Structures and Containers
+
+\defgroup utilities Complementing functionality
+
+\defgroup system Platform functionality
+
+*/

--- a/src/stdgpu/algorithm.h
+++ b/src/stdgpu/algorithm.h
@@ -17,6 +17,12 @@
 #define STDGPU_ALGORITHM_H
 
 /**
+ * \addtogroup algorithm algorithm
+ * \ingroup utilities
+ * @{
+ */
+
+/**
  * \file stdgpu/algorithm.h
  */
 
@@ -28,6 +34,7 @@ namespace stdgpu
 {
 
 /**
+ * \ingroup algorithm
  * \brief Computes the minimum of the given values
  * \tparam T The type of the values
  * \param[in] a A value
@@ -40,6 +47,7 @@ min(const T& a,
     const T& b);
 
 /**
+ * \ingroup algorithm
  * \brief Computes the maximum of the given values
  * \tparam T The type of the values
  * \param[in] a A value
@@ -53,6 +61,7 @@ max(const T& a,
 
 
 /**
+ * \ingroup algorithm
  * \brief Clamps a value to the given range
  * \tparam T The type of the values
  * \param[in] v A value
@@ -68,6 +77,12 @@ clamp(const T& v,
       const T& upper);
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -17,6 +17,12 @@
 #define STDGPU_ATOMIC_H
 
 /**
+ * \addtogroup atomic atomic
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/atomic.cuh
  */
 
@@ -613,6 +619,12 @@ class atomic_ref
 };
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/atomic_fwd
+++ b/src/stdgpu/atomic_fwd
@@ -17,6 +17,12 @@
 #define STDGPU_ATOMIC_FWD
 
 /**
+ * \addtogroup atomic atomic
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/atomic_fwd
  */
 
@@ -32,6 +38,12 @@ template <typename T>
 class atomic_ref;
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/attribute.h
+++ b/src/stdgpu/attribute.h
@@ -17,6 +17,12 @@
 #define STDGPU_ATTRIBUTE_H
 
 /**
+ * \addtogroup attribute attribute
+ * \ingroup system
+ * @{
+ */
+
+/**
  * \file stdgpu/attribute.h
  */
 
@@ -27,20 +33,17 @@
 namespace stdgpu
 {
 
-/**
- * \def STDGPU_HAS_CPP_ATTRIBUTE
- * \brief Checks whether the requested attribute is defined
- * \param[in] name The name of the requested C++ attribute
- * \return True if the attribute is defined, false otherwise or if the compiler does not support this check
- */
+//! @cond Doxygen_Suppress
 #ifdef __has_cpp_attribute
     #define STDGPU_HAS_CPP_ATTRIBUTE(name) __has_cpp_attribute(name)
 #else
     #define STDGPU_HAS_CPP_ATTRIBUTE(name) 0
 #endif
+//! @endcond
 
 
 /**
+ * \ingroup attribute
  * \def STDGPU_MAYBE_UNUSED
  * \brief Suppresses compiler warnings caused by variables that are or might be unused
  */
@@ -56,6 +59,7 @@ namespace stdgpu
 
 
 /**
+ * \ingroup attribute
  * \def STDGPU_FALLTHROUGH
  * \brief Suppresses compiler warnings caused by implicit fallthrough
  */
@@ -71,6 +75,7 @@ namespace stdgpu
 
 
 /**
+ * \ingroup attribute
  * \def STDGPU_NODISCARD
  * \brief Encourages compiler warnings or errors if the function return value is unused
  */
@@ -87,6 +92,12 @@ namespace stdgpu
 #endif
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/bit.h
+++ b/src/stdgpu/bit.h
@@ -17,6 +17,12 @@
 #define STDGPU_BIT_H
 
 /**
+ * \addtogroup bit bit
+ * \ingroup utilities
+ * @{
+ */
+
+/**
  * \file stdgpu/bit.h
  */
 
@@ -30,6 +36,7 @@ namespace stdgpu
 {
 
 /**
+ * \ingroup bit
  * \brief Determines whether the number is a power of two
  * \param[in] number A number
  * \return True if number is a power of two, false otherwise
@@ -39,6 +46,7 @@ STDGPU_HOST_DEVICE bool
 has_single_bit(const T number);
 
 /**
+ * \ingroup bit
  * \brief Computes the smallest power of two which is larger or equal than the given number
  * \param[in] number A number
  * \return The smallest power of two which is larger than the given number
@@ -48,6 +56,7 @@ STDGPU_HOST_DEVICE T
 bit_ceil(const T number);
 
 /**
+ * \ingroup bit
  * \brief Computes the largest power of two which is smaller or equal than the given number
  * \param[in] number A number
  * \return The largest power of two which is smaller than the given number
@@ -57,6 +66,7 @@ STDGPU_HOST_DEVICE T
 bit_floor(const T number);
 
 /**
+ * \ingroup bit
  * \brief Computes the modulus of the given number and a power of two divider
  * \param[in] number A number
  * \param[in] divider The divider with divider = 2^n
@@ -71,6 +81,7 @@ bit_mod(const T number,
         const T divider);
 
 /**
+ * \ingroup bit
  * \brief Computes the smallest number of bits to represent the given number
  * \param[in] number A number
  * \return The smallest number of bits to represent the given number
@@ -82,6 +93,7 @@ STDGPU_HOST_DEVICE T
 bit_width(const T number);
 
 /**
+ * \ingroup bit
  * \brief Counts the number of set bits in the number
  * \param[in] number A number
  * \return The number of set bits
@@ -95,6 +107,7 @@ popcount(const T number);
 
 // Deprecated classes and functions
 /**
+ * \ingroup bit
  * \deprecated Replaced by has_single_bit
  * \brief Determines whether the number is a power of two
  * \param[in] number A number
@@ -106,6 +119,7 @@ STDGPU_HOST_DEVICE bool
 ispow2(const T number);
 
 /**
+ * \ingroup bit
  * \deprecated Replaced by bit_mod
  * \brief Computes the modulus of the given number and a power of two divider
  * \param[in] number A number
@@ -122,6 +136,7 @@ mod2(const T number,
      const T divider);
 
 /**
+ * \ingroup bit
  * \deprecated Replaced by bit_width
  * \brief Computes the base-2 logarithm of a power of two
  * \param[in] number A number
@@ -134,6 +149,12 @@ STDGPU_HOST_DEVICE T
 log2pow2(const T number);
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -17,6 +17,12 @@
 #define STDGPU_BITSET_H
 
 /**
+ * \addtogroup bitset bitset
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/bitset.cuh
  */
 
@@ -291,6 +297,12 @@ class bitset
 };
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/bitset_fwd
+++ b/src/stdgpu/bitset_fwd
@@ -17,6 +17,12 @@
 #define STDGPU_BITSET_FWD
 
 /**
+ * \addtogroup bitset bitset
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/bitset_fwd
  */
 
@@ -28,6 +34,12 @@ namespace stdgpu
 class bitset;
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/cmath.h
+++ b/src/stdgpu/cmath.h
@@ -17,6 +17,12 @@
 #define STDGPU_CMATH_H
 
 /**
+ * \addtogroup cmath cmath
+ * \ingroup utilities
+ * @{
+ */
+
+/**
  * \file stdgpu/cmath.h
  */
 
@@ -28,6 +34,7 @@ namespace stdgpu
 {
 
 /**
+ * \ingroup cmath
  * \brief Computes the absolute value of the given argument
  * \param[in] arg A value
  * \return arg if arg > 0.0f, -arg otherwise
@@ -36,6 +43,12 @@ constexpr STDGPU_HOST_DEVICE float
 abs(const float arg);
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/compiler.h
+++ b/src/stdgpu/compiler.h
@@ -17,6 +17,12 @@
 #define STDGPU_COMPILER_H
 
 /**
+ * \addtogroup compiler compiler
+ * \ingroup system
+ * @{
+ */
+
+/**
  * \file stdgpu/compiler.h
  */
 
@@ -26,36 +32,44 @@ namespace stdgpu
 {
 
 /**
+ * \ingroup compiler
  * \brief Host compiler: Unknown
  */
 #define STDGPU_HOST_COMPILER_UNKNOWN 10
 /**
+ * \ingroup compiler
  * \brief Host compiler: GCC
  */
 #define STDGPU_HOST_COMPILER_GCC     11
 /**
+ * \ingroup compiler
  * \brief Host compiler: Clang
  */
 #define STDGPU_HOST_COMPILER_CLANG   12
 /**
+ * \ingroup compiler
  * \brief Host compiler: Microsoft Visual C++
  */
 #define STDGPU_HOST_COMPILER_MSVC    13
 
 /**
+ * \ingroup compiler
  * \brief Device compiler: Unknown
  */
 #define STDGPU_DEVICE_COMPILER_UNKNOWN 20
 /**
+ * \ingroup compiler
  * \brief Device compiler: NVCC
  */
 #define STDGPU_DEVICE_COMPILER_NVCC    21
 /**
+ * \ingroup compiler
  * \brief Device compiler: HCC
  */
 #define STDGPU_DEVICE_COMPILER_HCC     22
 
 /**
+ * \ingroup compiler
  * \def STDGPU_HOST_COMPILER
  * \brief The detected host compiler
  */
@@ -70,6 +84,7 @@ namespace stdgpu
 #endif
 
 /**
+ * \ingroup compiler
  * \def STDGPU_DEVICE_COMPILER
  * \brief The detected device compiler
  */
@@ -83,6 +98,7 @@ namespace stdgpu
 
 
 /**
+ * \ingroup compiler
  * \def STDGPU_HAS_CXX_17
  * \brief Indicator of C++17 availability
  */
@@ -94,6 +110,12 @@ namespace stdgpu
 
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/config.h.in
+++ b/src/stdgpu/config.h.in
@@ -19,6 +19,12 @@
 //! @endcond
 
 /**
+ * \addtogroup config config
+ * \ingroup system
+ * @{
+ */
+
+/**
  * \file stdgpu/config.h.in
  * \brief This file serves as a template for CMake which configures the corresponding config.h file.
  */
@@ -32,42 +38,37 @@ namespace stdgpu
 {
 
 /**
+ * \ingroup config
  * \brief Major version component of stdgpu library
  */
 #define STDGPU_VERSION_MAJOR @stdgpu_VERSION_MAJOR@
 /**
+ * \ingroup config
  * \brief Minor version component of stdgpu library
  */
 #define STDGPU_VERSION_MINOR @stdgpu_VERSION_MINOR@
 /**
+ * \ingroup config
  * \brief Patch version component of stdgpu library
  */
 #define STDGPU_VERSION_PATCH @stdgpu_VERSION_PATCH@
 /**
+ * \ingroup config
  * \brief Version string of stdgpu library
  */
 #define STDGPU_VERSION_STRING "@stdgpu_VERSION@"
 
 
-/**
- * \brief Selected backend
- */
+//! @cond Doxygen_Suppress
 #define STDGPU_BACKEND @STDGPU_BACKEND@
-/**
- * \brief Directory of selected backend
- */
 #define STDGPU_BACKEND_DIRECTORY @STDGPU_BACKEND_DIRECTORY@
-/**
- * \brief Namespace of selected backend
- */
 #define STDGPU_BACKEND_NAMESPACE @STDGPU_BACKEND_NAMESPACE@
-/**
- * \brief Macro namespace of selected backend
- */
 #define STDGPU_BACKEND_MACRO_NAMESPACE @STDGPU_BACKEND_MACRO_NAMESPACE@
+//! @endcond
 
 
 /**
+ * \ingroup config
  * \def STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING
  * \brief Library option to enable warnings when falling back to use auxiliary arrays
  */
@@ -78,6 +79,7 @@ namespace stdgpu
 #cmakedefine01 STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING
 
 /**
+ * \ingroup config
  * \def STDGPU_ENABLE_CONTRACT_CHECKS
  * \brief Library option to enable contract checks
  */
@@ -88,6 +90,7 @@ namespace stdgpu
 #cmakedefine01 STDGPU_ENABLE_CONTRACT_CHECKS
 
 /**
+ * \ingroup config
  * \def STDGPU_ENABLE_MANAGED_ARRAY_WARNING
  * \brief Library option to enable warnings when device initialization of managed memory can only be performed on the host
  */
@@ -98,6 +101,7 @@ namespace stdgpu
 #cmakedefine01 STDGPU_ENABLE_MANAGED_ARRAY_WARNING
 
 /**
+ * \ingroup config
  * \def STDGPU_USE_32_BIT_INDEX
  * \brief Library option to use 32-bit integers rather than 64-bit to define index_t
  */
@@ -108,6 +112,7 @@ namespace stdgpu
 #cmakedefine01 STDGPU_USE_32_BIT_INDEX
 
 /**
+ * \ingroup config
  * \def STDGPU_USE_FAST_DESTROY
  * \brief Library option to use fast destruction of arrays
  */
@@ -118,6 +123,7 @@ namespace stdgpu
 #cmakedefine01 STDGPU_USE_FAST_DESTROY
 
 /**
+ * \ingroup config
  * \def STDGPU_USE_FIBONACCI_HASHING
  * \brief Library option to use Fibonacci Hashing to compute the bucket from the hash value
  */
@@ -128,6 +134,12 @@ namespace stdgpu
 #cmakedefine01 STDGPU_USE_FIBONACCI_HASHING
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/contract.h
+++ b/src/stdgpu/contract.h
@@ -17,6 +17,12 @@
 #define STDGPU_CONTRACT_H
 
 /**
+ * \addtogroup contract contract
+ * \ingroup utilities
+ * @{
+ */
+
+/**
  * \file stdgpu/contract.h
  */
 
@@ -34,14 +40,17 @@ namespace stdgpu
 {
 
 /**
+ * \ingroup contract
  * \def STDGPU_EXPECTS(condition)
  * \brief A macro to define pre-conditions for both host and device
  */
 /**
+ * \ingroup contract
  * \def STDGPU_ENSURES(condition)
  * \brief A macro to define post-conditions for both host and device
  */
 /**
+ * \ingroup contract
  * \def STDGPU_ASSERT(condition)
  * \brief A macro to define in-body conditions for both host and device
  */
@@ -98,6 +107,12 @@ namespace stdgpu
 #endif
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/cstddef.h
+++ b/src/stdgpu/cstddef.h
@@ -17,6 +17,12 @@
 #define STDGPU_CSTDDEF_H
 
 /**
+ * \addtogroup cstddef cstddef
+ * \ingroup utilities
+ * @{
+ */
+
+/**
  * \file stdgpu/cstddef.h
  */
 
@@ -32,10 +38,20 @@
 namespace stdgpu
 {
 
-using index32_t = std::int_least32_t;   /**< std::int_least32_t */
-using index64_t = std::ptrdiff_t;       /**< std::ptrdiff_t */
+/**
+ * \ingroup cstddef
+ * \brief std::int_least32_t
+ */
+using index32_t = std::int_least32_t;
 
 /**
+ * \ingroup cstddef
+ * \brief std::ptrdiff_t
+ */
+using index64_t = std::ptrdiff_t;
+
+/**
+ * \ingroup cstddef
  * \typedef index_t
  * \brief index32_t if STDGPU_USE_32_BIT_INDEX is set, index64_t otherwise
  */
@@ -47,16 +63,19 @@ using index64_t = std::ptrdiff_t;       /**< std::ptrdiff_t */
 
 
 /**
+ * \ingroup cstddef
  * \brief Format constant for index32_t
  */
 #define STDGPU_PRIINDEX32 PRIdLEAST32
 
 /**
+ * \ingroup cstddef
  * \brief Format constant for index64_t
  */
 #define STDGPU_PRIINDEX64 "td"
 
 /**
+ * \ingroup cstddef
  * \def STDGPU_PRIINDEX
  * \brief STDGPU_PRIINDEX32 if STDGPU_USE_32_BIT_INDEX is set, STDGPU_PRIINDEX32 otherwise
  */
@@ -68,6 +87,7 @@ using index64_t = std::ptrdiff_t;       /**< std::ptrdiff_t */
 
 
 /**
+ * \ingroup cstddef
  * \def STDGPU_FUNC
  * \brief A macro for getting the name of the function where this macro is expanded
  */
@@ -80,6 +100,12 @@ using index64_t = std::ptrdiff_t;       /**< std::ptrdiff_t */
 #endif
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/cstdlib.h
+++ b/src/stdgpu/cstdlib.h
@@ -17,6 +17,12 @@
 #define STDGPU_CSTDLIB_H
 
 /**
+ * \addtogroup cstdlib cstdlib
+ * \ingroup utilities
+ * @{
+ */
+
+/**
  * \file stdgpu/cstdlib.h
  */
 
@@ -40,6 +46,7 @@ struct /*[[deprecated(" Use x / y and bit_mod(x, y) directly")]]*/ sizediv_t
 };
 
 /**
+ * \ingroup cstdlib
  * \brief Computes x/y and x%y where y = 2^n
  * \param[in] x A number
  * \param[in] y The divider with y = 2^n
@@ -55,6 +62,12 @@ sizedivPow2(const std::size_t x,
             const std::size_t y);
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -17,6 +17,12 @@
 #define STDGPU_DEQUE_H
 
 /**
+ * \addtogroup deque deque
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/deque.cuh
  */
 
@@ -338,6 +344,12 @@ class deque
 };
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/deque_fwd
+++ b/src/stdgpu/deque_fwd
@@ -17,6 +17,12 @@
 #define STDGPU_DEQUE_FWD
 
 /**
+ * \addtogroup deque deque
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/deque_fwd
  */
 
@@ -29,6 +35,12 @@ template <typename T>
 class deque;
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/functional.h
+++ b/src/stdgpu/functional.h
@@ -17,6 +17,12 @@
 #define STDGPU_FUNCTIONAL_H
 
 /**
+ * \addtogroup functional functional
+ * \ingroup utilities
+ * @{
+ */
+
+/**
  * \file stdgpu/functional.h
  */
 
@@ -330,6 +336,12 @@ private:
 };
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/iterator.h
+++ b/src/stdgpu/iterator.h
@@ -17,6 +17,12 @@
 #define STDGPU_ITERATOR_H
 
 /**
+ * \addtogroup iterator iterator
+ * \ingroup utilities
+ * @{
+ */
+
+/**
  * \file stdgpu/iterator.h
  */
 
@@ -32,6 +38,7 @@ namespace stdgpu
 {
 
 /**
+ * \ingroup iterator
  * \brief A host pointer class allowing to call thrust algorithms without explicitly using the thrust::device execution policy
  * \note Considered equivalent to thrust::device_ptr but can be processed in plain C++
  */
@@ -39,6 +46,7 @@ template <typename T>
 using device_ptr = thrust::pointer<T, thrust::device_system_tag>;
 
 /**
+ * \ingroup iterator
  * \brief A host pointer class allowing to call thrust algorithms without explicitly using the thrust::host execution policy
  */
 template <typename T>
@@ -77,7 +85,9 @@ struct iterator_traits<stdgpu::host_ptr<T>>
 
 namespace stdgpu
 {
+
 /**
+ * \ingroup iterator
  * \brief Constructs a device_ptr object
  * \tparam T The type of the array
  * \param[in] device_array An array
@@ -89,6 +99,7 @@ make_device(T* device_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Constructs a host_ptr object
  * \tparam T The type of the array
  * \param[in] host_array An array
@@ -100,6 +111,7 @@ make_host(T* host_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Finds the size (number of elements) of the given dynamically allocated array
  * \tparam T The type of the array
  * \param[in] array An array
@@ -112,6 +124,7 @@ size(T* array);
 
 
 /**
+ * \ingroup iterator
  * \brief Specialization for unknown data type: Finds the size (in bytes) of the given dynamically allocated array
  * \param[in] array An array
  * \return The size (in bytes) of the given array
@@ -124,6 +137,7 @@ size(void* array);
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a pointer to the begin of the given host array
  * \tparam T The type of the array
  * \param[in] host_array An array
@@ -135,6 +149,7 @@ host_begin(T* host_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a pointer to the end of the given host array
  * \tparam T The type of the array
  * \param[in] host_array An array
@@ -146,6 +161,7 @@ host_end(T* host_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a pointer to the begin of the given device array
  * \tparam T The type of the array
  * \param[in] device_array An array
@@ -157,6 +173,7 @@ device_begin(T* device_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a pointer to the end of the given device array
  * \tparam T The type of the array
  * \param[in] device_array An array
@@ -168,6 +185,7 @@ device_end(T* device_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a constant pointer to the begin of the given host array
  * \tparam T The type of the array
  * \param[in] host_array An array
@@ -179,6 +197,7 @@ host_begin(const T* host_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a constant pointer to the end of the given host array
  * \tparam T The type of the array
  * \param[in] host_array An array
@@ -190,6 +209,7 @@ host_end(const T* host_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a constant pointer to the begin of the given device array
  * \tparam T The type of the array
  * \param[in] device_array An array
@@ -201,6 +221,7 @@ device_begin(const T* device_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a constant pointer to the end of the given device array
  * \tparam T The type of the array
  * \param[in] device_array An array
@@ -212,6 +233,7 @@ device_end(const T* device_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a constant pointer to the begin of the given host array
  * \tparam T The type of the array
  * \param[in] host_array An array
@@ -223,6 +245,7 @@ host_cbegin(const T* host_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a constant pointer to the end of the given host array
  * \tparam T The type of the array
  * \param[in] host_array An array
@@ -234,6 +257,7 @@ host_cend(const T* host_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a constant pointer to the begin of the given device array
  * \tparam T The type of the array
  * \param[in] device_array An array
@@ -245,6 +269,7 @@ device_cbegin(const T* device_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a constant pointer to the end of the given device array
  * \tparam T The type of the array
  * \param[in] device_array An array
@@ -257,6 +282,7 @@ device_cend(const T* device_array);
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a pointer to the begin of the given host container
  * \tparam C The type of the container
  * \param[in] host_container An array
@@ -268,6 +294,7 @@ host_begin(C& host_container) -> decltype(host_container.host_begin());
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a pointer to the end of the given host container
  * \tparam C The type of the container
  * \param[in] host_container An array
@@ -279,6 +306,7 @@ host_end(C& host_container) -> decltype(host_container.host_end());
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a pointer to the begin of the given device container
  * \tparam C The type of the container
  * \param[in] device_container An array
@@ -290,6 +318,7 @@ device_begin(C& device_container) -> decltype(device_container.device_begin());
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a pointer to the end of the given device container
  * \tparam C The type of the container
  * \param[in] device_container An array
@@ -301,6 +330,7 @@ device_end(C& device_container) -> decltype(device_container.device_end());
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a contant pointer to the begin of the given host container
  * \tparam C The type of the container
  * \param[in] host_container An array
@@ -312,6 +342,7 @@ host_begin(const C& host_container) -> decltype(host_container.host_begin());
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a contant pointer to the end of the given host container
  * \tparam C The type of the container
  * \param[in] host_container An array
@@ -323,6 +354,7 @@ host_end(const C& host_container) -> decltype(host_container.host_end());
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a contant pointer to the begin of the given device container
  * \tparam C The type of the container
  * \param[in] device_container An array
@@ -334,6 +366,7 @@ device_begin(const C& device_container) -> decltype(device_container.device_begi
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a contant pointer to the end of the given device container
  * \tparam C The type of the container
  * \param[in] device_container An array
@@ -345,6 +378,7 @@ device_end(const C& device_container) -> decltype(device_container.device_end())
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a contant pointer to the begin of the given host container
  * \tparam C The type of the container
  * \param[in] host_container An array
@@ -356,6 +390,7 @@ host_cbegin(const C& host_container) -> decltype(host_begin(host_container));
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a contant pointer to the end of the given host container
  * \tparam C The type of the container
  * \param[in] host_container An array
@@ -367,6 +402,7 @@ host_cend(const C& host_container) -> decltype(host_end(host_container));
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a contant pointer to the begin of the given device container
  * \tparam C The type of the container
  * \param[in] device_container An array
@@ -378,6 +414,7 @@ device_cbegin(const C& device_container) -> decltype(device_begin(device_contain
 
 
 /**
+ * \ingroup iterator
  * \brief Creates a contant pointer to the end of the given device container
  * \tparam C The type of the container
  * \param[in] device_container An array
@@ -435,6 +472,7 @@ class back_insert_iterator
 };
 
 /**
+ * \ingroup iterator
  * \brief Constructs a back_insert_iterator
  * \param[in] c The container into which the elements are inserted
  * \return A back_insert_iterator for the given container
@@ -476,6 +514,7 @@ class front_insert_iterator
 };
 
 /**
+ * \ingroup iterator
  * \brief Constructs a front_insert_iterator
  * \param[in] c The container into which the elements are inserted
  * \return A front_insert_iterator for the given container
@@ -520,6 +559,7 @@ class insert_iterator
 };
 
 /**
+ * \ingroup iterator
  * \brief Constructs an insert_iterator
  * \param[in] c The container into which the elements are inserted
  * \return An insert_iterator for the given container
@@ -529,6 +569,13 @@ STDGPU_HOST_DEVICE insert_iterator<Container>
 inserter(Container& c);
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
+
 
 
 #include <stdgpu/impl/iterator_detail.h>

--- a/src/stdgpu/limits.h
+++ b/src/stdgpu/limits.h
@@ -17,6 +17,12 @@
 #define STDGPU_LIMITS_H
 
 /**
+ * \addtogroup limits limits
+ * \ingroup utilities
+ * @{
+ */
+
+/**
  * \file stdgpu/limits.h
  */
 
@@ -1559,6 +1565,12 @@ struct numeric_limits<long double>
 };
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -17,6 +17,12 @@
 #define STDGPU_MEMORY_H
 
 /**
+ * \addtogroup memory memory
+ * \ingroup utilities
+ * @{
+ */
+
+/**
  * \file stdgpu/memory.h
  */
 
@@ -264,6 +270,7 @@ namespace stdgpu
 {
 
 /**
+ * \ingroup memory
  * \brief The types of a dynamically allocated array
  */
 enum class dynamic_memory_type
@@ -276,6 +283,7 @@ enum class dynamic_memory_type
 
 
 /**
+ * \ingroup memory
  * \brief Determines the dynamic memory type of the given array
  * \param[in] array An array
  * \return The memory type of the array
@@ -485,6 +493,7 @@ struct allocator_traits
 
 
 /**
+ * \ingroup memory
  * \brief Destroys the value at the given pointer
  * \tparam T The value type
  * \tparam Args The argument types
@@ -499,6 +508,7 @@ construct_at(T* p,
 
 
 /**
+ * \ingroup memory
  * \brief Destroys the value at the given pointer
  * \tparam T The value type
  * \param[in] p A pointer to the value to destroy
@@ -509,6 +519,7 @@ destroy_at(T* p);
 
 
 /**
+ * \ingroup memory
  * \brief Destroys the range of values
  * \tparam Iterator The iterator type of the values
  * \param[in] first An iterator to the begin of the value range
@@ -521,6 +532,7 @@ destroy(Iterator first,
 
 
 /**
+ * \ingroup memory
  * \brief Destroys the range of values
  * \tparam Iterator The iterator type of the values
  * \tparam Size The size type
@@ -535,6 +547,7 @@ destroy_n(Iterator first,
 
 
 /**
+ * \ingroup memory
  * \brief Returns the total number of allocations of a specific memory type
  * \param[in] memory_type A dynamic memory type
  * \return The total number of allocation for the given type of memory if available, 0 otherwise
@@ -544,6 +557,7 @@ get_allocation_count(dynamic_memory_type memory_type);
 
 
 /**
+ * \ingroup memory
  * \brief Returns the total number of deallocations of a specific memory type
  * \param[in] memory_type A dynamic memory type
  * \return The total number of deallocation for the given type of memory if available, 0 otherwise
@@ -553,6 +567,7 @@ get_deallocation_count(dynamic_memory_type memory_type);
 
 
 /**
+ * \ingroup memory
  * \brief Finds the size (in bytes) of the given dynamically allocated array
  * \tparam T The type of the array
  * \param[in] array An array
@@ -576,6 +591,12 @@ struct safe_pinned_host_allocator;
 struct default_allocator_traits;
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -16,6 +16,13 @@
 #ifndef STDGPU_MUTEX_H
 #define STDGPU_MUTEX_H
 
+
+/**
+ * \addtogroup mutex mutex
+ * \ingroup utilities
+ * @{
+ */
+
 /**
  * \file stdgpu/mutex.cuh
  */
@@ -222,6 +229,7 @@ class mutex_ref
 
 
 /**
+ * \ingroup mutex
  * \brief Tryies to lock all the locks at the given positions {lock1, lock2, ..., lockn} for some n >= 1
  * \param[in] lock1 The first lock
  * \param[in] lock2 The second lock
@@ -235,6 +243,12 @@ try_lock(Lockable1 lock1,
          LockableN... lockn);
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/mutex_fwd
+++ b/src/stdgpu/mutex_fwd
@@ -17,6 +17,12 @@
 #define STDGPU_MUTEX_FWD
 
 /**
+ * \addtogroup mutex mutex
+ * \ingroup utilities
+ * @{
+ */
+
+/**
  * \file stdgpu/mutex_fwd
  */
 
@@ -29,6 +35,12 @@ class mutex_ref;
 class mutex_array;
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/platform.h
+++ b/src/stdgpu/platform.h
@@ -17,6 +17,12 @@
 #define STDGPU_PLATFORM_H
 
 /**
+ * \addtogroup platform platform
+ * \ingroup system
+ * @{
+ */
+
+/**
  * \file stdgpu/platform.h
  */
 
@@ -38,19 +44,31 @@ namespace stdgpu
 {
 
 /**
+ * \ingroup platform
  * \brief Backend: CUDA
  */
 #define STDGPU_BACKEND_CUDA   100
 /**
+ * \ingroup platform
  * \brief Backend: OpenMP
  */
 #define STDGPU_BACKEND_OPENMP 101
 /**
+ * \ingroup platform
  * \brief Backend: HIP
  */
 #define STDGPU_BACKEND_HIP    102
 
 
+/**
+ * \ingroup platform
+ * \def STDGPU_BACKEND
+ * \brief Selected backend
+ */
+// Workaround: Provide a define only for the purpose of creating the documentation
+#ifdef STDGPU_RUN_DOXYGEN
+    #define STDGPU_BACKEND
+#endif
 // STDGPU_BACKEND is defined in stdgpu/config.h
 
 
@@ -67,6 +85,7 @@ namespace detail
 
 
 /**
+ * \ingroup platform
  * \def STDGPU_HOST_DEVICE
  * \brief Platform-independent host device function annotation
  */
@@ -74,6 +93,7 @@ namespace detail
 
 
 /**
+ * \ingroup platform
  * \def STDGPU_DEVICE_ONLY
  * \brief Platform-independent device function annotation
  */
@@ -81,6 +101,7 @@ namespace detail
 
 
 /**
+ * \ingroup platform
  * \def STDGPU_CONSTANT
  * \brief Platform-independent constant variable annotation
  */
@@ -88,10 +109,12 @@ namespace detail
 
 
 /**
+ * \ingroup platform
  * \brief Code path: Host
  */
 #define STDGPU_CODE_HOST   1000
 /**
+ * \ingroup platform
  * \brief Code path: Device
  */
 #define STDGPU_CODE_DEVICE 1001
@@ -108,6 +131,7 @@ namespace detail
 
 
 /**
+ * \ingroup platform
  * \def STDGPU_CODE
  * \brief The code path
  */
@@ -129,6 +153,12 @@ namespace detail
 
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/queue.cuh
+++ b/src/stdgpu/queue.cuh
@@ -17,6 +17,12 @@
 #define STDGPU_QUEUE_H
 
 /**
+ * \addtogroup queue queue
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/queue.cuh
  */
 
@@ -143,6 +149,12 @@ class queue
 };
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/queue_fwd
+++ b/src/stdgpu/queue_fwd
@@ -17,6 +17,12 @@
 #define STDGPU_QUEUE_FWD
 
 /**
+ * \addtogroup queue queue
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/queue_fwd
  */
 
@@ -32,6 +38,12 @@ template <typename T,
 class queue;
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/ranges.h
+++ b/src/stdgpu/ranges.h
@@ -17,6 +17,12 @@
 #define STDGPU_RANGES_H
 
 /**
+ * \addtogroup ranges ranges
+ * \ingroup utilities
+ * @{
+ */
+
+/**
  * \file stdgpu/ranges.h
  */
 
@@ -357,9 +363,6 @@ class transform_range
 namespace detail
 {
 
-/**
- * \brief A functor to map from indices to values. The constructor expects a pointer to type T.
- */
 template <typename T>
 class select;
 
@@ -367,6 +370,7 @@ class select;
 
 
 /**
+ * \ingroup ranges
  * \brief A class representing a device indexed range over a set of values
  * \tparam T The value type
  */
@@ -374,6 +378,7 @@ template <typename T>
 using device_indexed_range = transform_range<device_range<index_t>, detail::select<T>>;
 
 /**
+ * \ingroup ranges
  * \brief A class representing a host indexed range over a set of values
  * \tparam T The value type
  */
@@ -381,6 +386,12 @@ template <typename T>
 using host_indexed_range = transform_range<host_range<index_t>, detail::select<T>>;
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/stack.cuh
+++ b/src/stdgpu/stack.cuh
@@ -17,6 +17,12 @@
 #define STDGPU_STACK_H
 
 /**
+ * \addtogroup stack stack
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/stack.cuh
  */
 
@@ -143,6 +149,12 @@ class stack
 };
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/stack_fwd
+++ b/src/stdgpu/stack_fwd
@@ -17,6 +17,12 @@
 #define STDGPU_STACK_FWD
 
 /**
+ * \addtogroup stack stack
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/stack_fwd
  */
 
@@ -32,6 +38,12 @@ template <typename T,
 class stack;
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -17,6 +17,12 @@
 #define STDGPU_UNORDERED_MAP_H
 
 /**
+ * \addtogroup unordered_map unordered_map
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/unordered_map.cuh
  */
 
@@ -418,6 +424,12 @@ class unordered_map
 };
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/unordered_map_fwd
+++ b/src/stdgpu/unordered_map_fwd
@@ -17,6 +17,12 @@
 #define STDGPU_UNORDEREDMAP_FWD
 
 /**
+ * \addtogroup unordered_map unordered_map
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/unordered_map_fwd
  */
 
@@ -38,6 +44,12 @@ template <typename Key,
 class unordered_map;
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -17,6 +17,12 @@
 #define STDGPU_UNORDERED_SET_H
 
 /**
+ * \addtogroup unordered_set unordered_set
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/unordered_set.cuh
  */
 
@@ -406,6 +412,12 @@ class unordered_set
 };
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/unordered_set_fwd
+++ b/src/stdgpu/unordered_set_fwd
@@ -17,6 +17,12 @@
 #define STDGPU_UNORDEREDSET_FWD
 
 /**
+ * \addtogroup unordered_set unordered_set
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/unordered_set_fwd
  */
 
@@ -37,6 +43,12 @@ template <typename Key,
 class unordered_set;
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/utility.h
+++ b/src/stdgpu/utility.h
@@ -17,6 +17,12 @@
 #define STDGPU_UTILITY_H
 
 /**
+ * \addtogroup utility utility
+ * \ingroup utilities
+ * @{
+ */
+
+/**
  * \file stdgpu/utility.h
  */
 
@@ -30,6 +36,7 @@ namespace stdgpu
 {
 
 /**
+ * \ingroup utility
  * \brief Forwards a value
  * \tparam T The type of the value
  * \param[in] t A value
@@ -41,6 +48,7 @@ forward(std::remove_reference_t<T>& t) noexcept;
 
 
 /**
+ * \ingroup utility
  * \brief Forwards a value
  * \tparam T The type of the value
  * \param[in] t A value
@@ -52,6 +60,7 @@ forward(std::remove_reference_t<T>&& t) noexcept;
 
 
 /**
+ * \ingroup utility
  * \brief Moves a value
  * \tparam T The type of the value
  * \param[in] t A value
@@ -62,6 +71,12 @@ constexpr STDGPU_HOST_DEVICE std::remove_reference_t<T>&&
 move(T&& t) noexcept;
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -17,6 +17,12 @@
 #define STDGPU_VECTOR_H
 
 /**
+ * \addtogroup vector vector
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/vector.cuh
  */
 
@@ -340,6 +346,12 @@ class vector
 };
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 

--- a/src/stdgpu/vector_fwd
+++ b/src/stdgpu/vector_fwd
@@ -17,6 +17,12 @@
 #define STDGPU_VECTOR_FWD
 
 /**
+ * \addtogroup vector vector
+ * \ingroup data_structures
+ * @{
+ */
+
+/**
  * \file stdgpu/vector_fwd
  */
 
@@ -29,6 +35,12 @@ template <typename T>
 class vector;
 
 } // namespace stdgpu
+
+
+
+/**
+ * @}
+ */
 
 
 


### PR DESCRIPTION
Unfortunately, doxygen puts the documented classes and functions all together in a single list which makes it near impossible to see what functionality belongs to the same header. Group related functionality into common modules which are named after the respective header in which they are defined. Furthermore, group semantically related modules together to obtain a nice overview of the provided functionality and the core parts of the library.