### PR TITLE
bitset: Remove deprecated functions

### DIFF
--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -288,10 +288,9 @@ class bitset
                       std::is_same<block_type, unsigned long long int>::value,
                       "stdgpu::bitset: block_type not supported");
 
-        //static constexpr index_t _bits_per_block = std::numeric_limits<block_type>::digits;
+        static constexpr index_t _bits_per_block = std::numeric_limits<block_type>::digits;
 
         block_type* _bit_blocks = nullptr;
-        index_t _bits_per_block = std::numeric_limits<block_type>::digits;  // deprecated: Will be replaced by static version
         index_t _number_bit_blocks = 0;
         index_t _size = 0;
 };

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -196,8 +196,7 @@ inline bitset
 bitset::createDeviceObject(const index_t& size)
 {
     bitset result;
-    result._bits_per_block      = std::numeric_limits<block_type>::digits;
-    result._number_bit_blocks   = detail::div_up(size, result._bits_per_block);
+    result._number_bit_blocks   = detail::div_up(size, _bits_per_block);
     result._bit_blocks          = createDeviceArray<block_type>(result._number_bit_blocks, static_cast<block_type>(0));
     result._size                = size;
 


### PR DESCRIPTION
This removes the deprecated functions in the `bitset` module.

Partially addresses #51