### PR TITLE
Container: Add coverage for handling empty containers

### DIFF
--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -207,6 +207,40 @@ atomic_ref<unsigned int>::operator^=<unsigned int, void>(const unsigned int);
 
 template <typename T>
 void
+empty_container()
+{
+    stdgpu::atomic<T> empty_container;
+
+    EXPECT_EQ(empty_container.load(), T());
+
+    const T loaded = empty_container;
+    EXPECT_EQ(loaded, T());
+
+    const T new_value = static_cast<T>(42);
+    empty_container.store(new_value);
+    empty_container = new_value;
+}
+
+
+
+TEST_F(stdgpu_atomic, empty_container_int)
+{
+    empty_container<int>();
+}
+
+TEST_F(stdgpu_atomic, empty_container_unsigned_int)
+{
+    empty_container<unsigned int>();
+}
+
+TEST_F(stdgpu_atomic, empty_container_unsigned_long_long_int)
+{
+    empty_container<unsigned long long int>();
+}
+
+
+template <typename T>
+void
 load_and_store()
 {
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -52,6 +52,19 @@ class stdgpu_bitset : public ::testing::Test
 
 
 
+TEST_F(stdgpu_bitset, empty_container)
+{
+    stdgpu::bitset empty_container;
+
+    EXPECT_TRUE(empty_container.empty());
+    EXPECT_EQ(empty_container.size(), 0);
+    EXPECT_EQ(empty_container.count(), 0);
+    EXPECT_FALSE(empty_container.all());
+    EXPECT_FALSE(empty_container.any());
+    EXPECT_FALSE(empty_container.none());
+}
+
+
 TEST_F(stdgpu_bitset, default_values)
 {
     EXPECT_EQ(bitset.count(), 0);

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -64,6 +64,17 @@ deque<int>::emplace_front<int>(int&&);
 } // namespace stdgpu
 
 
+TEST_F(stdgpu_deque, empty_container)
+{
+    stdgpu::deque<int> empty_container;
+
+    EXPECT_TRUE(empty_container.empty());
+    EXPECT_TRUE(empty_container.full());
+    EXPECT_EQ(empty_container.size(), 0);
+    EXPECT_TRUE(empty_container.valid());
+}
+
+
 template <typename T>
 class pop_back_deque
 {

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -48,6 +48,16 @@ class stdgpu_mutex : public ::testing::Test
 
 
 
+TEST_F(stdgpu_mutex, empty_container)
+{
+    stdgpu::mutex_array empty_container;
+
+    EXPECT_TRUE(empty_container.empty());
+    EXPECT_EQ(empty_container.size(), 0);
+    EXPECT_TRUE(empty_container.valid());
+}
+
+
 TEST_F(stdgpu_mutex, default_values)
 {
     EXPECT_TRUE(locks.valid());

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -73,6 +73,17 @@ class STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS : public ::testing::Test
 
 
 
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, empty_container)
+{
+    test_unordered_datastructure empty_container;
+
+    EXPECT_TRUE(empty_container.empty());
+    EXPECT_TRUE(empty_container.full());
+    EXPECT_EQ(empty_container.size(), 0);
+    EXPECT_TRUE(empty_container.valid());
+}
+
+
 namespace
 {
     void

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -61,6 +61,17 @@ vector<int>::emplace_back<int>(int&&);
 } // namespace stdgpu
 
 
+TEST_F(stdgpu_vector, empty_container)
+{
+    stdgpu::vector<int> empty_container;
+
+    EXPECT_TRUE(empty_container.empty());
+    EXPECT_TRUE(empty_container.full());
+    EXPECT_EQ(empty_container.size(), 0);
+    EXPECT_TRUE(empty_container.valid());
+}
+
+
 template <typename T>
 class pop_back_vector
 {


### PR DESCRIPTION
Empty containers, i.e. the ones not created via `createDeviceObject(...)`, are also valid objects and some functions implement special handling of this case to avoid segmentation faults. However, these corner cases were not covered by the test suite. Add the missing tests to increase the code coverage.