### PR TITLE
deque,vector: Remove bounds check in operator[]

### DIFF
--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -93,11 +93,7 @@ deque<T>::at(const deque<T>::index_type n) const
     STDGPU_EXPECTS(n < size());
     STDGPU_EXPECTS(occupied(n));
 
-    index_t index_to_wrap = static_cast<index_t>(_begin.load()) + n;
-
-    STDGPU_ASSERT(0 <= index_to_wrap);
-
-    return _data[index_to_wrap % _capacity];
+    return operator[](n);
 }
 
 
@@ -105,7 +101,7 @@ template <typename T>
 inline STDGPU_DEVICE_ONLY typename deque<T>::reference
 deque<T>::operator[](const deque<T>::index_type n)
 {
-    return at(n);
+    return const_cast<reference>(static_cast<const deque<T>*>(this)->operator[](n));
 }
 
 
@@ -113,7 +109,8 @@ template <typename T>
 inline STDGPU_DEVICE_ONLY typename deque<T>::const_reference
 deque<T>::operator[](const deque<T>::index_type n) const
 {
-    return at(n);
+    index_t index_to_wrap = static_cast<index_t>(_begin.load()) + n;
+    return _data[index_to_wrap % _capacity];
 }
 
 

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -82,7 +82,7 @@ vector<T>::at(const vector<T>::index_type n) const
     STDGPU_EXPECTS(n < size());
     STDGPU_EXPECTS(occupied(n));
 
-    return _data[n];
+    return operator[](n);
 }
 
 
@@ -90,7 +90,7 @@ template <typename T>
 inline STDGPU_DEVICE_ONLY typename vector<T>::reference
 vector<T>::operator[](const vector<T>::index_type n)
 {
-    return at(n);
+    return const_cast<vector<T>::reference>(static_cast<const vector<T>*>(this)->operator[](n));
 }
 
 
@@ -98,7 +98,7 @@ template <typename T>
 inline STDGPU_DEVICE_ONLY typename vector<T>::const_reference
 vector<T>::operator[](const vector<T>::index_type n) const
 {
-    return at(n);
+    return _data[n];
 }
 
 


### PR DESCRIPTION
`operator[]` should not perform bounds checks. Remove these checks by making `at()` call `operator[]` rather than the other way around.

Fixes #184 