### PR TITLE
README,doc: Add subdirectory READMEs and clean up documenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 <p align="center">
 <a href="#features">Features</a> |
 <a href="#examples">Examples</a> |
+<a href="#documentation">Documentation</a> |
 <a href="#getting-started">Getting Started</a> |
 <a href="#usage">Usage</a> |
 <a href="#contributing">Contributing</a> |
@@ -73,14 +74,16 @@ At its heart, stdgpu offers the following GPU data structures and containers:
 </tr>
 </table>
 
-In addition, stdgpu also provides commonly required functionality in <a href="https://stotko.github.io/stdgpu/algorithm_8h.html">`algorithm`</a>, <a href="https://stotko.github.io/stdgpu/bit_8h.html">`bit`</a>, <a href="https://stotko.github.io/stdgpu/cmath_8h.html">`cmath`</a>, <a href="https://stotko.github.io/stdgpu/contract_8h.html">`contract`</a>, <a href="https://stotko.github.io/stdgpu/cstddef_8h.html">`cstddef`</a>, <a href="https://stotko.github.io/stdgpu/cstdlib_8h.html">`cstlib`</a>, <a href="https://stotko.github.io/stdgpu/functional_8h.html">`functional`</a>, <a href="https://stotko.github.io/stdgpu/iterator_8h.html">`iterator`</a>, <a href="https://stotko.github.io/stdgpu/memory_8h.html">`memory`</a>, <a href="https://stotko.github.io/stdgpu/mutex_8cuh.html">`mutex`</a>, <a href="https://stotko.github.io/stdgpu/ranges_8h.html">`ranges`</a>, <a href="https://stotko.github.io/stdgpu/utility_8h.html">`utility`</a> to complement the GPU data structures and to increase their usability and interoperability.
+In addition, stdgpu also provides commonly required functionality in <a href="https://stotko.github.io/stdgpu/algorithm_8h.html">`algorithm`</a>, <a href="https://stotko.github.io/stdgpu/bit_8h.html">`bit`</a>, <a href="https://stotko.github.io/stdgpu/cmath_8h.html">`cmath`</a>, <a href="https://stotko.github.io/stdgpu/contract_8h.html">`contract`</a>, <a href="https://stotko.github.io/stdgpu/cstddef_8h.html">`cstddef`</a>, <a href="https://stotko.github.io/stdgpu/cstdlib_8h.html">`cstlib`</a>, <a href="https://stotko.github.io/stdgpu/functional_8h.html">`functional`</a>, <a href="https://stotko.github.io/stdgpu/iterator_8h.html">`iterator`</a>, <a href="https://stotko.github.io/stdgpu/limits_8h.html">`limits`</a>, <a href="https://stotko.github.io/stdgpu/memory_8h.html">`memory`</a>, <a href="https://stotko.github.io/stdgpu/mutex_8cuh.html">`mutex`</a>, <a href="https://stotko.github.io/stdgpu/ranges_8h.html">`ranges`</a>, <a href="https://stotko.github.io/stdgpu/utility_8h.html">`utility`</a> to complement the GPU data structures and to increase their usability and interoperability.
 
 
 ## Examples
 
-In order to reliably perform tasks on the GPU, stdgpu offers flexible interfaces that can be used in both **agnostic code**, e.g. via the algorithms provided by thrust, as well as in **native code**, e.g. custom CUDA kernels.
+In order to reliably perform complex tasks on the GPU, stdgpu offers flexible interfaces that can be used in both **agnostic code**, e.g. via the algorithms provided by thrust, as well as in **native code**, e.g. in custom CUDA kernels.
 
-<b>Agnostic code</b>. In the context of the SLAMCast live telepresence system, a simple task is the integration of a range of updated blocks into the duplicate-free set of queued blocks for streaming which can be expressed very conveniently:
+For instance, stdgpu is extensively used in <a href="https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence">SLAMCast</a>, a scalable live telepresence system, to implement real-time, large-scale 3D scene reconstruction as well as real-time 3D data streaming between a server and an arbitrary number of remote clients.
+
+<b>Agnostic code</b>. In the context of <a href="https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence">SLAMCast</a>, a simple task is the integration of a range of updated blocks into the duplicate-free set of queued blocks for data streaming which can be expressed very conveniently:
 
 ```cpp
 #include <stdgpu/cstddef.h>             // stdgpu::index_t
@@ -106,7 +109,7 @@ private:
 };
 ```
 
