### PR TITLE
General: Port HIP backend to ROCm 3.5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Before building the library, please make sure that all required tools and depend
 
 <b>Required for HIP backend (experimental)</b>
 
-- ROCm 3.1
+- ROCm 3.5
     - (Ubuntu) https://github.com/RadeonOpenCompute/ROCm
     - Includes thrust
 

--- a/cmake/hip/Findthrust.cmake
+++ b/cmake/hip/Findthrust.cmake
@@ -41,12 +41,7 @@ find_package_handle_standard_args(thrust
 
 if(thrust_FOUND)
     add_library(thrust::thrust INTERFACE IMPORTED)
-    # WORKAROUND: ROCm 3.1 forgot to export the namespace, so workaround this bug
-    if(TARGET roc::rocthrust)
-        set_target_properties(thrust::thrust PROPERTIES INTERFACE_LINK_LIBRARIES roc::rocthrust)
-    elseif(TARGET rocthrust)
-        set_target_properties(thrust::thrust PROPERTIES INTERFACE_LINK_LIBRARIES rocthrust)
-    endif()
+    set_target_properties(thrust::thrust PROPERTIES INTERFACE_LINK_LIBRARIES roc::rocthrust)
 
     mark_as_advanced(THRUST_INCLUDE_DIR
                      THRUST_VERSION

--- a/cmake/hip/set_device_flags.cmake
+++ b/cmake/hip/set_device_flags.cmake
@@ -2,11 +2,8 @@ function(stdgpu_set_device_flags STDGPU_OUTPUT_DEVICE_FLAGS)
     # Clear list before appending flags
     unset(${STDGPU_OUTPUT_DEVICE_FLAGS})
 
-    set(STDGPU_HIP_HCC_ID "Clang")
-    if(CMAKE_CXX_COMPILER_ID STREQUAL STDGPU_HIP_HCC_ID)
-        # FIXME These are needed to suppress some weird warnings/errors
-        list(APPEND ${STDGPU_OUTPUT_DEVICE_FLAGS} "-Wno-invalid-noreturn")
-    endif()
+    list(APPEND ${STDGPU_OUTPUT_DEVICE_FLAGS} "-Wno-unused-command-line-argument")
+    list(APPEND ${STDGPU_OUTPUT_DEVICE_FLAGS} "-Wno-pass-failed")
 
     set(${STDGPU_OUTPUT_DEVICE_FLAGS} "$<$<COMPILE_LANGUAGE:CXX>:${${STDGPU_OUTPUT_DEVICE_FLAGS}}>")
 
@@ -18,29 +15,4 @@ endfunction()
 # Auxiliary compiler flags for tests to be used with target_compile_options
 function(stdgpu_set_test_device_flags STDGPU_OUTPUT_DEVICE_TEST_FLAGS)
     # No flags required
-endfunction()
-
-
-function(stdgpu_hip_set_architecture_flags STDGPU_OUTPUT_DEVICE_LINK_FLAGS)
-    # NOTE ROCm can auto-detect the GPU, so the list below is overly pessimistic.
-    # NOTE However, this list of hard-coded targets allows cross-compilation and compilation on systems without AMD GPUs.
-    list(APPEND STDGPU_HIP_AMDGPU_TARGETS "gfx803" "gfx900" "gfx906" "gfx908")
-
-    set(STDGPU_HIP_HAVE_SUITABLE_GPU FALSE)
-
-    foreach(STDGPU_HIP_TARGET IN LISTS STDGPU_HIP_AMDGPU_TARGETS)
-        set(STDGPU_HIP_HCC_ID "Clang")
-        if(CMAKE_CXX_COMPILER_ID STREQUAL STDGPU_HIP_HCC_ID)
-            list(APPEND ${STDGPU_OUTPUT_DEVICE_LINK_FLAGS} "--amdgpu-target=${STDGPU_HIP_TARGET}")
-            message(STATUS "  Enabled compilation for AMDGPU target ${STDGPU_HIP_TARGET}")
-            set(STDGPU_HIP_HAVE_SUITABLE_GPU TRUE)
-        endif()
-    endforeach()
-
-    if(NOT STDGPU_HIP_HAVE_SUITABLE_GPU)
-        message(FATAL_ERROR "  No HIP-capable GPU detected")
-    endif()
-
-    # Make output variable visible
-    set(${STDGPU_OUTPUT_DEVICE_LINK_FLAGS} ${${STDGPU_OUTPUT_DEVICE_LINK_FLAGS}} PARENT_SCOPE)
 endfunction()

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -158,7 +158,7 @@ Before building the library, please make sure that all required tools and depend
 
 <b>Required for HIP backend (experimental)</b>
 
-- ROCm 3.1
+- ROCm 3.5
     - (Ubuntu) https://github.com/RadeonOpenCompute/ROCm
     - Includes thrust
 

--- a/scripts/ci/configure_hip_debug.sh
+++ b/scripts/ci/configure_hip_debug.sh
@@ -7,4 +7,4 @@ sh scripts/utils/create_empty_directory.sh build
 
 # Configure project
 # NOTE: Set C++ compiler to HCC rather than HIPCC. HIPCC does not pass CMake's compiler check since it needs a --amdgpu-target=<arch> flag.
-sh scripts/utils/configure_debug.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_HIP -DSTDGPU_TREAT_WARNINGS_AS_ERRORS=ON -DCMAKE_CXX_COMPILER=hcc
+sh scripts/utils/configure_debug.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_HIP -DSTDGPU_TREAT_WARNINGS_AS_ERRORS=ON -DCMAKE_CXX_COMPILER=hipcc

--- a/scripts/ci/configure_hip_release.sh
+++ b/scripts/ci/configure_hip_release.sh
@@ -7,4 +7,4 @@ sh scripts/utils/create_empty_directory.sh build
 
 # Configure project
 # NOTE: Set C++ compiler to HCC rather than HIPCC. HIPCC does not pass CMake's compiler check since it needs a --amdgpu-target=<arch> flag.
-sh scripts/utils/configure_release.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_HIP -DSTDGPU_TREAT_WARNINGS_AS_ERRORS=ON -DCMAKE_CXX_COMPILER=hcc
+sh scripts/utils/configure_release.sh -DSTDGPU_BACKEND=STDGPU_BACKEND_HIP -DSTDGPU_TREAT_WARNINGS_AS_ERRORS=ON -DCMAKE_CXX_COMPILER=hipcc

--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -30,18 +30,10 @@ configure_file("${STDGPU_INCLUDE_LOCAL_DIR}/stdgpu/config.h.in"
                @ONLY)
 
 
-# FIXME:
-# The ROCm HCC compiler/linker seems to have trouble with template specializations.
-# While there are linker errors for STATIC libraries, SHARED libraries seem to work/link for some reason.
-if(STDGPU_BACKEND STREQUAL STDGPU_BACKEND_HIP)
-    message(WARNING "STDGPU_HIP_BACKEND: Building SHARED library to workaround linker errors with template specializations. This might be a bug in ROCm's HCC compiler/linker.")
+if(STDGPU_BUILD_SHARED_LIBS)
     add_library(stdgpu SHARED)
 else()
-    if(STDGPU_BUILD_SHARED_LIBS)
-        add_library(stdgpu SHARED)
-    else()
-        add_library(stdgpu STATIC)
-    endif()
+    add_library(stdgpu STATIC)
 endif()
 
 target_sources(stdgpu PRIVATE impl/iterator.cpp

--- a/src/stdgpu/compiler.h
+++ b/src/stdgpu/compiler.h
@@ -56,17 +56,17 @@ namespace stdgpu
  * \ingroup compiler
  * \brief Device compiler: Unknown
  */
-#define STDGPU_DEVICE_COMPILER_UNKNOWN 20
+#define STDGPU_DEVICE_COMPILER_UNKNOWN  20
 /**
  * \ingroup compiler
  * \brief Device compiler: NVCC
  */
-#define STDGPU_DEVICE_COMPILER_NVCC    21
+#define STDGPU_DEVICE_COMPILER_NVCC     21
 /**
  * \ingroup compiler
- * \brief Device compiler: HCC
+ * \brief Device compiler: HIP-Clang
  */
-#define STDGPU_DEVICE_COMPILER_HCC     22
+#define STDGPU_DEVICE_COMPILER_HIPCLANG 22
 
 /**
  * \ingroup compiler
@@ -90,8 +90,8 @@ namespace stdgpu
  */
 #if defined(__NVCC__)
     #define STDGPU_DEVICE_COMPILER STDGPU_DEVICE_COMPILER_NVCC
-#elif defined(__HCC__) || defined(__HIP__)
-    #define STDGPU_DEVICE_COMPILER STDGPU_DEVICE_COMPILER_HCC
+#elif defined(__HIP__)
+    #define STDGPU_DEVICE_COMPILER STDGPU_DEVICE_COMPILER_HIPCLANG
 #else
     #define STDGPU_DEVICE_COMPILER STDGPU_DEVICE_COMPILER_UNKNOWN
 #endif

--- a/src/stdgpu/contract.h
+++ b/src/stdgpu/contract.h
@@ -30,7 +30,6 @@
 #include <cassert>
 #include <exception>
 
-#include <stdgpu/config.h>
 #include <stdgpu/cstddef.h>
 #include <stdgpu/platform.h>
 
@@ -77,19 +76,11 @@ namespace stdgpu
     #define STDGPU_DETAIL_HOST_ENSURES(condition) STDGPU_DETAIL_HOST_CHECK("Postcondition", condition)
     #define STDGPU_DETAIL_HOST_ASSERT(condition) STDGPU_DETAIL_HOST_CHECK("Assertion", condition)
 
-    // FIXME:
-    // HIP's device assert() function does not seem to override/overload the host compiler version.
-    // Even using HIP's device assert() function implementation directly results in linker errors.
-    // Thus, disable contract checks until a better workaround/fix is found.
-    #if STDGPU_BACKEND == STDGPU_BACKEND_HIP
-        #define STDGPU_DETAIL_WORKAROUND_ASSERT(condition) STDGPU_DETAIL_EMPTY_STATEMENT
-    #else
-        #define STDGPU_DETAIL_WORKAROUND_ASSERT(condition) assert(condition) // NOLINT(hicpp-no-array-decay)
-    #endif
+    #define STDGPU_DETAIL_DEVICE_CHECK(condition) assert(condition) // NOLINT(hicpp-no-array-decay)
 
-    #define STDGPU_DETAIL_DEVICE_EXPECTS(condition) STDGPU_DETAIL_WORKAROUND_ASSERT(condition)
-    #define STDGPU_DETAIL_DEVICE_ENSURES(condition) STDGPU_DETAIL_WORKAROUND_ASSERT(condition)
-    #define STDGPU_DETAIL_DEVICE_ASSERT(condition) STDGPU_DETAIL_WORKAROUND_ASSERT(condition)
+    #define STDGPU_DETAIL_DEVICE_EXPECTS(condition) STDGPU_DETAIL_DEVICE_CHECK(condition)
+    #define STDGPU_DETAIL_DEVICE_ENSURES(condition) STDGPU_DETAIL_DEVICE_CHECK(condition)
+    #define STDGPU_DETAIL_DEVICE_ASSERT(condition) STDGPU_DETAIL_DEVICE_CHECK(condition)
 
     #if STDGPU_CODE == STDGPU_CODE_DEVICE
         #define STDGPU_EXPECTS(condition) STDGPU_DETAIL_DEVICE_EXPECTS(condition)

--- a/src/stdgpu/hip/CMakeLists.txt
+++ b/src/stdgpu/hip/CMakeLists.txt
@@ -1,9 +1,9 @@
 
 # NOTE For version checking only
-find_package(hip 3.1 REQUIRED)
+find_package(hip 3.5 REQUIRED)
 
 set(STDGPU_DEPENDENCIES_BACKEND_INIT "
-find_dependency(hip 3.1 REQUIRED)
+find_dependency(hip 3.5 REQUIRED)
 " PARENT_SCOPE)
 
 target_sources(stdgpu PRIVATE impl/memory.cpp
@@ -11,13 +11,6 @@ target_sources(stdgpu PRIVATE impl/memory.cpp
                               impl/mutex.cpp)
 
 target_compile_definitions(stdgpu PUBLIC THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP)
-
-include("${stdgpu_SOURCE_DIR}/cmake/${STDGPU_BACKEND_DIRECTORY}/set_device_flags.cmake")
-# NOTE HIP architecture flags must be passed as device link flags
-stdgpu_hip_set_architecture_flags(STDGPU_DEVICE_LINK_FLAGS)
-message(STATUS "Created HIP device link flags : ${STDGPU_DEVICE_LINK_FLAGS}")
-
-target_link_options(stdgpu PUBLIC ${STDGPU_DEVICE_LINK_FLAGS})
 
 
 # Install custom thrust module

--- a/src/stdgpu/hip/platform.h
+++ b/src/stdgpu/hip/platform.h
@@ -33,7 +33,7 @@ namespace hip
  * \def STDGPU_HIP_HOST_DEVICE
  * \brief Platform-independent host device function annotation
  */
-#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_HCC
+#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_HIPCLANG
     #define STDGPU_HIP_HOST_DEVICE __host__ __device__
 #else
     #define STDGPU_HIP_HOST_DEVICE
@@ -44,7 +44,7 @@ namespace hip
  * \def STDGPU_HIP_DEVICE_ONLY
  * \brief Platform-independent device function annotation
  */
-#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_HCC
+#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_HIPCLANG
     #define STDGPU_HIP_DEVICE_ONLY __device__
 #else
     // Should trigger a compact error message containing the error string
@@ -56,7 +56,7 @@ namespace hip
  * \def STDGPU_HIP_CONSTANT
  * \brief Platform-independent constant variable annotation
  */
-#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_HCC
+#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_HIPCLANG
     #define STDGPU_HIP_CONSTANT __constant__
 #else
     #define STDGPU_HIP_CONSTANT
@@ -78,7 +78,7 @@ namespace hip
  * \def STDGPU_HIP_IS_DEVICE_COMPILED
  * \brief Platform-independent device compilation detection
  */
-#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_HCC
+#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_HIPCLANG
     #define STDGPU_HIP_IS_DEVICE_COMPILED 1
 #else
     #define STDGPU_HIP_IS_DEVICE_COMPILED 0

--- a/test/stdgpu/iterator.cpp
+++ b/test/stdgpu/iterator.cpp
@@ -47,6 +47,8 @@ class stdgpu_iterator : public ::testing::Test
 namespace stdgpu
 {
 
+// NOTE HIP-Clang requires STDGPU_HOST_DEVICE annotation
+/*
 template
 device_ptr<int>
 make_device<int>(int*);
@@ -54,6 +56,7 @@ make_device<int>(int*);
 template
 host_ptr<int>
 make_host<int>(int*);
+*/
 
 template
 index64_t


### PR DESCRIPTION
ROCm 3.5 deprecated the HCC compiler and all newer versions recommend HIP-Clang to be the device compiler. Port the HIP backend to this new compiler and bump the required version of ROCm. This way, we also get rid of the HCC-specific workarounds and limitations.