### PR TITLE
examples: Fix sign comparison warnings in CUDA examples

### DIFF
--- a/examples/cuda/bitset.cu
+++ b/examples/cuda/bitset.cu
@@ -41,7 +41,7 @@ set_bits(const int* d_result,
          stdgpu::bitset bits,
          stdgpu::atomic<int> counter)
 {
-    stdgpu::index_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    stdgpu::index_t i = static_cast<stdgpu::index_t>(blockIdx.x * blockDim.x + threadIdx.x);
 
     if (i >= d_result_size) return;
 
@@ -88,7 +88,7 @@ main()
 
     counter.store(0);
 
-    set_bits<<< blocks, threads >>>(d_result, n / 2, bits, counter);
+    set_bits<<< static_cast<unsigned int>(blocks), static_cast<unsigned int>(threads) >>>(d_result, n / 2, bits, counter);
     cudaDeviceSynchronize();
 
     // bits : 010101...01
@@ -97,7 +97,7 @@ main()
 
     counter.store(0);
 
-    set_bits<<< blocks, threads >>>(d_result, n / 2, bits, counter);
+    set_bits<<< static_cast<unsigned int>(blocks), static_cast<unsigned int>(threads) >>>(d_result, n / 2, bits, counter);
     cudaDeviceSynchronize();
 
     // bits : 010101...01

--- a/examples/cuda/deque.cu
+++ b/examples/cuda/deque.cu
@@ -40,7 +40,7 @@ insert_neighbors_with_duplicates(const int* d_input,
                                  const stdgpu::index_t n,
                                  stdgpu::deque<int> deq)
 {
-    stdgpu::index_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    stdgpu::index_t i = static_cast<stdgpu::index_t>(blockIdx.x * blockDim.x + threadIdx.x);
 
     if (i >= n) return;
 
@@ -85,7 +85,7 @@ main()
 
     stdgpu::index_t threads = 32;
     stdgpu::index_t blocks = (n + threads - 1) / threads;
-    insert_neighbors_with_duplicates<<< blocks, threads >>>(d_input, n, deq);
+    insert_neighbors_with_duplicates<<< static_cast<unsigned int>(blocks), static_cast<unsigned int>(threads) >>>(d_input, n, deq);
     cudaDeviceSynchronize();
 
     // deq : 0, 1, 1, 2, 2, 2, 3, 3, 3,  ..., 99, 99, 99, 100, 100, 101

--- a/examples/cuda/mutex_array.cu
+++ b/examples/cuda/mutex_array.cu
@@ -42,7 +42,7 @@ try_partial_sum(const int* d_input,
                 stdgpu::mutex_array locks,
                 int* d_result)
 {
-    stdgpu::index_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    stdgpu::index_t i = static_cast<stdgpu::index_t>(blockIdx.x * blockDim.x + threadIdx.x);
 
     if (i >= n) return;
 
@@ -93,7 +93,7 @@ main()
 
     stdgpu::index_t threads = 32;
     stdgpu::index_t blocks = (n + threads - 1) / threads;
-    try_partial_sum<<< blocks, threads >>>(d_input, n, locks, d_result);
+    try_partial_sum<<< static_cast<unsigned int>(blocks), static_cast<unsigned int>(threads) >>>(d_input, n, locks, d_result);
     cudaDeviceSynchronize();
 
     int sum = thrust::reduce(stdgpu::device_cbegin(d_result), stdgpu::device_cend(d_result),

--- a/examples/cuda/unordered_map.cu
+++ b/examples/cuda/unordered_map.cu
@@ -62,7 +62,7 @@ insert_neighbors(const int* d_result,
                  const stdgpu::index_t n,
                  stdgpu::unordered_map<int, int> map)
 {
-    stdgpu::index_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    stdgpu::index_t i = static_cast<stdgpu::index_t>(blockIdx.x * blockDim.x + threadIdx.x);
 
     if (i >= n) return;
 
@@ -104,7 +104,7 @@ main()
 
     stdgpu::index_t threads = 32;
     stdgpu::index_t blocks = (n / 2 + threads - 1) / threads;
-    insert_neighbors<<< blocks, threads >>>(d_result, n / 2, map);
+    insert_neighbors<<< static_cast<unsigned int>(blocks), static_cast<unsigned int>(threads) >>>(d_result, n / 2, map);
     cudaDeviceSynchronize();
 
     // map : 0, 1, 2, 3, ..., 100

--- a/examples/cuda/unordered_set.cu
+++ b/examples/cuda/unordered_set.cu
@@ -40,7 +40,7 @@ insert_neighbors(const int* d_result,
                  const stdgpu::index_t n,
                  stdgpu::unordered_set<int> set)
 {
-    stdgpu::index_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    stdgpu::index_t i = static_cast<stdgpu::index_t>(blockIdx.x * blockDim.x + threadIdx.x);
 
     if (i >= n) return;
 
@@ -82,7 +82,7 @@ main()
 
     stdgpu::index_t threads = 32;
     stdgpu::index_t blocks = (n / 2 + threads - 1) / threads;
-    insert_neighbors<<< blocks, threads >>>(d_result, n / 2, set);
+    insert_neighbors<<< static_cast<unsigned int>(blocks), static_cast<unsigned int>(threads) >>>(d_result, n / 2, set);
     cudaDeviceSynchronize();
 
     // set : 0, 1, 2, 3, ..., 100

--- a/examples/cuda/vector.cu
+++ b/examples/cuda/vector.cu
@@ -30,7 +30,7 @@ insert_neighbors_with_duplicates(const int* d_input,
                                  const stdgpu::index_t n,
                                  stdgpu::vector<int> vec)
 {
-    stdgpu::index_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    stdgpu::index_t i = static_cast<stdgpu::index_t>(blockIdx.x * blockDim.x + threadIdx.x);
 
     if (i >= n) return;
 
@@ -66,7 +66,7 @@ main()
 
     stdgpu::index_t threads = 32;
     stdgpu::index_t blocks = (n + threads - 1) / threads;
-    insert_neighbors_with_duplicates<<< blocks, threads >>>(d_input, n, vec);
+    insert_neighbors_with_duplicates<<< static_cast<unsigned int>(blocks), static_cast<unsigned int>(threads) >>>(d_input, n, vec);
     cudaDeviceSynchronize();
 
     // vec : 0, 1, 1, 2, 2, 2, 3, 3, 3,  ..., 99, 99, 99, 100, 100, 101


### PR DESCRIPTION
CUDA uses unsigned integers to represent thread and thread block numbers. Since we use signed integers for indices, this may raise compiler warnings. Fix these sign comparison warnings by explicit casting.