### PR TITLE
mutex: Remove deprecated functions

### DIFF
--- a/src/stdgpu/impl/mutex_detail.cuh
+++ b/src/stdgpu/impl/mutex_detail.cuh
@@ -26,48 +26,6 @@
 namespace stdgpu
 {
 
-inline STDGPU_DEVICE_ONLY
-mutex_ref::operator mutex_array::reference()
-{
-    return mutex_array::reference(_lock_bits[_n]);
-}
-
-
-inline STDGPU_HOST_DEVICE
-mutex_ref::mutex_ref(bitset lock_bits,
-                     const index_t n)
-    : _lock_bits(lock_bits),
-      _n(n)
-{
-
-}
-
-
-inline STDGPU_DEVICE_ONLY bool
-mutex_ref::try_lock()
-{
-    // Change state to LOCKED
-    // Test whether it was UNLOCKED previously --> TRUE : This call got the lock, FALSE : Other call got the lock
-    return !_lock_bits.set(_n);
-}
-
-
-inline STDGPU_DEVICE_ONLY void
-mutex_ref::unlock()
-{
-    // Change state back to UNLOCKED
-    _lock_bits.reset(_n);
-}
-
-
-inline STDGPU_DEVICE_ONLY bool
-mutex_ref::locked() const
-{
-    return _lock_bits[_n];
-}
-
-
-
 inline STDGPU_HOST_DEVICE
 mutex_array::reference::reference(const bitset::reference& bit_ref)
     : _bit_ref(bit_ref)
@@ -120,23 +78,20 @@ mutex_array::destroyDeviceObject(mutex_array& device_object)
 }
 
 
-inline STDGPU_DEVICE_ONLY mutex_ref
+inline STDGPU_DEVICE_ONLY mutex_array::reference
 mutex_array::operator[](const index_t n)
 {
     STDGPU_EXPECTS(0 <= n);
     STDGPU_EXPECTS(n < size());
 
-    return mutex_ref(_lock_bits, n);
+    return reference(_lock_bits[n]);
 }
 
 
-inline STDGPU_DEVICE_ONLY const mutex_ref
+inline STDGPU_DEVICE_ONLY const mutex_array::reference
 mutex_array::operator[](const index_t n) const
 {
-    STDGPU_EXPECTS(0 <= n);
-    STDGPU_EXPECTS(n < size());
-
-    return mutex_ref(_lock_bits, n);
+    return const_cast<mutex_array*>(this)->operator[](n);
 }
 
 

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -97,7 +97,6 @@ class mutex_array
 
             private:
                 friend mutex_array;
-                friend mutex_ref;
 
                 STDGPU_HOST_DEVICE
                 explicit reference(const bitset::reference& bit_ref);
@@ -131,9 +130,8 @@ class mutex_array
          * \param[in] n The position of the requested mutex
          * \return The n-th mutex
          * \pre 0 <= n < size()
-         * \note Returns a mutex_ref object to preserve the API. Use and store this as mutex_array::reference!
          */
-        STDGPU_DEVICE_ONLY mutex_ref
+        STDGPU_DEVICE_ONLY reference
         operator[](const index_t n);
 
         /**
@@ -141,9 +139,8 @@ class mutex_array
          * \param[in] n The position of the requested mutex
          * \return The n-th mutex
          * \pre 0 <= n < size()
-         * \note Returns a mutex_ref object to preserve the API. Use and store this as mutex_array::reference!
          */
-        STDGPU_DEVICE_ONLY const mutex_ref
+        STDGPU_DEVICE_ONLY const reference
         operator[](const index_t n) const;
 
 
@@ -172,59 +169,6 @@ class mutex_array
     private:
         bitset _lock_bits = {};
         index_t _size = 0;
-};
-
-
-/**
- * \brief Old and implicitly deprecated class to model a mutex reference on the GPU. Use mutex_array::reference instead!
- * \deprecated Replaced by mutex_array::reference
- */
-class mutex_ref
-{
-    public:
-        /**
-         * \brief Converts this object to an instance of mutex_array::reference
-         * \return The same reference object but represented as an instance of the more modern and lightweight mutex_array::reference class
-         * \note This is a porting aid to mutex_array::reference which has the same API but is more lightweight than this class
-         */
-        STDGPU_DEVICE_ONLY
-        operator mutex_array::reference(); // NOLINT(hicpp-explicit-conversions)
-
-        /**
-         * \brief See mutex_array::reference
-         */
-        STDGPU_HOST_DEVICE
-        mutex_ref() = delete;
-
-        /**
-         * \brief See mutex_array::reference
-         * \return See mutex_array::reference
-         */
-        STDGPU_DEVICE_ONLY bool
-        try_lock();
-
-        /**
-         * \brief See mutex_array::reference
-         */
-        STDGPU_DEVICE_ONLY void
-        unlock();
-
-        /**
-         * \brief See mutex_array::reference
-         * \return See mutex_array::reference
-         */
-        STDGPU_DEVICE_ONLY bool
-        locked() const;
-
-    private:
-        friend mutex_array;
-
-        STDGPU_HOST_DEVICE
-        mutex_ref(bitset lock_bits,
-                  const index_t n);
-
-        bitset _lock_bits = {};
-        index_t _n = -1;
 };
 
 

--- a/src/stdgpu/mutex_fwd
+++ b/src/stdgpu/mutex_fwd
@@ -31,7 +31,6 @@
 namespace stdgpu
 {
 
-class mutex_ref;
 class mutex_array;
 
 } // namespace stdgpu


### PR DESCRIPTION
This removes the deprecated functions in the `mutex` module.

Partially addresses #51