### PR TITLE
README,doc: Extend documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,13 @@ More examples can be found in the <a href="https://github.com/stotko/stdgpu/tree
 
 ## Documentation
 
-A comprehensive API documentation of stdgpu can be found at <a href="https://stotko.github.io/stdgpu">https://stotko.github.io/stdgpu</a>.
+A comprehensive introduction into the design and API of stdgpu can be found here:
+
+- <a href="https://stotko.github.io/stdgpu">stdgpu API documentation</a>
+- <a href="https://thrust.github.io/doc/group__algorithms.html">thrust algorithms documentation</a>
+- <a href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">Research paper</a>
+
+Since a core feature and design goal of stdgpu is its **interoperability** with thrust, it offers **full support for all thrust algorithms** instead of reinventing the wheel. More information about the design can be found in the related <a href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">research paper</a>.
 
 
 ## Building

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,3 +1,9 @@
 ## Documentation
 
-A comprehensive API documentation of stdgpu can be found at <a href="https://stotko.github.io/stdgpu">https://stotko.github.io/stdgpu</a>.
+A comprehensive introduction into the design and API of stdgpu can be found here:
+
+- <a href="https://stotko.github.io/stdgpu">stdgpu API documentation</a>
+- <a href="https://thrust.github.io/doc/group__algorithms.html">thrust algorithms documentation</a>
+- <a href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">Research paper</a>
+
+Since a core feature and design goal of stdgpu is its **interoperability** with thrust, it offers **full support for all thrust algorithms** instead of reinventing the wheel. More information about the design can be found in the related <a href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">research paper</a>.

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -111,7 +111,13 @@ More examples can be found in the <a href="https://github.com/stotko/stdgpu/tree
 
 \section documentation Documentation
 
-A comprehensive API documentation of stdgpu can be found at <a href="https://stotko.github.io/stdgpu">https://stotko.github.io/stdgpu</a>.
+A comprehensive introduction into the design and API of stdgpu can be found here:
+
+- <a href="https://stotko.github.io/stdgpu">stdgpu API documentation</a>
+- <a href="https://thrust.github.io/doc/group__algorithms.html">thrust algorithms documentation</a>
+- <a href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">Research paper</a>
+
+Since a core feature and design goal of stdgpu is its **interoperability** with thrust, it offers **full support for all thrust algorithms** instead of reinventing the wheel. More information about the design can be found in the related <a href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">research paper</a>.
 
 
 \section building Building


### PR DESCRIPTION
The documentation section in the `README` only contains a link to the API documentation. Extend it to also cover the thrust algorithms documentation as well as our research paper explaining the design. This way, the features and intended use cases should become more obvious to new users.