### PR TITLE
cmake: Use CUDA_ARCHITECTURES property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.17)
+cmake_minimum_required(VERSION 3.15...3.18)
 
 
 project(stdgpu VERSION 1.3.0
@@ -57,10 +57,14 @@ if(STDGPU_SETUP_COMPILER_FLAGS)
     message(STATUS "Created test device flags : ${STDGPU_TEST_DEVICE_FLAGS}")
 
     if(STDGPU_BACKEND STREQUAL STDGPU_BACKEND_CUDA)
-        # FIXME Use the architecture flags for both device compiling and device linking until there is a proper abstraction
-        stdgpu_cuda_set_architecture_flags(STDGPU_DEVICE_COMPILE_AND_LINK_FLAGS)
-        string(APPEND CMAKE_CUDA_FLAGS "${STDGPU_DEVICE_COMPILE_AND_LINK_FLAGS}")
-        message(STATUS "Building with modified CMAKE_CUDA_FLAGS : ${CMAKE_CUDA_FLAGS}")
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+            stdgpu_cuda_set_architecture_flags(STDGPU_CUDA_ARCHITECTURES)
+            set(CMAKE_CUDA_ARCHITECTURES ${STDGPU_CUDA_ARCHITECTURES})
+        else()
+            stdgpu_cuda_set_architecture_flags(STDGPU_DEVICE_COMPILE_AND_LINK_FLAGS)
+            string(APPEND CMAKE_CUDA_FLAGS "${STDGPU_DEVICE_COMPILE_AND_LINK_FLAGS}")
+            message(STATUS "Building with modified CMAKE_CUDA_FLAGS : ${CMAKE_CUDA_FLAGS}")
+        endif()
     endif()
 
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/set_host_flags.cmake")

--- a/cmake/cuda/set_device_flags.cmake
+++ b/cmake/cuda/set_device_flags.cmake
@@ -53,18 +53,26 @@ function(stdgpu_set_test_device_flags STDGPU_OUTPUT_DEVICE_TEST_FLAGS)
 endfunction()
 
 
-function(stdgpu_cuda_set_architecture_flags STDGPU_OUTPUT_DEVICE_COMPILE_AND_LINK_FLAGS)
-    # NOTE Available in CMake 3.17+
-    # include("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/check_compute_capability.cmake")
-    include("${stdgpu_SOURCE_DIR}/cmake/${STDGPU_BACKEND_DIRECTORY}/check_compute_capability.cmake")
+function(stdgpu_cuda_set_architecture_flags STDGPU_OUTPUT_ARCHITECTURE_FLAGS)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+        include("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/check_compute_capability.cmake")
+    else()
+        include("${stdgpu_SOURCE_DIR}/cmake/${STDGPU_BACKEND_DIRECTORY}/check_compute_capability.cmake")
+    endif()
 
     set(STDGPU_CUDA_HAVE_SUITABLE_GPU FALSE)
 
     foreach(STDGPU_CUDA_CC IN LISTS STDGPU_CUDA_COMPUTE_CAPABILITIES)
-        if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
-            string(APPEND ${STDGPU_OUTPUT_DEVICE_COMPILE_AND_LINK_FLAGS} " --generate-code arch=compute_${STDGPU_CUDA_CC},code=sm_${STDGPU_CUDA_CC}")
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+            list(APPEND ${STDGPU_OUTPUT_ARCHITECTURE_FLAGS} ${STDGPU_CUDA_CC})
             message(STATUS "Enabled compilation for CC ${STDGPU_CUDA_CC}")
             set(STDGPU_CUDA_HAVE_SUITABLE_GPU TRUE)
+        else()
+            if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+                string(APPEND ${STDGPU_OUTPUT_ARCHITECTURE_FLAGS} " --generate-code arch=compute_${STDGPU_CUDA_CC},code=sm_${STDGPU_CUDA_CC}")
+                message(STATUS "Enabled compilation for CC ${STDGPU_CUDA_CC}")
+                set(STDGPU_CUDA_HAVE_SUITABLE_GPU TRUE)
+            endif()
         endif()
     endforeach()
 
@@ -73,5 +81,5 @@ function(stdgpu_cuda_set_architecture_flags STDGPU_OUTPUT_DEVICE_COMPILE_AND_LIN
     endif()
 
     # Make output variable visible
-    set(${STDGPU_OUTPUT_DEVICE_COMPILE_AND_LINK_FLAGS} ${${STDGPU_OUTPUT_DEVICE_COMPILE_AND_LINK_FLAGS}} PARENT_SCOPE)
+    set(${STDGPU_OUTPUT_ARCHITECTURE_FLAGS} ${${STDGPU_OUTPUT_ARCHITECTURE_FLAGS}} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
CMake 3.18+ adds a new abstraction upon the CUDA architecture flag generation. Use this new property to support Clang as the CUDA compiler.