### PR TITLE
General: Add support for CUDA-Clang compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ Before building the library, please make sure that all required tools and depend
 
 <b>Required for CUDA backend</b>
 
+- CUDA compiler
+    - NVCC
+        - Already included in CUDA Toolkit
+    - Clang 11
+        - (Ubuntu 18.04) https://apt.llvm.org/
+        - Requires at least CMake 3.18
 - CUDA Toolkit 10.0
     - (Ubuntu/Windows) https://developer.nvidia.com/cuda-downloads
     - Includes thrust

--- a/cmake/cuda/set_device_flags.cmake
+++ b/cmake/cuda/set_device_flags.cmake
@@ -33,6 +33,11 @@ function(stdgpu_set_device_flags STDGPU_OUTPUT_DEVICE_FLAGS)
     if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
         string(REPLACE ";" "," ${STDGPU_OUTPUT_DEVICE_FLAGS} "${${STDGPU_OUTPUT_DEVICE_FLAGS}}")
         set(${STDGPU_OUTPUT_DEVICE_FLAGS} "-Xcompiler=${${STDGPU_OUTPUT_DEVICE_FLAGS}}")
+    elseif(CMAKE_CUDA_COMPILER_ID STREQUAL "Clang")
+        # Directly pass flags to CUDA-Clang
+
+        # Workaround to suppress ptxas warnings in thrust (see https://github.com/NVIDIA/thrust/issues/1327)
+        set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcuda-ptxas --disable-warnings" PARENT_SCOPE)
     endif()
 
     set(${STDGPU_OUTPUT_DEVICE_FLAGS} "$<$<COMPILE_LANGUAGE:CUDA>:${${STDGPU_OUTPUT_DEVICE_FLAGS}}>")

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -142,6 +142,12 @@ Before building the library, please make sure that all required tools and depend
 
 <b>Required for CUDA backend</b>
 
+- CUDA compiler
+    - NVCC
+        - Already included in CUDA Toolkit
+    - Clang 11
+        - (Ubuntu 18.04) https://apt.llvm.org/
+        - Requires at least CMake 3.18
 - CUDA Toolkit 10.0
     - (Ubuntu/Windows) https://developer.nvidia.com/cuda-downloads
     - Includes thrust

--- a/src/stdgpu/compiler.h
+++ b/src/stdgpu/compiler.h
@@ -67,6 +67,11 @@ namespace stdgpu
  * \brief Device compiler: HIP-Clang
  */
 #define STDGPU_DEVICE_COMPILER_HIPCLANG 22
+/**
+ * \ingroup compiler
+ * \brief Device compiler: CUDA-Clang
+ */
+#define STDGPU_DEVICE_COMPILER_CUDACLANG 23
 
 /**
  * \ingroup compiler
@@ -92,6 +97,8 @@ namespace stdgpu
     #define STDGPU_DEVICE_COMPILER STDGPU_DEVICE_COMPILER_NVCC
 #elif defined(__HIP__)
     #define STDGPU_DEVICE_COMPILER STDGPU_DEVICE_COMPILER_HIPCLANG
+#elif defined(__clang__) && defined(__CUDA__)
+    #define STDGPU_DEVICE_COMPILER STDGPU_DEVICE_COMPILER_CUDACLANG
 #else
     #define STDGPU_DEVICE_COMPILER STDGPU_DEVICE_COMPILER_UNKNOWN
 #endif

--- a/src/stdgpu/contract.h
+++ b/src/stdgpu/contract.h
@@ -30,10 +30,26 @@
 #include <cassert>
 #include <exception>
 
+#include <stdgpu/compiler.h>
 #include <stdgpu/config.h>
 #include <stdgpu/cstddef.h>
 #include <stdgpu/platform.h>
 
+
+
+//! @cond Doxygen_Suppress
+// NOTE: CUDA-Clang uses merged parsing and needs a device version of std::terminate
+#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_CUDACLANG
+    namespace std
+    {
+        STDGPU_CUDA_DEVICE_ONLY void
+        terminate()
+        {
+            // Dummy function for parsing only
+        }
+    } // namespace std
+#endif
+//! @endcond
 
 
 namespace stdgpu

--- a/src/stdgpu/cuda/platform.h
+++ b/src/stdgpu/cuda/platform.h
@@ -30,7 +30,7 @@ namespace cuda
  * \def STDGPU_CUDA_HOST_DEVICE
  * \brief Platform-independent host device function annotation
  */
-#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC
+#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC || STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_CUDACLANG
     #define STDGPU_CUDA_HOST_DEVICE __host__ __device__
 #else
     #define STDGPU_CUDA_HOST_DEVICE
@@ -41,7 +41,7 @@ namespace cuda
  * \def STDGPU_CUDA_DEVICE_ONLY
  * \brief Platform-independent device function annotation
  */
-#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC
+#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC || STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_CUDACLANG
     #define STDGPU_CUDA_DEVICE_ONLY __device__
 #else
     // Should trigger a compact error message containing the error string
@@ -53,7 +53,7 @@ namespace cuda
  * \def STDGPU_CUDA_CONSTANT
  * \brief Platform-independent constant variable annotation
  */
-#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC
+#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC || STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_CUDACLANG
     #define STDGPU_CUDA_CONSTANT __constant__
 #else
     #define STDGPU_CUDA_CONSTANT
@@ -75,7 +75,7 @@ namespace cuda
  * \def STDGPU_CUDA_IS_DEVICE_COMPILED
  * \brief Platform-independent device compilation detection
  */
-#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC
+#if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC || STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_CUDACLANG
     #define STDGPU_CUDA_IS_DEVICE_COMPILED 1
 #else
     #define STDGPU_CUDA_IS_DEVICE_COMPILED 0


### PR DESCRIPTION
CMake 3.18 introduced support for Clang as the CUDA compiler. Having more than a single compiler at hand is highly beneficial to improve the portability and platform independence. Add detection for CUDA-Clang and enable the CUDA platform annotations for it. 

In the future, we may reduce the minimum requirements to Clang 10. However, this requires to turn off C++ extensions due to a bug in Clang which has been fixed in Clang 11.