-<b>Native code</b>. More complex operations such as the creation of the update set or other complex algorithms can be implemented natively, e.g. in custom CUDA kernels with stdgpu's CUDA backend enabled:
+<b>Native code</b>. More complex operations such as the creation of the duplicate-free set of updated blocks or other algorithms can be implemented natively, e.g. in custom CUDA kernels with stdgpu's CUDA backend enabled:
 
 ```cpp
 #include <stdgpu/cstddef.h>             // stdgpu::index_t
@@ -150,6 +153,11 @@ compute_update_set(const short3* blocks,
 ```
 
 More examples can be found in the <a href="https://github.com/stotko/stdgpu/tree/master/examples">`examples`</a> directory.
+
+
+## Documentation
+
+A comprehensive API documentation of stdgpu can be found at <a href="https://stotko.github.io/stdgpu">https://stotko.github.io/stdgpu</a>.
 
 
 ## Getting Started
@@ -293,13 +301,13 @@ For detailed information on how to contribute, see <a href="https://github.com/s
 
 Distributed under the Apache 2.0 License. See <a href="https://github.com/stotko/stdgpu/blob/master/LICENSE">`LICENSE`</a> for more information.
 
-stdgpu has been developed as part of the SLAMCast live telepresence system which performs real-time, large-scale 3D scene reconstruction from RGB-D camera images as well as real-time data streaming between a server and an arbitrary number of remote clients.
-
 If you use stdgpu in one of your projects, please cite the following publications:
+
+<a style="font-weight:bold" href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">stdgpu: Efficient STL-like Data Structures on the GPU</a>
 
 ```
 @UNPUBLISHED{stotko2019stdgpu,
-    author = {Stotko, Patrick},
+    author = {Stotko, P.},
      title = {{stdgpu: Efficient STL-like Data Structures on the GPU}},
       year = {2019},
      month = aug,
@@ -307,6 +315,8 @@ If you use stdgpu in one of your projects, please cite the following publication
        url = {https://arxiv.org/abs/1908.05936}
 }
 ```
+
+<a style="font-weight:bold" href="https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence">SLAMCast: Large-Scale, Real-Time 3D Reconstruction and Streaming for Immersive Multi-Client Live Telepresence</a>
 
 ```
 @article{stotko2019slamcast,
@@ -316,7 +326,8 @@ If you use stdgpu in one of your projects, please cite the following publication
     volume = {25},
     number = {5},
      pages = {2102--2112},
-      year = {2019}
+      year = {2019},
+     month = may
 }
 ```
 

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1446,7 +1446,7 @@ GENERATE_TREEVIEW      = YES
 # Minimum value: 0, maximum value: 20, default value: 4.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-ENUM_VALUES_PER_LINE   = 4
+ENUM_VALUES_PER_LINE   = 0
 
 # If the treeview is enabled (see GENERATE_TREEVIEW) then this tag can be used
 # to set the initial width (in pixels) of the frame in which the tree is shown.

--- a/doc/DoxygenLayout.xml
+++ b/doc/DoxygenLayout.xml
@@ -5,21 +5,27 @@
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="pages" visible="yes" title="" intro=""/>
     <tab type="modules" visible="yes" title="" intro=""/>
-    <tab type="namespaces" visible="yes" title="">
-      <tab type="namespacelist" visible="yes" title="" intro=""/>
-      <tab type="namespacemembers" visible="yes" title="" intro=""/>
+    <tab type="namespaces" visible="no" title="">
+      <tab type="namespacelist" visible="no" title="" intro=""/>
+      <tab type="namespacemembers" visible="no" title="" intro=""/>
     </tab>
+    <!--
     <tab type="classes" visible="yes" title="">
       <tab type="classlist" visible="yes" title="" intro=""/>
-      <tab type="classindex" visible="$ALPHABETICAL_INDEX" title=""/> 
-      <tab type="hierarchy" visible="yes" title="" intro=""/>
-      <tab type="classmembers" visible="yes" title="" intro=""/>
+      <tab type="classindex" visible="$ALPHABETICAL_INDEX" title=""/>
+      <tab type="hierarchy" visible="no" title="" intro=""/>
+      <tab type="classmembers" visible="no" title="" intro=""/>
     </tab>
+    -->
+    <tab type="classlist" visible="yes" title="" intro=""/>
+    <!--
     <tab type="files" visible="yes" title="">
       <tab type="filelist" visible="yes" title="" intro=""/>
       <tab type="globals" visible="yes" title="" intro=""/>
     </tab>
-    <tab type="examples" visible="yes" title="" intro=""/>  
+    -->
+    <tab type="filelist" visible="yes" title="" intro=""/>
+    <tab type="examples" visible="yes" title="" intro=""/>
   </navindex>
 
   <!-- Layout definition for a class page -->
@@ -138,7 +144,7 @@
   <!-- Layout definition for a group page -->
   <group>
     <briefdescription visible="no"/>
