### PR TITLE
unordered_map,unordered_set: Remove deprecated functions

### DIFF
--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -334,7 +334,6 @@ class unordered_base
         /**
          * \brief The maximum size
          * \return The maximum size
-         * \note Equivalent to total_count()
          */
         STDGPU_HOST_DEVICE index_t
         max_size() const;
@@ -391,14 +390,6 @@ class unordered_base
         allocator_type _alloctor = {};                  /**< The allocator */                               // NOLINT(misc-non-private-member-variables-in-classes)
 
         mutable vector<index_t> _range_indices = {};    /**< The buffer of range indices */                 // NOLINT(misc-non-private-member-variables-in-classes)
-
-        // Deprecated
-        static unordered_base
-        createDeviceObject(const index_t& bucket_count,
-                           const index_t& excess_count);
-
-        STDGPU_HOST_DEVICE index_t
-        excess_count() const;
 
         STDGPU_HOST_DEVICE index_t
         total_count() const;

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -254,22 +254,6 @@ unordered_map<Key, T, Hash, KeyEqual>::bucket_count() const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_HOST_DEVICE index_t
-unordered_map<Key, T, Hash, KeyEqual>::excess_count() const
-{
-    return _base.excess_count();
-}
-
-
-template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline STDGPU_HOST_DEVICE index_t
-unordered_map<Key, T, Hash, KeyEqual>::total_count() const
-{
-    return _base.total_count();
-}
-
-
-template <typename Key, typename T, typename Hash, typename KeyEqual>
 inline STDGPU_HOST_DEVICE float
 unordered_map<Key, T, Hash, KeyEqual>::load_factor() const
 {
@@ -326,22 +310,6 @@ unordered_map<Key, T, Hash, KeyEqual>::createDeviceObject(const index_t& capacit
 
     unordered_map<Key, T, Hash, KeyEqual> result;
     result._base = detail::unordered_base<key_type, value_type, detail::select1st<value_type>, hasher, key_equal>::createDeviceObject(capacity);
-
-    return result;
-}
-
-
-template <typename Key, typename T, typename Hash, typename KeyEqual>
-unordered_map<Key, T, Hash, KeyEqual>
-unordered_map<Key, T, Hash, KeyEqual>::createDeviceObject(const index_t& bucket_count,
-                                                          const index_t& excess_count)
-{
-    STDGPU_EXPECTS(bucket_count > 0);
-    STDGPU_EXPECTS(excess_count > 0);
-    STDGPU_EXPECTS(has_single_bit<std::size_t>(static_cast<std::size_t>(bucket_count)));
-
-    unordered_map<Key, T, Hash, KeyEqual> result;
-    result._base = detail::unordered_base<key_type, value_type, detail::select1st<value_type>, hasher, key_equal>::createDeviceObject(bucket_count, excess_count);
 
     return result;
 }

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -239,22 +239,6 @@ unordered_set<Key, Hash, KeyEqual>::bucket_count() const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_HOST_DEVICE index_t
-unordered_set<Key, Hash, KeyEqual>::excess_count() const
-{
-    return _base.excess_count();
-}
-
-
-template <typename Key, typename Hash, typename KeyEqual>
-inline STDGPU_HOST_DEVICE index_t
-unordered_set<Key, Hash, KeyEqual>::total_count() const
-{
-    return _base.total_count();
-}
-
-
-template <typename Key, typename Hash, typename KeyEqual>
 inline STDGPU_HOST_DEVICE float
 unordered_set<Key, Hash, KeyEqual>::load_factor() const
 {
@@ -311,22 +295,6 @@ unordered_set<Key, Hash, KeyEqual>::createDeviceObject(const index_t& capacity)
 
     unordered_set<Key, Hash, KeyEqual> result;
     result._base = detail::unordered_base<key_type, value_type, thrust::identity<key_type>, hasher, key_equal>::createDeviceObject(capacity);
-
-    return result;
-}
-
-
-template <typename Key, typename Hash, typename KeyEqual>
-unordered_set<Key, Hash, KeyEqual>
-unordered_set<Key, Hash, KeyEqual>::createDeviceObject(const index_t& bucket_count,
-                                                       const index_t& excess_count)
-{
-    STDGPU_EXPECTS(bucket_count > 0);
-    STDGPU_EXPECTS(excess_count > 0);
-    STDGPU_EXPECTS(has_single_bit<std::size_t>(static_cast<std::size_t>(bucket_count)));
-
-    unordered_set<Key, Hash, KeyEqual> result;
-    result._base = detail::unordered_base<key_type, value_type, thrust::identity<key_type>, hasher, key_equal>::createDeviceObject(bucket_count, excess_count);
 
     return result;
 }

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -105,21 +105,6 @@ class unordered_map
 
 
         /**
-         * \deprecated Replaced by createDeviceObject(const index_t& capacity)
-         * \brief Creates an object of this class on the GPU (device)
-         * \param[in] bucket_count The number of buckets
-         * \param[in] excess_count The number of excess entries
-         * \pre bucket_count > 0
-         * \pre excess_count > 0
-         * \pre has_single_bit(bucket_count)
-         * \return A newly created object of this class allocated on the GPU (device)
-         */
-        [[deprecated("Replaced by createDeviceObject(const index_t& capacity)")]]
-        static unordered_map
-        createDeviceObject(const index_t& bucket_count,
-                           const index_t& excess_count);
-
-        /**
          * \brief Creates an object of this class on the GPU (device)
          * \param[in] capacity The capacity of the object
          * \pre capacity > 0
@@ -370,24 +355,6 @@ class unordered_map
          */
         STDGPU_HOST_DEVICE index_t
         bucket_count() const;
-
-        /**
-         * \deprecated Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function
-         * \brief The excess count
-         * \return The number of excess entries for handling collisions
-         */
-        [[deprecated("Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function")]]
-        STDGPU_HOST_DEVICE index_t
-        excess_count() const;
-
-        /**
-         * \deprecated Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function
-         * \brief The total count
-         * \return The total number of entries
-         */
-        [[deprecated("Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function")]]
-        STDGPU_HOST_DEVICE index_t
-        total_count() const;
 
 
         /**

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -93,21 +93,6 @@ class unordered_set
 
 
         /**
-         * \deprecated Replaced by createDeviceObject(const index_t& capacity)
-         * \brief Creates an object of this class on the GPU (device)
-         * \param[in] bucket_count The number of buckets
-         * \param[in] excess_count The number of excess entries
-         * \pre bucket_count > 0
-         * \pre excess_count > 0
-         * \pre has_single_bit(bucket_count)
-         * \return A newly created object of this class allocated on the GPU (device)
-         */
-        [[deprecated("Replaced by createDeviceObject(const index_t& capacity)")]]
-        static unordered_set
-        createDeviceObject(const index_t& bucket_count,
-                           const index_t& excess_count);
-
-        /**
          * \brief Creates an object of this class on the GPU (device)
          * \param[in] capacity The capacity of the object
          * \pre capacity > 0
@@ -358,24 +343,6 @@ class unordered_set
          */
         STDGPU_HOST_DEVICE index_t
         bucket_count() const;
-
-        /**
-         * \deprecated Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function
-         * \brief The excess count
-         * \return The number of excess entries for handling collisions
-         */
-        [[deprecated("Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function")]]
-        STDGPU_HOST_DEVICE index_t
-        excess_count() const;
-
-        /**
-         * \deprecated Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function
-         * \brief The total count
-         * \return The total number of entries
-         */
-        [[deprecated("Implementation detail of deprecated createDeviceObject(const index_t& bucket_count, const index_t& excess_count) function")]]
-        STDGPU_HOST_DEVICE index_t
-        total_count() const;
 
 
         /**

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -2289,21 +2289,6 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, clear)
 }
 
 
-TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, deprecated_createDeviceObject)
-{
-    const stdgpu::index_t buckets = static_cast<stdgpu::index_t>(pow(2, 17));
-    const stdgpu::index_t excess  = 1000;
-
-    test_unordered_datastructure deprecated_hash_datastructure = test_unordered_datastructure::createDeviceObject(buckets, excess);
-
-    EXPECT_EQ(deprecated_hash_datastructure.bucket_count(), buckets);
-    EXPECT_EQ(deprecated_hash_datastructure.excess_count(), excess);
-    EXPECT_EQ(deprecated_hash_datastructure.total_count(),  buckets + excess);
-
-    test_unordered_datastructure::destroyDeviceObject(deprecated_hash_datastructure);
-}
-
-
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, get_allocator)
 {
     test_unordered_datastructure::allocator_type a = hash_datastructure.get_allocator();


### PR DESCRIPTION
This removes the deprecated functions in the `unordered_map` and `unordered_set` modules.

Partially addresses #51