### PR TITLE
platform: Change detection of device code for OpenMP

### DIFF
--- a/src/stdgpu/contract.h
+++ b/src/stdgpu/contract.h
@@ -84,7 +84,7 @@ namespace stdgpu
     #if STDGPU_BACKEND == STDGPU_BACKEND_HIP
         #define STDGPU_DETAIL_WORKAROUND_ASSERT(condition) STDGPU_DETAIL_EMPTY_STATEMENT
     #else
-        #define STDGPU_DETAIL_WORKAROUND_ASSERT(condition) assert(condition)
+        #define STDGPU_DETAIL_WORKAROUND_ASSERT(condition) assert(condition) // NOLINT(hicpp-no-array-decay)
     #endif
 
     #define STDGPU_DETAIL_DEVICE_EXPECTS(condition) STDGPU_DETAIL_WORKAROUND_ASSERT(condition)

--- a/src/stdgpu/openmp/platform.h
+++ b/src/stdgpu/openmp/platform.h
@@ -48,7 +48,7 @@ namespace openmp
  * \def STDGPU_OPENMP_IS_DEVICE_CODE
  * \brief Platform-independent device code detection
  */
-#define STDGPU_OPENMP_IS_DEVICE_CODE 0
+#define STDGPU_OPENMP_IS_DEVICE_CODE 1
 
 
 /**

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -1371,23 +1371,17 @@ namespace
             static int constructor_calls;
             static int destructor_calls;
 
-            STDGPU_HOST_DEVICE
             Counter()
             {
-                #if STDGPU_CODE == STDGPU_CODE_HOST
-                    Counter::constructor_calls++;
-                #endif
+                Counter::constructor_calls++;
 
                 // Suppress unused member warning
                 x = 0;
             }
 
-            STDGPU_HOST_DEVICE
             ~Counter()
             {
-                #if STDGPU_CODE == STDGPU_CODE_HOST
-                    Counter::destructor_calls++;
-                #endif
+                Counter::destructor_calls++;
 
                 // Suppress unused member warning
                 x = 0;


### PR DESCRIPTION
For the OpenMP backend, the `platform` macros currently always report code to be `STDGPU_CODE_HOST`. Since some `STDGPU_HOST_DEVICE` annotated function may use different paths for host and device code and the device path may contain backend-specific optimizations, this choice will lead to backend-specific code being ignored.

Change the detection code to always report `STDGPU_CODE_DEVICE` rather than `STDGPU_CODE_HOST`. Note that for such functions using different code paths, these paths should result in equivalent behavior anyways.