### PR TITLE
Container: Add allocator member

### DIFF
--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -339,6 +339,7 @@ class deque
         atomic<unsigned int> _begin = {};
         atomic<unsigned int> _end = {};
         index_t _capacity = 0;
+        allocator_type _alloctor = {};
 
         mutable vector<index_t> _range_indices = {};
 };

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -36,8 +36,7 @@ deque<T>::createDeviceObject(const index_t& capacity)
     STDGPU_EXPECTS(capacity > 0);
 
     deque<T> result;
-    allocator_type a;   // Will be replaced by member
-    result._data     = allocator_traits<allocator_type>::allocate(a, capacity);
+    result._data     = allocator_traits<allocator_type>::allocate(result._alloctor, capacity);
     result._locks    = mutex_array::createDeviceObject(capacity);
     result._occupied = bitset::createDeviceObject(capacity);
     result._size     = atomic<int>::createDeviceObject();
@@ -56,8 +55,7 @@ deque<T>::destroyDeviceObject(deque<T>& device_object)
 {
     device_object.clear();
 
-    allocator_type a = device_object.get_allocator();   // Will be replaced by member
-    allocator_traits<allocator_type>::deallocate(a, device_object._data, device_object._capacity);
+    allocator_traits<allocator_type>::deallocate(device_object._alloctor, device_object._data, device_object._capacity);
     mutex_array::destroyDeviceObject(device_object._locks);
     bitset::destroyDeviceObject(device_object._occupied);
     atomic<int>::destroyDeviceObject(device_object._size);
@@ -73,7 +71,7 @@ template <typename T>
 inline STDGPU_HOST_DEVICE typename deque<T>::allocator_type
 deque<T>::get_allocator() const
 {
-    return allocator_type();
+    return _alloctor;
 }
 
 
@@ -183,8 +181,7 @@ deque<T>::push_back(const T& element)
 
                 if (!occupied(push_position))
                 {
-                    allocator_type a = get_allocator();     // Will be replaced by member
-                    allocator_traits<allocator_type>::construct(a, &(_data[push_position]), element);
+                    allocator_traits<allocator_type>::construct(_alloctor, &(_data[push_position]), element);
                     bool was_occupied = _occupied.set(push_position);
                     pushed = true;
 
@@ -239,9 +236,8 @@ deque<T>::pop_back()
                 if (occupied(pop_position))
                 {
                     bool was_occupied = _occupied.reset(pop_position);
-                    allocator_type a = get_allocator();     // Will be replaced by member
-                    allocator_traits<allocator_type>::construct(a, &popped, _data[pop_position], true);
-                    allocator_traits<allocator_type>::destroy(a, &(_data[pop_position]));
+                    allocator_traits<allocator_type>::construct(_alloctor, &popped, _data[pop_position], true);
+                    allocator_traits<allocator_type>::destroy(_alloctor, &(_data[pop_position]));
 
                     if (!was_occupied)
                     {
@@ -301,8 +297,7 @@ deque<T>::push_front(const T& element)
 
                 if (!occupied(push_position))
                 {
-                    allocator_type a = get_allocator();     // Will be replaced by member
-                    allocator_traits<allocator_type>::construct(a, &(_data[push_position]), element);
+                    allocator_traits<allocator_type>::construct(_alloctor, &(_data[push_position]), element);
                     bool was_occupied = _occupied.set(push_position);
                     pushed = true;
 
@@ -356,9 +351,8 @@ deque<T>::pop_front()
                 if (occupied(pop_position))
                 {
                     bool was_occupied = _occupied.reset(pop_position);
-                    allocator_type a = get_allocator();     // Will be replaced by member
-                    allocator_traits<allocator_type>::construct(a, &popped, _data[pop_position], true);
-                    allocator_traits<allocator_type>::destroy(a, &(_data[pop_position]));
+                    allocator_traits<allocator_type>::construct(_alloctor, &popped, _data[pop_position], true);
+                    allocator_traits<allocator_type>::destroy(_alloctor, &(_data[pop_position]));
 
                     if (!was_occupied)
                     {

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -388,6 +388,7 @@ class unordered_base
         key_from_value _key_from_value = {};            /**< The value to key functor */                    // NOLINT(misc-non-private-member-variables-in-classes)
         key_equal _key_equal = {};                      /**< The key comparison functor */                  // NOLINT(misc-non-private-member-variables-in-classes)
         hasher _hash = {};                              /**< The hashing function */                        // NOLINT(misc-non-private-member-variables-in-classes)
+        allocator_type _alloctor = {};                  /**< The allocator */                               // NOLINT(misc-non-private-member-variables-in-classes)
 
         mutable vector<index_t> _range_indices = {};    /**< The buffer of range indices */                 // NOLINT(misc-non-private-member-variables-in-classes)
 

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -100,7 +100,7 @@ template <typename Key, typename Value, typename KeyFromValue, typename Hash, ty
 inline STDGPU_HOST_DEVICE typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::allocator_type
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::get_allocator() const
 {
-    return allocator_type();
+    return _alloctor;
 }
 
 
@@ -596,8 +596,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_insert(const unord
                 // !!! VERIFY CONDITIONS HAVE NOT CHANGED !!!
                 if (!contains(block) && !occupied(bucket_index))
                 {
-                    allocator_type a = get_allocator();     // Will be replaced by member
-                    allocator_traits<allocator_type>::construct(a, &(_values[bucket_index]), value);
+                    allocator_traits<allocator_type>::construct(_alloctor, &(_values[bucket_index]), value);
                     // Do not touch the linked list
                     //_offsets[bucket_index] = 0;
 
@@ -641,8 +640,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_insert(const unord
                     {
                         index_t new_linked_list_end = popped.first;
 
-                        allocator_type a = get_allocator();     // Will be replaced by member
-                        allocator_traits<allocator_type>::construct(a, &(_values[new_linked_list_end]), value);
+                        allocator_traits<allocator_type>::construct(_alloctor, &(_values[new_linked_list_end]), value);
                         _offsets[new_linked_list_end] = 0;
 
                         // Set occupied status after entry has been fully constructed
@@ -702,8 +700,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_erase(const unorde
                     --_occupied_count;
 
                     // Default values
-                    allocator_type a = get_allocator();     // Will be replaced by member
-                    allocator_traits<allocator_type>::destroy(a, &(_values[position]));
+                    allocator_traits<allocator_type>::destroy(_alloctor, &(_values[position]));
                     // Do not touch the linked list
                     //_offsets[position] = 0;
 
@@ -749,8 +746,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_erase(const unorde
                     --_occupied_count;
 
                     // Default values
-                    allocator_type a = get_allocator();     // Will be replaced by member
-                    allocator_traits<allocator_type>::destroy(a, &(_values[position]));
+                    allocator_traits<allocator_type>::destroy(_alloctor, &(_values[position]));
                     // Do not reset the offset of the erased linked list entry as another thread executing find() might still need it, so make try_insert responsible for resetting it
                     //_offsets[position] = 0;
                     _excess_list_positions.push_back(position);
@@ -1060,10 +1056,9 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::createDeviceObject(con
     index_t total_count = bucket_count + excess_count;
 
     unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual> result;
-    allocator_type a;   // Will be replaced by member
     result._bucket_count            = bucket_count;
     result._excess_count            = excess_count;
-    result._values                  = allocator_traits<allocator_type>::allocate(a, total_count);
+    result._values                  = allocator_traits<allocator_type>::allocate(result._alloctor, total_count);
     result._offsets                 = createDeviceArray<index_t>(total_count, 0);
     result._occupied                = bitset::createDeviceObject(total_count);
     result._occupied_count          = atomic<int>::createDeviceObject();
@@ -1097,10 +1092,9 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::createDeviceObject(con
     index_t total_count = bucket_count + excess_count;
 
     unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual> result;
-    allocator_type a;   // Will be replaced by member
     result._bucket_count            = bucket_count;
     result._excess_count            = excess_count;
-    result._values                  = allocator_traits<allocator_type>::allocate(a, total_count);
+    result._values                  = allocator_traits<allocator_type>::allocate(result._alloctor, total_count);
     result._offsets                 = createDeviceArray<index_t>(total_count, 0);
     result._occupied                = bitset::createDeviceObject(total_count);
     result._occupied_count          = atomic<int>::createDeviceObject();
@@ -1128,9 +1122,8 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::destroyDeviceObject(un
 {
     device_object.clear();
 
-    allocator_type a = device_object.get_allocator();   // Will be replaced by member
     index_t total_count = device_object._bucket_count + device_object._excess_count;
-    allocator_traits<allocator_type>::deallocate(a, device_object._values, total_count);
+    allocator_traits<allocator_type>::deallocate(device_object._alloctor, device_object._values, total_count);
 
     device_object._bucket_count = 0;
     device_object._excess_count = 0;

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -343,6 +343,7 @@ class vector
         bitset _occupied = {};
         atomic<int> _size = {};
         index_t _capacity = 0;
+        allocator_type _alloctor = {};
 };
 
 } // namespace stdgpu

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -2291,3 +2291,18 @@ TEST_F(stdgpu_deque, const_device_range)
 }
 
 
+TEST_F(stdgpu_deque, get_allocator)
+{
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
+
+    stdgpu::deque<int>::allocator_type a = pool.get_allocator();
+
+    int* array = a.allocate(N);
+    a.deallocate(array, N);
+
+    stdgpu::deque<int>::destroyDeviceObject(pool);
+}
+
+

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -2304,3 +2304,12 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, deprecated_createDeviceObject)
 }
 
 
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, get_allocator)
+{
+    test_unordered_datastructure::allocator_type a = hash_datastructure.get_allocator();
+
+    test_unordered_datastructure::value_type* array = a.allocate(hash_datastructure_size);
+    a.deallocate(array, hash_datastructure_size);
+}
+
+

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -1515,3 +1515,18 @@ TEST_F(stdgpu_vector, const_device_range)
 }
 
 
+TEST_F(stdgpu_vector, get_allocator)
+{
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::vector<int> pool = stdgpu::vector<int>::createDeviceObject(N);
+
+    stdgpu::vector<int>::allocator_type a = pool.get_allocator();
+
+    int* array = a.allocate(N);
+    a.deallocate(array, N);
+
+    stdgpu::vector<int>::destroyDeviceObject(pool);
+}
+
+


### PR DESCRIPTION
In #56, all containers got a member function to return its allocator object. However, no explicit member object has been introduced so far due to compatibility reasons. Add this new allocator member object now and use it in the member functions. This makes the containers work correctly for allocators that have a state.

Fixes #62 