### PR TITLE
examples: Pass containers by reference for OpenMP backend

### DIFF
--- a/examples/openmp/bitset.cpp
+++ b/examples/openmp/bitset.cpp
@@ -38,8 +38,8 @@ struct is_odd
 void
 set_bits(const int* d_result,
          const stdgpu::index_t d_result_size,
-         stdgpu::bitset bits,
-         stdgpu::atomic<int> counter)
+         stdgpu::bitset& bits,
+         stdgpu::atomic<int>& counter)
 {
     #pragma omp parallel for
     for (stdgpu::index_t i = 0; i < d_result_size; ++i)

--- a/examples/openmp/deque.cpp
+++ b/examples/openmp/deque.cpp
@@ -38,7 +38,7 @@ struct is_odd
 void
 insert_neighbors_with_duplicates(const int* d_input,
                                  const stdgpu::index_t n,
-                                 stdgpu::deque<int> deq)
+                                 stdgpu::deque<int>& deq)
 {
     #pragma omp parallel for
     for (stdgpu::index_t i = 0; i < n; ++i)

--- a/examples/openmp/mutex_array.cpp
+++ b/examples/openmp/mutex_array.cpp
@@ -39,7 +39,7 @@ struct is_odd
 void
 try_partial_sum(const int* d_input,
                 const stdgpu::index_t n,
-                stdgpu::mutex_array locks,
+                stdgpu::mutex_array& locks,
                 int* d_result)
 {
     #pragma omp parallel for

--- a/examples/openmp/unordered_map.cpp
+++ b/examples/openmp/unordered_map.cpp
@@ -60,7 +60,7 @@ struct int_pair_plus
 void
 insert_neighbors(const int* d_result,
                  const stdgpu::index_t n,
-                 stdgpu::unordered_map<int, int> map)
+                 stdgpu::unordered_map<int, int>& map)
 {
     #pragma omp parallel for
     for (stdgpu::index_t i = 0; i < n; ++i)

--- a/examples/openmp/unordered_set.cpp
+++ b/examples/openmp/unordered_set.cpp
@@ -38,7 +38,7 @@ struct is_odd
 void
 insert_neighbors(const int* d_result,
                  const stdgpu::index_t n,
-                 stdgpu::unordered_set<int> set)
+                 stdgpu::unordered_set<int>& set)
 {
     #pragma omp parallel for
     for (stdgpu::index_t i = 0; i < n; ++i)

--- a/examples/openmp/vector.cpp
+++ b/examples/openmp/vector.cpp
@@ -28,7 +28,7 @@
 void
 insert_neighbors_with_duplicates(const int* d_input,
                                  const stdgpu::index_t n,
-                                 stdgpu::vector<int> vec)
+                                 stdgpu::vector<int>& vec)
 {
     #pragma omp parallel for
     for (stdgpu::index_t i = 0; i < n; ++i)


### PR DESCRIPTION
In the new examples, the containers are passed by value, even in the ones for the OpenMP backend. While this is required for the CUDA and HIP backends, pass-by-reference should still be preferred for the OpenMP backend. Fix this these minor issues detected by Coverity Scan.