### PR TITLE
atomic: Make all operations follow sequentially consistent ordering

### DIFF
--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -59,7 +59,7 @@ namespace stdgpu
  * Differences to std::atomic:
  *  - Atomics must be modeled as containers since threads have to operate on the exact same object (which also requires copy and move constructors)
  *  - Manual allocation and destruction of container required
- *  - load and store are not atomically safe
+ *  - All operations (including load() and store()) explicitly follow sequentially consistent ordering
  *  - Additional min and max functions for all supported integer and floating point types
  *  - Additional increment/decrement + modulo functions for unsigned int
  */
@@ -100,37 +100,33 @@ class atomic
 
 
         /**
-         * \brief Loads and returns the current value of the atomic object
+         * \brief Atomically loads and returns the current value of the atomic object
          * \return The current value of this object
-         * \note This operation is not atomically safe
          */
         STDGPU_HOST_DEVICE T
         load() const;
 
 
         /**
-         * \brief Loads and returns the current value of the atomic object
+         * \brief Atomically loads and returns the current value of the atomic object
          * \return The current value of this object
-         * \note Equivalent to load()
          */
         STDGPU_HOST_DEVICE
         operator T() const; // NOLINT(hicpp-explicit-conversions)
 
 
         /**
-         * \brief Replaces the current value with desired
+         * \brief Atomically replaces the current value with desired one
          * \param[in] desired The value to store to the atomic object
-         * \note This operation is not atomically safe
          */
         STDGPU_HOST_DEVICE void
         store(const T desired);
 
 
         /**
-         * \brief Replaces the current value with desired
+         * \brief Atomically replaces the current value with desired one
          * \param[in] desired The value to store to the atomic object
          * \return The desired value
-         * \note Equivalent to store()
          */
         STDGPU_HOST_DEVICE T //NOLINT(misc-unconventional-assign-operator)
         operator=(const T desired);

