### PR TITLE
cmake: Remove deprecated options

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,12 +274,8 @@ In addition, the implementation of some functionality can be controlled via conf
 
 Configuration Option | Effect | Default
 --- | --- | ---
-`STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING` | Enable warnings when auxiliary arrays are allocated in memory API (**deprecated**) | `OFF`
 `STDGPU_ENABLE_CONTRACT_CHECKS` | Enable contract checks | `OFF` if `CMAKE_BUILD_TYPE` equals `Release` or `MinSizeRel`, `ON` otherwise
-`STDGPU_ENABLE_MANAGED_ARRAY_WARNING` | Enable warnings when managed memory is initialized on the host side but should be on device in memory API (**deprecated**) | `OFF`
 `STDGPU_USE_32_BIT_INDEX` | Use 32-bit instead of 64-bit signed integer for `index_t` | `ON`
-`STDGPU_USE_FAST_DESTROY` | Use fast destruction of allocated arrays (filled with a default value) by omitting destructor calls in memory API (**deprecated**) | `OFF`
-`STDGPU_USE_FIBONACCI_HASHING` | Use Fibonacci Hashing instead of Modulo to compute hash bucket indices (**deprecated**) | `ON`
 
 
 ## Contributing

--- a/cmake/config_summary.cmake
+++ b/cmake/config_summary.cmake
@@ -21,12 +21,8 @@ function(stdgpu_print_configuration_summary)
     message(STATUS "")
 
     message(STATUS "Configuration:")
-    message(STATUS "  STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING     :   [deprecated] ${STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING}")
     message(STATUS "  STDGPU_ENABLE_CONTRACT_CHECKS             :   ${STDGPU_ENABLE_CONTRACT_CHECKS}")
-    message(STATUS "  STDGPU_ENABLE_MANAGED_ARRAY_WARNING       :   [deprecated] ${STDGPU_ENABLE_MANAGED_ARRAY_WARNING}")
     message(STATUS "  STDGPU_USE_32_BIT_INDEX                   :   ${STDGPU_USE_32_BIT_INDEX}")
-    message(STATUS "  STDGPU_USE_FAST_DESTROY                   :   [deprecated] ${STDGPU_USE_FAST_DESTROY}")
-    message(STATUS "  STDGPU_USE_FIBONACCI_HASHING              :   [deprecated] ${STDGPU_USE_FIBONACCI_HASHING}")
 
     message(STATUS "")
 

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -225,12 +225,8 @@ In addition, the implementation of some functionality can be controlled via conf
 
 Configuration Option | Effect | Default
 --- | --- | ---
-`STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING` | Enable warnings when auxiliary arrays are allocated in memory API (**deprecated**) | `OFF`
 `STDGPU_ENABLE_CONTRACT_CHECKS` | Enable contract checks | `OFF` if `CMAKE_BUILD_TYPE` equals `Release` or `MinSizeRel`, `ON` otherwise
-`STDGPU_ENABLE_MANAGED_ARRAY_WARNING` | Enable warnings when managed memory is initialized on the host side but should be on device in memory API (**deprecated**) | `OFF`
 `STDGPU_USE_32_BIT_INDEX` | Use 32-bit instead of 64-bit signed integer for `index_t` | `ON`
-`STDGPU_USE_FAST_DESTROY` | Use fast destruction of allocated arrays (filled with a default value) by omitting destructor calls in memory API (**deprecated**) | `OFF`
-`STDGPU_USE_FIBONACCI_HASHING` | Use Fibonacci Hashing instead of Modulo to compute hash bucket indices (**deprecated**) | `ON`
 
 
 \section contributing Contributing

--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -18,12 +18,8 @@ else()
     set(STDGPU_ENABLE_CONTRACT_CHECKS_DEFAULT ON)
 endif()
 
-option(STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING "Enable warnings when auxiliary arrays are allocated in memory API (deprecated), default: OFF" OFF)
 option(STDGPU_ENABLE_CONTRACT_CHECKS "Enable contract checks, default: OFF if CMAKE_BUILD_TYPE is Release or MinSizeRel, ON otherwise" ${STDGPU_ENABLE_CONTRACT_CHECKS_DEFAULT})
-option(STDGPU_ENABLE_MANAGED_ARRAY_WARNING "Enable warnings when managed memory is initialized on the host side but should be on device in memory API (deprecated), default: OFF" OFF)
 option(STDGPU_USE_32_BIT_INDEX "Use 32-bit instead of 64-bit signed integer for index_t, default: ON" ON)
