### PR TITLE
limits: Suppress long double device code warning with MSVC

### DIFF
--- a/src/stdgpu/impl/limits_detail.h
+++ b/src/stdgpu/impl/limits_detail.h
@@ -21,6 +21,8 @@
 #include <cmath>
 #include <cstdint>
 
+#include <stdgpu/compiler.h>
+
 
 
 namespace stdgpu
@@ -749,7 +751,12 @@ numeric_limits<long double>::round_error() noexcept
 constexpr STDGPU_HOST_DEVICE long double
 numeric_limits<long double>::infinity() noexcept
 {
-    return HUGE_VALL;
+    // Suppress long double is treated as double in device code warning for MSVC on CUDA
+    #if STDGPU_HOST_COMPILER == STDGPU_HOST_COMPILER_MSVC
+        return HUGE_VAL;
+    #else
+        return HUGE_VALL;
+    #endif
 }
 
 } // namespace stdgpu


### PR DESCRIPTION
The probably last long-standing warning is thrown by MSVC with the CUDA backend enabled stating that long double will be treated as double in device code. This is caused by MSVC's implementation of `HUGE_VALL` which is expands to `(long double)INFINITY`. Suppress this warning by using `HUGE_VAL` for MSVC instead which avoids explicitly casting to `long double`.