### PR TITLE
cmake: Make installable package relocatable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ add_subdirectory(doc)
 # Install exported targets and cmake files
 install(EXPORT stdgpu-targets
         NAMESPACE stdgpu::
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${STDGPU_CMAKE_INSTALL_DIR}"
+        DESTINATION "${STDGPU_CMAKE_INSTALL_DIR}"
         COMPONENT stdgpu)
 
 include(CMakePackageConfigHelpers)
@@ -116,7 +116,7 @@ write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/stdgpu-config-vers
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/stdgpu-config.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/stdgpu-config-version.cmake"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${STDGPU_CMAKE_INSTALL_DIR}"
+        DESTINATION "${STDGPU_CMAKE_INSTALL_DIR}"
         COMPONENT stdgpu)
 
 

--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -72,11 +72,11 @@ add_subdirectory(${STDGPU_BACKEND_DIRECTORY})
 # Export targets and install header files
 install(TARGETS stdgpu
         EXPORT stdgpu-targets
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${STDGPU_LIB_INSTALL_DIR}"
+        DESTINATION "${STDGPU_LIB_INSTALL_DIR}"
         COMPONENT stdgpu)
 
 install(DIRECTORY "${STDGPU_INCLUDE_LOCAL_DIR}/" "${STDGPU_BUILD_INCLUDE_DIR}/"
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/${STDGPU_INCLUDE_INSTALL_DIR}
+        DESTINATION "${STDGPU_INCLUDE_INSTALL_DIR}"
         COMPONENT stdgpu
         FILES_MATCHING
         PATTERN "*.h"
@@ -89,9 +89,9 @@ configure_file("${stdgpu_SOURCE_DIR}/cmake/stdgpu-dependencies.cmake.in"
                @ONLY)
 
 install(FILES "${STDGPU_BUILD_CMAKE_DIR}/stdgpu-dependencies.cmake"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${STDGPU_CMAKE_INSTALL_DIR}"
+        DESTINATION "${STDGPU_CMAKE_INSTALL_DIR}"
         COMPONENT stdgpu)
 
 install(FILES "${stdgpu_SOURCE_DIR}/cmake/Findthrust.cmake"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${STDGPU_CMAKE_INSTALL_DIR}"
+        DESTINATION "${STDGPU_CMAKE_INSTALL_DIR}"
         COMPONENT stdgpu)

--- a/src/stdgpu/cuda/CMakeLists.txt
+++ b/src/stdgpu/cuda/CMakeLists.txt
@@ -16,5 +16,5 @@ target_link_libraries(stdgpu PUBLIC CUDA::cudart)
 
 # Install custom CUDA module
 install(FILES "${stdgpu_SOURCE_DIR}/cmake/${STDGPU_BACKEND_DIRECTORY}/FindCUDAToolkit.cmake"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${STDGPU_CMAKE_INSTALL_DIR}/${STDGPU_BACKEND_DIRECTORY}"
+        DESTINATION "${STDGPU_CMAKE_INSTALL_DIR}/${STDGPU_BACKEND_DIRECTORY}"
         COMPONENT stdgpu)

--- a/src/stdgpu/hip/CMakeLists.txt
+++ b/src/stdgpu/hip/CMakeLists.txt
@@ -22,5 +22,5 @@ target_link_options(stdgpu PUBLIC ${STDGPU_DEVICE_LINK_FLAGS})
 
 # Install custom thrust module
 install(FILES "${stdgpu_SOURCE_DIR}/cmake/${STDGPU_BACKEND_DIRECTORY}/Findthrust.cmake"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/${STDGPU_CMAKE_INSTALL_DIR}/${STDGPU_BACKEND_DIRECTORY}"
+        DESTINATION "${STDGPU_CMAKE_INSTALL_DIR}/${STDGPU_BACKEND_DIRECTORY}"
         COMPONENT stdgpu)


### PR DESCRIPTION
When installing stdgpu to a certain location, the package currently contains absolute paths which hard-code the installation destination. However, this prohibits moving the package to another location and forces a re-installation with the modified path. Make the package relocatable by removing all absolute paths to reduce this installation burden for users.