-option(STDGPU_USE_FAST_DESTROY "Use fast destruction of allocated arrays (filled with a default value) by omitting destructor calls in memory API (deprecated), default: OFF" OFF)
-option(STDGPU_USE_FIBONACCI_HASHING "Use Fibonacci Hashing instead of Modulo to compute hash bucket indices (deprecated), default: ON" ON)
 
 configure_file("${STDGPU_INCLUDE_LOCAL_DIR}/stdgpu/config.h.in"
                "${STDGPU_BUILD_INCLUDE_DIR}/stdgpu/config.h"

--- a/src/stdgpu/config.h.in
+++ b/src/stdgpu/config.h.in
@@ -69,17 +69,6 @@ namespace stdgpu
 
 /**
  * \ingroup config
- * \def STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING
- * \brief Library option to enable warnings when falling back to use auxiliary arrays
- */
-// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
-#ifdef STDGPU_RUN_DOXYGEN
-    #define STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING
-#endif
-#cmakedefine01 STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING
-
-/**
- * \ingroup config
  * \def STDGPU_ENABLE_CONTRACT_CHECKS
  * \brief Library option to enable contract checks
  */
@@ -91,17 +80,6 @@ namespace stdgpu
 
 /**
  * \ingroup config
- * \def STDGPU_ENABLE_MANAGED_ARRAY_WARNING
- * \brief Library option to enable warnings when device initialization of managed memory can only be performed on the host
- */
-// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
-#ifdef STDGPU_RUN_DOXYGEN
-    #define STDGPU_ENABLE_MANAGED_ARRAY_WARNING
-#endif
-#cmakedefine01 STDGPU_ENABLE_MANAGED_ARRAY_WARNING
-
-/**
- * \ingroup config
  * \def STDGPU_USE_32_BIT_INDEX
  * \brief Library option to use 32-bit integers rather than 64-bit to define index_t
  */
@@ -110,28 +88,6 @@ namespace stdgpu
     #define STDGPU_USE_32_BIT_INDEX
 #endif
 #cmakedefine01 STDGPU_USE_32_BIT_INDEX
-
-/**
- * \ingroup config
- * \def STDGPU_USE_FAST_DESTROY
- * \brief Library option to use fast destruction of arrays
- */
-// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
-#ifdef STDGPU_RUN_DOXYGEN
-    #define STDGPU_USE_FAST_DESTROY
-#endif
-#cmakedefine01 STDGPU_USE_FAST_DESTROY
-
-/**
- * \ingroup config
- * \def STDGPU_USE_FIBONACCI_HASHING
- * \brief Library option to use Fibonacci Hashing to compute the bucket from the hash value
- */
-// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
-#ifdef STDGPU_RUN_DOXYGEN
-    #define STDGPU_USE_FIBONACCI_HASHING
-#endif
-#cmakedefine01 STDGPU_USE_FIBONACCI_HASHING
 
 } // namespace stdgpu
 

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -27,7 +27,6 @@
 #include <thrust/logical.h>
 
 #include <stdgpu/bit.h>
-#include <stdgpu/config.h>
 #include <stdgpu/contract.h>
 #include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
@@ -449,11 +448,7 @@ template <typename Key, typename Value, typename KeyFromValue, typename Hash, ty
 inline STDGPU_HOST_DEVICE index_t
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::bucket(const key_type& key) const
 {
-    #if STDGPU_USE_FIBONACCI_HASHING
-        index_t result = fibonacci_hashing(_hash(key), bucket_count());
-    #else
-        index_t result = static_cast<index_t>(bit_mod<std::size_t>(_hash(key), static_cast<std::size_t>(bucket_count())));
-    #endif
+    index_t result = fibonacci_hashing(_hash(key), bucket_count());
 
     STDGPU_ENSURES(0 <= result);
     STDGPU_ENSURES(result < bucket_count());

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -53,7 +53,6 @@ enum class Initialization
  * \param[in] default_value A default value, that should be stored in every array entry
  * \return The allocated device array if count > 0, nullptr otherwise
  * \post get_dynamic_memory_type(result) == dynamic_memory_type::device if count > 0
- * \note If `STDGPU_ENABLE_AUXILIARY_ARRAY_WARNING` is defined, this functions prints a warning when the array initialization requires using an auxiliary host array (i.e. to support compilation without a device compiler as a .cpp file).
  */
 template <typename T>
 T*
@@ -83,7 +82,6 @@ createHostArray(const stdgpu::index64_t count,
  * \param[in] initialize_on The device on which the fill operation is performed
  * \return The allocated managed array if count > 0, nullptr otherwise
  * \post get_dynamic_memory_type(result) == dynamic_memory_type::managed if count > 0
- * \note If `STDGPU_ENABLE_MANAGED_ARRAY_WARNING` is defined, this functions prints a warning when device initialization is not possible and initialization on the host is performed instead (i.e. to support compilation without a device compiler as a .cpp file).
  */
 template <typename T>
 T*


### PR DESCRIPTION
This removes the deprecated CMake options and the related functionality.

Partially addresses #51