-    <detaileddescription title="Description"/>
+    <detaileddescription visible="no" title="Description"/>
     <groupgraph visible="$GROUP_GRAPHS"/>
     <memberdecl>
       <nestedgroups visible="yes" title=""/>

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,3 @@
+## Documentation
+
+A comprehensive API documentation of stdgpu can be found at <a href="https://stotko.github.io/stdgpu">https://stotko.github.io/stdgpu</a>.

--- a/doc/stdgpu/chapters.doxy
+++ b/doc/stdgpu/chapters.doxy
@@ -2,7 +2,7 @@
 
 \page chapters Chapters
 
-Here is a list of all modules:
+Here is a list of all chapters:
 
 - \subpage memory
 - \subpage iterator

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -28,14 +28,16 @@ At its heart, stdgpu offers the following GPU data structures and containers:
 </tr>
 </table>
 
-In addition, stdgpu also provides commonly required functionality in <a href="https://stotko.github.io/stdgpu/algorithm_8h.html">`algorithm`</a>, <a href="https://stotko.github.io/stdgpu/bit_8h.html">`bit`</a>, <a href="https://stotko.github.io/stdgpu/cmath_8h.html">`cmath`</a>, <a href="https://stotko.github.io/stdgpu/contract_8h.html">`contract`</a>, <a href="https://stotko.github.io/stdgpu/cstddef_8h.html">`cstddef`</a>, <a href="https://stotko.github.io/stdgpu/cstdlib_8h.html">`cstlib`</a>, <a href="https://stotko.github.io/stdgpu/functional_8h.html">`functional`</a>, <a href="https://stotko.github.io/stdgpu/iterator_8h.html">`iterator`</a>, <a href="https://stotko.github.io/stdgpu/memory_8h.html">`memory`</a>, <a href="https://stotko.github.io/stdgpu/mutex_8cuh.html">`mutex`</a>, <a href="https://stotko.github.io/stdgpu/ranges_8h.html">`ranges`</a>, <a href="https://stotko.github.io/stdgpu/utility_8h.html">`utility`</a> to complement the GPU data structures and to increase their usability and interoperability.
+In addition, stdgpu also provides commonly required functionality in <a href="https://stotko.github.io/stdgpu/algorithm_8h.html">`algorithm`</a>, <a href="https://stotko.github.io/stdgpu/bit_8h.html">`bit`</a>, <a href="https://stotko.github.io/stdgpu/cmath_8h.html">`cmath`</a>, <a href="https://stotko.github.io/stdgpu/contract_8h.html">`contract`</a>, <a href="https://stotko.github.io/stdgpu/cstddef_8h.html">`cstddef`</a>, <a href="https://stotko.github.io/stdgpu/cstdlib_8h.html">`cstlib`</a>, <a href="https://stotko.github.io/stdgpu/functional_8h.html">`functional`</a>, <a href="https://stotko.github.io/stdgpu/iterator_8h.html">`iterator`</a>, <a href="https://stotko.github.io/stdgpu/limits_8h.html">`limits`</a>, <a href="https://stotko.github.io/stdgpu/memory_8h.html">`memory`</a>, <a href="https://stotko.github.io/stdgpu/mutex_8cuh.html">`mutex`</a>, <a href="https://stotko.github.io/stdgpu/ranges_8h.html">`ranges`</a>, <a href="https://stotko.github.io/stdgpu/utility_8h.html">`utility`</a> to complement the GPU data structures and to increase their usability and interoperability.
 
 
 \section examples Examples
 
-In order to reliably perform tasks on the GPU, stdgpu offers flexible interfaces that can be used in both **agnostic code**, e.g. via the algorithms provided by thrust, as well as in **native code**, e.g. custom CUDA kernels.
+In order to reliably perform complex tasks on the GPU, stdgpu offers flexible interfaces that can be used in both **agnostic code**, e.g. via the algorithms provided by thrust, as well as in **native code**, e.g. in custom CUDA kernels.
 
-<b>Agnostic code</b>. In the context of the SLAMCast live telepresence system, a simple task is the integration of a range of updated blocks into the duplicate-free set of queued blocks for streaming which can be expressed very conveniently:
+For instance, stdgpu is extensively used in <a href="https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence">SLAMCast</a>, a scalable live telepresence system, to implement real-time, large-scale 3D scene reconstruction as well as real-time 3D data streaming between a server and an arbitrary number of remote clients.
+
+<b>Agnostic code</b>. In the context of <a href="https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence">SLAMCast</a>, a simple task is the integration of a range of updated blocks into the duplicate-free set of queued blocks for data streaming which can be expressed very conveniently:
 
 \code{.cpp}
 #include <stdgpu/cstddef.h>             // stdgpu::index_t
