### PR TITLE
cmake: Fix error with unspecified build type

### DIFF
--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -12,7 +12,7 @@ find_dependency(thrust 1.9.2 REQUIRED MODULE)
 
 
 # Setup library options and config file
-if(${CMAKE_BUILD_TYPE} MATCHES "Release" OR ${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
+if(CMAKE_BUILD_TYPE MATCHES "Release" OR CMAKE_BUILD_TYPE MATCHES "MinSizeRel")
     set(STDGPU_ENABLE_CONTRACT_CHECKS_DEFAULT OFF)
 else()
     set(STDGPU_ENABLE_CONTRACT_CHECKS_DEFAULT ON)


### PR DESCRIPTION
In case `CMAKE_BUILD_TYPE` is not set by the user, expanding this variable will result in collapsing it in an expression and causing configuration errors in `if` clauses. Fix such an error by using the variable rather than its expanded value.