--- a/src/stdgpu/cuda/atomic.cuh
+++ b/src/stdgpu/cuda/atomic.cuh
@@ -28,6 +28,25 @@ namespace cuda
 {
 
 /**
+ * \brief Atomically loads and returns the current value of the atomic object
+ * \param[in] address A pointer to a value
+ * \return The current value of this object
+ */
+template <typename T>
+STDGPU_DEVICE_ONLY T
+atomic_load(T* address);
+
+/**
+ * \brief Atomically replaces the current value with desired one
+ * \param[in] address A pointer to a value
+ * \param[in] desired The value to store to the atomic object
+ */
+template <typename T>
+STDGPU_DEVICE_ONLY void
+atomic_store(T* address,
+             const T desired);
+
+/**
  * \brief Atomically exchanges the stored value with the given argument
  * \param[in] address A pointer to a value
  * \param[in] desired The desired argument to store

--- a/src/stdgpu/cuda/impl/atomic_detail.cuh
+++ b/src/stdgpu/cuda/impl/atomic_detail.cuh
@@ -17,7 +17,6 @@
 #define STDGPU_CUDA_ATOMIC_DETAIL_H
 
 #include <stdgpu/algorithm.h>
-#include <stdgpu/contract.h>
 #include <stdgpu/limits.h>
 #include <stdgpu/platform.h>
 
@@ -49,7 +48,7 @@ atomicMin(float* address,
     do
     {
         assumed = old;
-        old = atomicCAS(address_as_int, assumed, __float_as_int( fminf(__int_as_float(assumed), value) ));
+        old = atomicCAS(address_as_int, assumed, __float_as_int( stdgpu::min<float>(__int_as_float(assumed), value) ));
 
     // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
     }
@@ -69,7 +68,7 @@ atomicMax(float* address,
     do
     {
         assumed = old;
-        old = atomicCAS(address_as_int, assumed, __float_as_int( fmaxf(__int_as_float(assumed), value) ));
+        old = atomicCAS(address_as_int, assumed, __float_as_int( stdgpu::max<float>(__int_as_float(assumed), value) ));
 
     // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
     }
@@ -179,12 +178,47 @@ namespace stdgpu
 namespace cuda
 {
 
+template <typename T>
+STDGPU_DEVICE_ONLY T
+atomic_load(T* address)
+{
+    __threadfence();
+
+    volatile T* volatile_address = address;
+    T current = *volatile_address;
+
+    __threadfence();
+
+    return current;
+}
+
+
+template <typename T>
+STDGPU_DEVICE_ONLY void
+atomic_store(T* address,
+             const T desired)
+{
+    __threadfence();
+
+    volatile T* volatile_address = address;
+    *volatile_address = desired;
+
+    __threadfence();
+}
+
+
 template <typename T, typename>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired)
 {
-    return atomicExch(address, desired);
+    __threadfence();
+
+    T old = atomicExch(address, desired);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -194,7 +228,13 @@ atomic_compare_exchange(T* address,
                         const T expected,
                         const T desired)
 {
-    return atomicCAS(address, expected, desired);
+    __threadfence();
+
+    T old = atomicCAS(address, expected, desired);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -203,7 +243,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg)
 {
-    return atomicAdd(address, arg);
+    __threadfence();
+
+    T old = atomicAdd(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -212,7 +258,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg)
 {
-    return atomicSub(address, arg);
+    __threadfence();
+
+    T old = atomicSub(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -221,7 +273,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg)
 {
-    return atomicAnd(address, arg);
+    __threadfence();
+
+    T old = atomicAnd(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -230,7 +288,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg)
 {
-    return atomicOr(address, arg);
+    __threadfence();
+
+    T old = atomicOr(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -239,7 +303,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg)
 {
-    return atomicXor(address, arg);
+    __threadfence();
+
+    T old = atomicXor(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -248,7 +318,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg)
 {
-    return atomicMin(address, arg);
+    __threadfence();
+
+    T old = atomicMin(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -257,7 +333,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg)
 {
-    return atomicMax(address, arg);
+    __threadfence();
+
+    T old = atomicMax(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -266,7 +348,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg)
 {
-    return atomicInc(address, arg);
+    __threadfence();
+
+    T old = atomicInc(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -275,7 +363,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg)
 {
-    return atomicDec(address, arg);
+    __threadfence();
+
+    T old = atomicDec(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 } // namespace cuda

--- a/src/stdgpu/hip/atomic.h
+++ b/src/stdgpu/hip/atomic.h
@@ -28,6 +28,25 @@ namespace hip
 {
 
 /**
+ * \brief Atomically loads and returns the current value of the atomic object
+ * \param[in] address A pointer to a value
+ * \return The current value of this object
+ */
+template <typename T>
+STDGPU_DEVICE_ONLY T
+atomic_load(T* address);
+
+/**
+ * \brief Atomically replaces the current value with desired one
+ * \param[in] address A pointer to a value
+ * \param[in] desired The value to store to the atomic object
+ */
+template <typename T>
+STDGPU_DEVICE_ONLY void
+atomic_store(T* address,
+             const T desired);
+
+/**
  * \brief Atomically exchanges the stored value with the given argument
  * \param[in] address A pointer to a value
  * \param[in] desired The desired argument to store

--- a/src/stdgpu/hip/impl/atomic_detail.h
+++ b/src/stdgpu/hip/impl/atomic_detail.h
@@ -16,7 +16,7 @@
 #ifndef STDGPU_HIP_ATOMIC_DETAIL_H
 #define STDGPU_HIP_ATOMIC_DETAIL_H
 
-#include <stdgpu/contract.h>
+#include <stdgpu/algorithm.h>
 #include <stdgpu/limits.h>
 #include <stdgpu/platform.h>
 
@@ -48,7 +48,7 @@ atomicMin(float* address,
     do
     {
         assumed = old;
-        old = atomicCAS(address_as_int, assumed, __float_as_int( fminf(__int_as_float(assumed), value) ));
+        old = atomicCAS(address_as_int, assumed, __float_as_int( stdgpu::min<float>(__int_as_float(assumed), value) ));
 
     // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
     }
@@ -68,7 +68,7 @@ atomicMax(float* address,
     do
     {
         assumed = old;
-        old = atomicCAS(address_as_int, assumed, __float_as_int( fmaxf(__int_as_float(assumed), value) ));
+        old = atomicCAS(address_as_int, assumed, __float_as_int( stdgpu::max<float>(__int_as_float(assumed), value) ));
 
     // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
     }
@@ -84,12 +84,47 @@ namespace stdgpu
 namespace hip
 {
 
+template <typename T>
+STDGPU_DEVICE_ONLY T
+atomic_load(T* address)
+{
+    __threadfence();
+
+    volatile T* volatile_address = address;
+    T current = *volatile_address;
+
+    __threadfence();
+
+    return current;
+}
+
+
+template <typename T>
+STDGPU_DEVICE_ONLY void
+atomic_store(T* address,
+             const T desired)
+{
+    __threadfence();
+
+    volatile T* volatile_address = address;
+    *volatile_address = desired;
+
+    __threadfence();
+}
+
+
 template <typename T, typename>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired)
 {
-    return atomicExch(address, desired);
+    __threadfence();
+
+    T old = atomicExch(address, desired);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -99,7 +134,13 @@ atomic_compare_exchange(T* address,
                         const T expected,
                         const T desired)
 {
-    return atomicCAS(address, expected, desired);
+    __threadfence();
+
+    T old = atomicCAS(address, expected, desired);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -108,7 +149,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg)
 {
-    return atomicAdd(address, arg);
+    __threadfence();
+
+    T old = atomicAdd(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -117,7 +164,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg)
 {
-    return atomicSub(address, arg);
+    __threadfence();
+
+    T old = atomicSub(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -126,7 +179,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg)
 {
-    return atomicAnd(address, arg);
+    __threadfence();
+
+    T old = atomicAnd(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -135,7 +194,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg)
 {
-    return atomicOr(address, arg);
+    __threadfence();
+
+    T old = atomicOr(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -144,7 +209,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg)
 {
-    return atomicXor(address, arg);
+    __threadfence();
+
+    T old = atomicXor(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -153,7 +224,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg)
 {
-    return atomicMin(address, arg);
+    __threadfence();
+
+    T old = atomicMin(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -162,7 +239,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg)
 {
-    return atomicMax(address, arg);
+    __threadfence();
+
+    T old = atomicMax(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -171,7 +254,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg)
 {
-    return atomicInc(address, arg);
+    __threadfence();
+
+    T old = atomicInc(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 
@@ -180,7 +269,13 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg)
 {
-    return atomicDec(address, arg);
+    __threadfence();
+
+    T old = atomicDec(address, arg);
+
+    __threadfence();
+
+    return old;
 }
 
 } // namespace hip

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -324,7 +324,7 @@ atomic_ref<T>::load() const
 
     T local_value;
     #if STDGPU_CODE == STDGPU_CODE_DEVICE
-        local_value = *(_value);
+        local_value = stdgpu::STDGPU_BACKEND_NAMESPACE::atomic_load(_value);
     #else
         copyDevice2HostArray<T>(_value, 1, &local_value, MemoryCopy::NO_CHECK);
     #endif
@@ -351,7 +351,7 @@ atomic_ref<T>::store(const T desired)
     }
 
     #if STDGPU_CODE == STDGPU_CODE_DEVICE
-        *(_value) = desired;
+        stdgpu::STDGPU_BACKEND_NAMESPACE::atomic_store(_value, desired);
     #else
         copyHost2DeviceArray<T>(&desired, 1, _value, MemoryCopy::NO_CHECK);
     #endif

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -76,7 +76,8 @@ bitset::reference::operator=(const reference& x)
 inline STDGPU_DEVICE_ONLY
 bitset::reference::operator bool() const
 {
-    return bit(*_bit_block, _bit_n);
+    stdgpu::atomic_ref<block_type> bit_block(*_bit_block);
+    return bit(bit_block.load(), _bit_n);
 }
 
 

--- a/src/stdgpu/openmp/atomic.h
+++ b/src/stdgpu/openmp/atomic.h
@@ -28,6 +28,25 @@ namespace openmp
 {
 
 /**
+ * \brief Atomically loads and returns the current value of the atomic object
+ * \param[in] address A pointer to a value
+ * \return The current value of this object
+ */
+template <typename T>
+STDGPU_DEVICE_ONLY T
+atomic_load(T* address);
+
+/**
+ * \brief Atomically replaces the current value with desired one
+ * \param[in] address A pointer to a value
+ * \param[in] desired The value to store to the atomic object
+ */
+template <typename T>
+STDGPU_DEVICE_ONLY void
+atomic_store(T* address,
+             const T desired);
+
+/**
  * \brief Atomically exchanges the stored value with the given argument
  * \param[in] address A pointer to a value
  * \param[in] desired The desired argument to store

--- a/src/stdgpu/openmp/impl/atomic_detail.h
+++ b/src/stdgpu/openmp/impl/atomic_detail.h
@@ -18,8 +18,6 @@
 
 #include <algorithm>
 
-#include <stdgpu/contract.h>
-#include <stdgpu/limits.h>
 #include <stdgpu/platform.h>
 
 
@@ -30,17 +28,56 @@ namespace stdgpu
 namespace openmp
 {
 
+template <typename T>
+STDGPU_DEVICE_ONLY T
+atomic_load(T* address)
+{
+    // Implicit flush due to omp critical
+
+    T current;
+    #pragma omp critical
+    {
+        current = *address;
+    }
+
+    // Implicit flush due to omp critical
+
+    return current;
+}
+
+
+template <typename T>
+STDGPU_DEVICE_ONLY void
+atomic_store(T* address,
+             const T desired)
+{
+    // Implicit flush due to omp critical
+
+    #pragma omp critical
+    {
+        *address = desired;
+    }
+
+    // Implicit flush due to omp critical
+}
+
+
 template <typename T, typename>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired)
 {
+    // Implicit flush due to omp critical
+
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = desired;
     }
+
+    // Implicit flush due to omp critical
+
     return old;
 }
 
@@ -51,12 +88,17 @@ atomic_compare_exchange(T* address,
                         const T expected,
                         const T desired)
 {
+    // Implicit flush due to omp critical
+
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = (old == expected) ? desired : old;
     }
+
+    // Implicit flush due to omp critical
+
     return old;
 }
 
@@ -66,12 +108,17 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg)
 {
+    // Implicit flush due to omp critical
+
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = old + arg;
     }
+
+    // Implicit flush due to omp critical
+
     return old;
 }
 
@@ -81,12 +128,17 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg)
 {
+    // Implicit flush due to omp critical
+
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = old - arg;
     }
+
+    // Implicit flush due to omp critical
+
     return old;
 }
 
@@ -96,12 +148,17 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg)
 {
+    // Implicit flush due to omp critical
+
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = old & arg; // NOLINT(hicpp-signed-bitwise)
     }
+
+    // Implicit flush due to omp critical
+
     return old;
 }
 
@@ -111,12 +168,17 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg)
 {
+    // Implicit flush due to omp critical
+
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = old | arg; // NOLINT(hicpp-signed-bitwise)
     }
+
+    // Implicit flush due to omp critical
+
     return old;
 }
 
@@ -126,12 +188,17 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg)
 {
+    // Implicit flush due to omp critical
+
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = old ^ arg; // NOLINT(hicpp-signed-bitwise)
     }
+
+    // Implicit flush due to omp critical
+
     return old;
 }
 
@@ -141,12 +208,17 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg)
 {
+    // Implicit flush due to omp critical
+
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = std::min(old, arg);
     }
+
+    // Implicit flush due to omp critical
+
     return old;
 }
 
@@ -156,12 +228,17 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg)
 {
+    // Implicit flush due to omp critical
+
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = std::max(old, arg);
     }
+
+    // Implicit flush due to omp critical
+
     return old;
 }
 
@@ -171,12 +248,17 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg)
 {
+    // Implicit flush due to omp critical
+
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = (old >= arg) ? T(0) : old + T(1);
     }
+
+    // Implicit flush due to omp critical
+
     return old;
 }
 
@@ -186,12 +268,17 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg)
 {
+    // Implicit flush due to omp critical
+
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = (old == T(0) || old > arg) ? arg : old - T(1);
     }
+
+    // Implicit flush due to omp critical
+
     return old;
 }
 


### PR DESCRIPTION
Up to now, `atomic` and `atomic_ref` do not specify the memory order that they will enforce. In the C++ standard library, the default memory order for calls to them is sequential consistency, so users will assume that stdgpu also enforces this order. However, we did not explicitly enforced this which might lead to runtime errors or dead locks. Explicitly make all atomic member functions, including `load()` and `store()` follow sequentially consistent ordering to ensure consistency with the C++ standard library.