### PR TITLE
contract: Add support for expressions containing commas

### DIFF
--- a/src/stdgpu/contract.h
+++ b/src/stdgpu/contract.h
@@ -30,6 +30,7 @@
 #include <cassert>
 #include <exception>
 
+#include <stdgpu/config.h>
 #include <stdgpu/cstddef.h>
 #include <stdgpu/platform.h>
 
@@ -60,41 +61,41 @@ namespace stdgpu
 
 #if STDGPU_ENABLE_CONTRACT_CHECKS
 
-    #define STDGPU_DETAIL_HOST_CHECK(type, condition) \
-        if (!(condition)) \
+    #define STDGPU_DETAIL_HOST_CHECK(type, ...) \
+        if (!(__VA_ARGS__)) \
         { \
             printf("stdgpu : " type " failure :\n" \
                    "  File      : %s:%d\n" \
                    "  Function  : %s\n" \
                    "  Condition : %s\n", \
-                   __FILE__, __LINE__, static_cast<const char*>(STDGPU_FUNC), #condition); \
+                   __FILE__, __LINE__, static_cast<const char*>(STDGPU_FUNC), #__VA_ARGS__); \
             std::terminate(); \
         } \
         STDGPU_DETAIL_EMPTY_STATEMENT
 
-    #define STDGPU_DETAIL_HOST_EXPECTS(condition) STDGPU_DETAIL_HOST_CHECK("Precondition", condition)
-    #define STDGPU_DETAIL_HOST_ENSURES(condition) STDGPU_DETAIL_HOST_CHECK("Postcondition", condition)
-    #define STDGPU_DETAIL_HOST_ASSERT(condition) STDGPU_DETAIL_HOST_CHECK("Assertion", condition)
+    #define STDGPU_DETAIL_HOST_EXPECTS(...) STDGPU_DETAIL_HOST_CHECK("Precondition", __VA_ARGS__)
+    #define STDGPU_DETAIL_HOST_ENSURES(...) STDGPU_DETAIL_HOST_CHECK("Postcondition", __VA_ARGS__)
+    #define STDGPU_DETAIL_HOST_ASSERT(...) STDGPU_DETAIL_HOST_CHECK("Assertion", __VA_ARGS__)
 
-    #define STDGPU_DETAIL_DEVICE_CHECK(condition) assert(condition) // NOLINT(hicpp-no-array-decay)
+    #define STDGPU_DETAIL_DEVICE_CHECK(...) assert((__VA_ARGS__)) // NOLINT(hicpp-no-array-decay)
 
-    #define STDGPU_DETAIL_DEVICE_EXPECTS(condition) STDGPU_DETAIL_DEVICE_CHECK(condition)
-    #define STDGPU_DETAIL_DEVICE_ENSURES(condition) STDGPU_DETAIL_DEVICE_CHECK(condition)
-    #define STDGPU_DETAIL_DEVICE_ASSERT(condition) STDGPU_DETAIL_DEVICE_CHECK(condition)
+    #define STDGPU_DETAIL_DEVICE_EXPECTS(...) STDGPU_DETAIL_DEVICE_CHECK(__VA_ARGS__)
+    #define STDGPU_DETAIL_DEVICE_ENSURES(...) STDGPU_DETAIL_DEVICE_CHECK(__VA_ARGS__)
+    #define STDGPU_DETAIL_DEVICE_ASSERT(...) STDGPU_DETAIL_DEVICE_CHECK(__VA_ARGS__)
 
     #if STDGPU_CODE == STDGPU_CODE_DEVICE
-        #define STDGPU_EXPECTS(condition) STDGPU_DETAIL_DEVICE_EXPECTS(condition)
-        #define STDGPU_ENSURES(condition) STDGPU_DETAIL_DEVICE_ENSURES(condition)
-        #define STDGPU_ASSERT(condition) STDGPU_DETAIL_DEVICE_ASSERT(condition)
+        #define STDGPU_EXPECTS(...) STDGPU_DETAIL_DEVICE_EXPECTS(__VA_ARGS__)
+        #define STDGPU_ENSURES(...) STDGPU_DETAIL_DEVICE_ENSURES(__VA_ARGS__)
+        #define STDGPU_ASSERT(...) STDGPU_DETAIL_DEVICE_ASSERT(__VA_ARGS__)
     #else
-        #define STDGPU_EXPECTS(condition) STDGPU_DETAIL_HOST_EXPECTS(condition)
-        #define STDGPU_ENSURES(condition) STDGPU_DETAIL_HOST_ENSURES(condition)
-        #define STDGPU_ASSERT(condition) STDGPU_DETAIL_HOST_ASSERT(condition)
+        #define STDGPU_EXPECTS(...) STDGPU_DETAIL_HOST_EXPECTS(__VA_ARGS__)
+        #define STDGPU_ENSURES(...) STDGPU_DETAIL_HOST_ENSURES(__VA_ARGS__)
+        #define STDGPU_ASSERT(...) STDGPU_DETAIL_HOST_ASSERT(__VA_ARGS__)
     #endif
 #else
-    #define STDGPU_EXPECTS(condition) STDGPU_DETAIL_EMPTY_STATEMENT
-    #define STDGPU_ENSURES(condition) STDGPU_DETAIL_EMPTY_STATEMENT
-    #define STDGPU_ASSERT(condition) STDGPU_DETAIL_EMPTY_STATEMENT
+    #define STDGPU_EXPECTS(...) STDGPU_DETAIL_EMPTY_STATEMENT
+    #define STDGPU_ENSURES(...) STDGPU_DETAIL_EMPTY_STATEMENT
+    #define STDGPU_ASSERT(...) STDGPU_DETAIL_EMPTY_STATEMENT
 #endif
 
 } // namespace stdgpu

