### PR TITLE
ranges: Remove deprecated functions

### DIFF
--- a/src/stdgpu/impl/ranges_detail.h
+++ b/src/stdgpu/impl/ranges_detail.h
@@ -43,19 +43,6 @@ device_range<T>::device_range(T* p,
 }
 
 
-#if STDGPU_USE_32_BIT_INDEX
-template <typename T>
-STDGPU_HOST_DEVICE
-device_range<T>::device_range(T* p,
-                              index_t n)
-    : _begin(p),
-      _end(p + n)
-{
-
-}
-#endif
-
-
 template <typename T>
 STDGPU_HOST_DEVICE
 device_range<T>::device_range(typename device_range<T>::iterator begin,
@@ -75,22 +62,6 @@ device_range<T>::device_range(typename device_range<T>::iterator begin,
       _end(end)
 {
 
-}
-
-
-template <typename T>
-STDGPU_HOST_DEVICE typename device_range<T>::iterator
-device_range<T>::begin()
-{
-    return _begin;
-}
-
-
-template <typename T>
-STDGPU_HOST_DEVICE typename device_range<T>::iterator
-device_range<T>::end()
-{
-    return _end;
 }
 
 
@@ -145,19 +116,6 @@ host_range<T>::host_range(T* p,
 }
 
 
-#if STDGPU_USE_32_BIT_INDEX
-template <typename T>
-STDGPU_HOST_DEVICE
-host_range<T>::host_range(T* p,
-                          index_t n)
-    : _begin(p),
-      _end(p + n)
-{
-
-}
-#endif
-
-
 template <typename T>
 STDGPU_HOST_DEVICE
 host_range<T>::host_range(typename host_range<T>::iterator begin,
@@ -177,22 +135,6 @@ host_range<T>::host_range(typename host_range<T>::iterator begin,
       _end(end)
 {
 
-}
-
-
-template <typename T>
-STDGPU_HOST_DEVICE typename host_range<T>::iterator
-host_range<T>::begin()
-{
-    return _begin;
-}
-
-
-template <typename T>
-STDGPU_HOST_DEVICE typename host_range<T>::iterator
-host_range<T>::end()
-{
-    return _end;
 }
 
 
@@ -245,22 +187,6 @@ transform_range<R, UnaryFunction>::transform_range(R r,
       _end(r.end(), f)
 {
 
-}
-
-
-template <typename R, typename UnaryFunction>
-STDGPU_HOST_DEVICE typename transform_range<R, UnaryFunction>::iterator
-transform_range<R, UnaryFunction>::begin()
-{
-    return _begin;
-}
-
-
-template <typename R, typename UnaryFunction>
-STDGPU_HOST_DEVICE typename transform_range<R, UnaryFunction>::iterator
-transform_range<R, UnaryFunction>::end()
-{
-    return _end;
 }
 
 

--- a/src/stdgpu/ranges.h
+++ b/src/stdgpu/ranges.h
@@ -33,9 +33,6 @@
 #include <stdgpu/iterator.h>
 #include <stdgpu/platform.h>
 
-// For compatibility only. Remove this along with deprecated constructors
-#include <stdgpu/config.h>
-
 
 
 namespace stdgpu
@@ -74,19 +71,6 @@ class device_range
         device_range(T* p,
                      index64_t n);
 
-        #if STDGPU_USE_32_BIT_INDEX
-        /**
-         * \deprecated Replaced by device_range(T*, index64_t)
-         * \brief Constructor
-         * \param[in] p A pointer to the array
-         * \param[in] n The number of array elements
-         */
-        //[[deprecated("Replaced by device_range(T*, index64_t")]]
-        STDGPU_HOST_DEVICE
-        device_range(T* p,
-                     index_t n);
-        #endif
-
         /**
          * \brief Constructor
          * \param[in] begin An iterator to the begin of an array
@@ -104,24 +88,6 @@ class device_range
         STDGPU_HOST_DEVICE
         device_range(iterator begin,
                      iterator end);
-
-        /**
-         * \deprecated Replaced by begin() const
-         * \brief An iterator to the begin of the range
-         * \return An iterator to the begin of the range
-         */
-        //[[deprecated("Replaced by begin() const]]
-        STDGPU_HOST_DEVICE iterator
-        begin();
-
-        /**
-         * \deprecated Replaced by end() const
-         * \brief An iterator to the end of the range
-         * \return An iterator to the end of the range
-         */
-        //[[deprecated("Replaced by end() const]]
-        STDGPU_HOST_DEVICE iterator
-        end();
 
         /**
          * \brief An iterator to the begin of the range
@@ -190,19 +156,6 @@ class host_range
         host_range(T* p,
                    index64_t n);
 
-        #if STDGPU_USE_32_BIT_INDEX
-        /**
-         * \deprecated Replaced by host_range(T*, index64_t)
-         * \brief Constructor
-         * \param[in] p A pointer to the array
-         * \param[in] n The number of array elements
-         */
-        //[[deprecated("Replaced by host_range(T*, index64_t")]]
-        STDGPU_HOST_DEVICE
-        host_range(T* p,
-                   index_t n);
-        #endif
-
         /**
          * \brief Constructor
          * \param[in] begin An iterator to the begin of an array
@@ -220,24 +173,6 @@ class host_range
         STDGPU_HOST_DEVICE
         host_range(iterator begin,
                    iterator end);
-
-        /**
-         * \deprecated Replaced by begin() const
-         * \brief An iterator to the begin of the range
-         * \return An iterator to the begin of the range
-         */
-        //[[deprecated("Replaced by begin() const]]
-        STDGPU_HOST_DEVICE iterator
-        begin();
-
-        /**
-         * \deprecated Replaced by end() const
-         * \brief An iterator to the end of the range
-         * \return An iterator to the end of the range
-         */
-        //[[deprecated("Replaced by end() const]]
-        STDGPU_HOST_DEVICE iterator
-        end();
 
         /**
          * \brief An iterator to the begin of the range
@@ -307,24 +242,6 @@ class transform_range
         STDGPU_HOST_DEVICE
         transform_range(R r,
                         UnaryFunction f);
-
-        /**
-         * \deprecated Replaced by begin() const
-         * \brief An iterator to the begin of the range
-         * \return An iterator to the begin of the range
-         */
-        //[[deprecated("Replaced by begin() const]]
-        STDGPU_HOST_DEVICE iterator
-        begin();
-
-        /**
-         * \deprecated Replaced by end() const
-         * \brief An iterator to the end of the range
-         * \return An iterator to the end of the range
-         */
-        //[[deprecated("Replaced by end() const]]
-        STDGPU_HOST_DEVICE iterator
-        end();
 
         /**
          * \brief An iterator to the begin of the range

--- a/test/stdgpu/ranges.cpp
+++ b/test/stdgpu/ranges.cpp
@@ -89,22 +89,6 @@ TEST_F(stdgpu_ranges, device_range_pointer_with_size)
 }
 
 
-TEST_F(stdgpu_ranges, device_range_pointer_with_size_deprecated)
-{
-    const stdgpu::index_t size = 42;
-    int* array = createDeviceArray<int>(size);
-
-    const stdgpu::device_range<int> array_range(array, size);
-    int* array_begin   = array_range.begin().get();
-    int* array_end     = array_range.end().get();
-
-    EXPECT_EQ(array_begin, array);
-    EXPECT_EQ(array_end,   array + size);
-
-    destroyDeviceArray<int>(array);
-}
-
-
 TEST_F(stdgpu_ranges, device_range_pointer_automatic_size)
 {
     const stdgpu::index64_t size = 42;
@@ -146,22 +130,6 @@ TEST_F(stdgpu_ranges, device_range_iterator_pair)
     stdgpu::device_ptr<int> end_iterator   = stdgpu::make_device(array + size);
 
     const stdgpu::device_range<int> array_range(begin_iterator, end_iterator);
-    int* array_begin   = array_range.begin().get();
-    int* array_end     = array_range.end().get();
-
-    EXPECT_EQ(array_begin, array);
-    EXPECT_EQ(array_end,   array + size);
-
-    destroyDeviceArray<int>(array);
-}
-
-
-TEST_F(stdgpu_ranges, device_range_deprecated_nonconst_begin_end)
-{
-    const stdgpu::index64_t size = 42;
-    int* array = createDeviceArray<int>(size);
-
-    stdgpu::device_range<int> array_range(array, size);
     int* array_begin   = array_range.begin().get();
     int* array_end     = array_range.end().get();
 
@@ -227,22 +195,6 @@ TEST_F(stdgpu_ranges, host_range_pointer_with_size)
 }
 
 
-TEST_F(stdgpu_ranges, host_range_pointer_with_size_deprecated)
-{
-    const stdgpu::index_t size = 42;
-    int* array = createHostArray<int>(size);
-
-    const stdgpu::host_range<int> array_range(array, size);
-    int* array_begin   = array_range.begin().get();
-    int* array_end     = array_range.end().get();
-
-    EXPECT_EQ(array_begin, array);
-    EXPECT_EQ(array_end,   array + size);
-
-    destroyHostArray<int>(array);
-}
-
-
 TEST_F(stdgpu_ranges, host_range_pointer_automatic_size)
 {
     const stdgpu::index64_t size = 42;
@@ -284,22 +236,6 @@ TEST_F(stdgpu_ranges, host_range_iterator_pair)
     stdgpu::host_ptr<int> end_iterator   = stdgpu::make_host(array + size);
 
     const stdgpu::host_range<int> array_range(begin_iterator, end_iterator);
-    int* array_begin   = array_range.begin().get();
-    int* array_end     = array_range.end().get();
-
-    EXPECT_EQ(array_begin, array);
-    EXPECT_EQ(array_end,   array + size);
-
-    destroyHostArray<int>(array);
-}
-
-
-TEST_F(stdgpu_ranges, host_range_deprecated_nonconst_begin_end)
-{
-    const stdgpu::index64_t size = 42;
-    int* array = createHostArray<int>(size);
-
-    stdgpu::host_range<int> array_range(array, size);
     int* array_begin   = array_range.begin().get();
     int* array_end     = array_range.end().get();
 
@@ -414,23 +350,6 @@ TEST_F(stdgpu_ranges, transform_range_with_range_and_function)
 
     destroyHostArray<int>(array);
     destroyHostArray<int>(array_result);
-}
-
-
-TEST_F(stdgpu_ranges, transform_range_deprecated_nonconst_begin_end)
-{
-    const stdgpu::index64_t size = 42;
-    int* array = createHostArray<int>(size);
-
-    const stdgpu::host_range<int> array_range(array);
-    stdgpu::transform_range<stdgpu::host_range<int>, square<int>> square_range(array_range, square<int>());
-    int* array_begin   = square_range.begin().base().get();
-    int* array_end     = square_range.end().base().get();
-
-    EXPECT_EQ(array_begin, array);
-    EXPECT_EQ(array_end,   array + size);
-
-    destroyHostArray<int>(array);
 }
 
 


### PR DESCRIPTION
This removes the deprecated functions in the `ranges` module.

Partially addresses #51