@@ -61,7 +63,7 @@ private:
 };
 \endcode
 
-<b>Native code</b>. More complex operations such as the creation of the update set or other complex algorithms can be implemented natively, e.g. in custom CUDA kernels with stdgpu's CUDA backend enabled:
+<b>Native code</b>. More complex operations such as the creation of the duplicate-free set of updated blocks or other algorithms can be implemented natively, e.g. in custom CUDA kernels with stdgpu's CUDA backend enabled:
 
 \code{.cpp}
 #include <stdgpu/cstddef.h>             // stdgpu::index_t
@@ -105,6 +107,11 @@ compute_update_set(const short3* blocks,
 \endcode
 
 More examples can be found in the <a href="https://github.com/stotko/stdgpu/tree/master/examples">`examples`</a> directory.
+
+
+\section documentation Documentation
+
+A comprehensive API documentation of stdgpu can be found at <a href="https://stotko.github.io/stdgpu">https://stotko.github.io/stdgpu</a>.
 
 
 \section getting-started Getting Started
@@ -248,13 +255,13 @@ For detailed information on how to contribute, see <a href="https://github.com/s
 
 Distributed under the Apache 2.0 License. See <a href="https://github.com/stotko/stdgpu/blob/master/LICENSE">`LICENSE`</a> for more information.
 
-stdgpu has been developed as part of the SLAMCast live telepresence system which performs real-time, large-scale 3D scene reconstruction from RGB-D camera images as well as real-time data streaming between a server and an arbitrary number of remote clients.
-
 If you use stdgpu in one of your projects, please cite the following publications:
+
+<a style="font-weight:bold" href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">stdgpu: Efficient STL-like Data Structures on the GPU</a>
 
 \code{.bib}
 @UNPUBLISHED{stotko2019stdgpu,
-    author = {Stotko, Patrick},
+    author = {Stotko, P.},
      title = {{stdgpu: Efficient STL-like Data Structures on the GPU}},
       year = {2019},
      month = aug,
@@ -262,6 +269,8 @@ If you use stdgpu in one of your projects, please cite the following publication
        url = {https://arxiv.org/abs/1908.05936}
 }
 \endcode
+
+<a style="font-weight:bold" href="https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence">SLAMCast: Large-Scale, Real-Time 3D Reconstruction and Streaming for Immersive Multi-Client Live Telepresence</a>
 
 \code{.bib}
 @article{stotko2019slamcast,
@@ -271,7 +280,8 @@ If you use stdgpu in one of your projects, please cite the following publication
     volume = {25},
     number = {5},
      pages = {2102--2112},
-      year = {2019}
+      year = {2019},
+     month = may
 }
 \endcode
 

--- a/doc/style.css
+++ b/doc/style.css
@@ -2,7 +2,7 @@ body
 {
     background-color: #EBEBF0;
     color: black;
-    margin: 0;
+    margin: 0px;
 }
 
 
@@ -10,14 +10,15 @@ div.contents
 {
     text-align: justify;
     margin-top: 0px;
-    margin-bottom: 10px;
+    margin-bottom: 0px;
     padding-left: 20px;
     padding-right: 20px;
     padding-top: 5px;
     padding-bottom: 5px;
     margin-left: auto;
     margin-right: auto;
-    width: 1280px;
+    min-height: calc(100vh - 173px);
+    max-width: 1280px;
     background-color: white;
 }
 
@@ -27,7 +28,7 @@ div.header
     background-image: none;
     margin-left: auto;
     margin-right: auto;
-    width: 1280px;
+    max-width: 1280px;
     padding-left: 20px;
     padding-right: 20px;
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+## Examples
+
+This directory contains several examples demonstrating how stdgpu can be used. In particular, the examples can be divided into two classes:
+
+- **Host code with device support**. Examples that can be compiled and run by both the *host and device compiler* are put into this directory. This includes most of the functionality that complements the GPU data structures and containers.
+
+- **Device only code**. Since all GPU data structures and containers can be used in *native* code to cover as many use cases as possible, e.g. in custom CUDA kernels, the respective examples must be compiled by the *device compiler*. This requires knowledge about the chosen backend, so they are put into backend-specific subdirectories.


### PR DESCRIPTION
Although the documentation is linked at GitHub, these links are not easily discoverable in the `README`. Furthermore, users might look into `doc/` to find the documentation which, however, will be a dead end. Add a dedicated section in the `README` to point at the documentation and create a local `README` in `doc/` with the same section content. Furthermore, create a local `README` in `examples/` as well to explain the structure and requirements of the examples. Finally, clean up the documentation style and remove unintuitive doxygen pages.