--- a/test/stdgpu/CMakeLists.txt
+++ b/test/stdgpu/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(teststdgpu main.cpp)
 target_sources(teststdgpu PRIVATE algorithm.cpp
                                   bit.cpp
                                   cmath.cpp
+                                  contract.cpp
                                   functional.cpp
                                   iterator.cpp
                                   limits.cpp

--- a/test/stdgpu/contract.cpp
+++ b/test/stdgpu/contract.cpp
@@ -1,0 +1,153 @@
+/*
+ *  Copyright 2020 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+#include <stdgpu/config.h>
+#include <stdgpu/contract.h>
+
+
+
+class stdgpu_contract : public ::testing::Test
+{
+    protected:
+        // Called before each test
+        void SetUp() override
+        {
+
+        }
+
+        // Called after each test
+        void TearDown() override
+        {
+
+        }
+
+};
+
+
+TEST_F(stdgpu_contract, expects_host_value)
+{
+    #if STDGPU_ENABLE_CONTRACT_CHECKS
+        volatile bool true_value = true;
+
+        STDGPU_EXPECTS(true_value);
+
+        volatile bool false_value = false;
+
+        EXPECT_DEATH(STDGPU_EXPECTS(false_value), ""); //NOLINT(hicpp-no-array-decay)
+    #endif
+}
+
+
+TEST_F(stdgpu_contract, expects_host_expression)
+{
+    #if STDGPU_ENABLE_CONTRACT_CHECKS
+        volatile int value_1 = 42;
+        volatile int value_2 = 24;
+
+        STDGPU_EXPECTS(value_1 == 42 && value_2 > 0);
+
+        EXPECT_DEATH(STDGPU_EXPECTS(value_1 != 42 || value_2 <= 0), ""); //NOLINT(hicpp-no-array-decay)
+    #endif
+}
+
+
+TEST_F(stdgpu_contract, expects_host_comma_expression)
+{
+    #if STDGPU_ENABLE_CONTRACT_CHECKS
+        STDGPU_EXPECTS(std::is_same<int, int>::value); //NOLINT(hicpp-static-assert,misc-static-assert)
+
+        EXPECT_DEATH(STDGPU_EXPECTS(std::is_same<int, float>::value), ""); //NOLINT(hicpp-no-array-decay,hicpp-static-assert,misc-static-assert)
+    #endif
+}
+
+
+TEST_F(stdgpu_contract, ensures_host_value)
+{
+    #if STDGPU_ENABLE_CONTRACT_CHECKS
+        volatile bool true_value = true;
+
+        STDGPU_ENSURES(true_value);
+
+        volatile bool false_value = false;
+
+        EXPECT_DEATH(STDGPU_ENSURES(false_value), ""); //NOLINT(hicpp-no-array-decay)
+    #endif
+}
+
+
+TEST_F(stdgpu_contract, ensures_host_expression)
+{
+    #if STDGPU_ENABLE_CONTRACT_CHECKS
+        volatile int value_1 = 42;
+        volatile int value_2 = 24;
+
+        STDGPU_ENSURES(value_1 == 42 && value_2 > 0);
+
+        EXPECT_DEATH(STDGPU_ENSURES(value_1 != 42 || value_2 <= 0), ""); //NOLINT(hicpp-no-array-decay)
+    #endif
+}
+
+
+TEST_F(stdgpu_contract, ensures_host_comma_expression)
+{
+    #if STDGPU_ENABLE_CONTRACT_CHECKS
+        STDGPU_ENSURES(std::is_same<int, int>::value); //NOLINT(hicpp-static-assert,misc-static-assert)
+
+        EXPECT_DEATH(STDGPU_ENSURES(std::is_same<int, float>::value), ""); //NOLINT(hicpp-no-array-decay,hicpp-static-assert,misc-static-assert)
+    #endif
+}
+
+
+TEST_F(stdgpu_contract, assert_host_value)
+{
+    #if STDGPU_ENABLE_CONTRACT_CHECKS
+        volatile bool true_value = true;
+
+        STDGPU_ASSERT(true_value);
+
+        volatile bool false_value = false;
+
+        EXPECT_DEATH(STDGPU_ASSERT(false_value), ""); //NOLINT(hicpp-no-array-decay)
+    #endif
+}
+
+
+TEST_F(stdgpu_contract, assert_host_expression)
+{
+    #if STDGPU_ENABLE_CONTRACT_CHECKS
+        volatile int value_1 = 42;
+        volatile int value_2 = 24;
+
+        STDGPU_ASSERT(value_1 == 42 && value_2 > 0);
+
+        EXPECT_DEATH(STDGPU_ASSERT(value_1 != 42 || value_2 <= 0), ""); //NOLINT(hicpp-no-array-decay)
+    #endif
+}
+
+
+TEST_F(stdgpu_contract, assert_host_comma_expression)
+{
+    #if STDGPU_ENABLE_CONTRACT_CHECKS
+        STDGPU_ASSERT(std::is_same<int, int>::value); //NOLINT(hicpp-static-assert,misc-static-assert)
+
+        EXPECT_DEATH(STDGPU_ASSERT(std::is_same<int, float>::value), ""); //NOLINT(hicpp-no-array-decay,hicpp-static-assert,misc-static-assert)
+    #endif
+}
+
+


### PR DESCRIPTION
The contracts are defined as macros to handle the different scenarios and use cases. However, expressions containing commas, which is often the case in the presence of templates, are rejected by the compiler if not properly guarded by parentheses. Although this behavior is well-known from the `assert(...)` macro, it still limits the usability. Add support for such unguarded expressions and introduce dedicated unit tests for the `contract` macros.