### PR TITLE
src,test: Handle more recent clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,18 +2,22 @@
 Checks: "-*,\
 bugprone-*,\
 hicpp-*,\
+-hicpp-avoid-c-arrays,\
 -hicpp-vararg,\
 -hicpp-use-auto,\
 -hicpp-special-member-functions,\
 misc-*,\
 modernize-*,\
+-modernize-avoid-c-arrays,\
 -modernize-use-auto,\
 -modernize-pass-by-value,\
 -modernize-return-braced-init-list,\
+-modernize-use-trailing-return-type,\
 performance-*,\
 readability-*,\
 -readability-avoid-const-params-in-decls,\
 -readability-const-return-type,\
+-readability-magic-numbers,\
 "
 HeaderFilterRegex: 'src|test/stdgpu'
 ...

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -131,9 +131,9 @@ class bitset
                 reference(block_type* bit_block,
                           const index_t bit_n);
 
-                STDGPU_DEVICE_ONLY bool
+                static STDGPU_DEVICE_ONLY bool
                 bit(block_type bits,
-                    const index_t n) const;
+                    const index_t n);
 
                 static constexpr index_t _bits_per_block = std::numeric_limits<block_type>::digits;
 

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -109,7 +109,7 @@ bitset::reference::flip()
 
 inline STDGPU_DEVICE_ONLY bool
 bitset::reference::bit(bitset::reference::block_type bits,
-                       const index_t n) const
+                       const index_t n)
 {
     STDGPU_EXPECTS(0 <= n);
     STDGPU_EXPECTS(n < _bits_per_block);

--- a/src/stdgpu/impl/iterator_detail.h
+++ b/src/stdgpu/impl/iterator_detail.h
@@ -48,13 +48,13 @@ size(T* array)
 {
     index64_t size_bytes = size<void>(static_cast<void*>(const_cast<std::remove_cv_t<T>*>(array)));
 
-    if (size_bytes % static_cast<index64_t>(sizeof(T)) != 0)
+    if (size_bytes % static_cast<index64_t>(sizeof(T)) != 0) //NOLINT(bugprone-sizeof-expression)
     {
         printf("stdgpu::size : Array type not matching the memory alignment. Returning 0 ...\n");
         return 0;
     }
 
-    return size_bytes / static_cast<index64_t>(sizeof(T));
+    return size_bytes / static_cast<index64_t>(sizeof(T)); //NOLINT(bugprone-sizeof-expression)
 }
 
 

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -368,7 +368,7 @@ copyDevice2HostArray(const T* source_device_array,
 {
     stdgpu::detail::memcpy(destination_host_array,
                            source_device_array,
-                           count * static_cast<stdgpu::index64_t>(sizeof(T)),
+                           count * static_cast<stdgpu::index64_t>(sizeof(T)), //NOLINT(bugprone-sizeof-expression)
                            stdgpu::dynamic_memory_type::host,
                            stdgpu::dynamic_memory_type::device,
                            check_safety != MemoryCopy::RANGE_CHECK);
@@ -384,7 +384,7 @@ copyHost2DeviceArray(const T* source_host_array,
 {
     stdgpu::detail::memcpy(destination_device_array,
                            source_host_array,
-                           count * static_cast<stdgpu::index64_t>(sizeof(T)),
+                           count * static_cast<stdgpu::index64_t>(sizeof(T)), //NOLINT(bugprone-sizeof-expression)
                            stdgpu::dynamic_memory_type::device,
                            stdgpu::dynamic_memory_type::host,
                            check_safety != MemoryCopy::RANGE_CHECK);
@@ -400,7 +400,7 @@ copyHost2HostArray(const T* source_host_array,
 {
     stdgpu::detail::memcpy(destination_host_array,
                            source_host_array,
-                           count * static_cast<stdgpu::index64_t>(sizeof(T)),
+                           count * static_cast<stdgpu::index64_t>(sizeof(T)), //NOLINT(bugprone-sizeof-expression)
                            stdgpu::dynamic_memory_type::host,
                            stdgpu::dynamic_memory_type::host,
                            check_safety != MemoryCopy::RANGE_CHECK);
@@ -416,7 +416,7 @@ copyDevice2DeviceArray(const T* source_device_array,
 {
     stdgpu::detail::memcpy(destination_device_array,
                            source_device_array,
-                           count * static_cast<stdgpu::index64_t>(sizeof(T)),
+                           count * static_cast<stdgpu::index64_t>(sizeof(T)), //NOLINT(bugprone-sizeof-expression)
                            stdgpu::dynamic_memory_type::device,
                            stdgpu::dynamic_memory_type::device,
                            check_safety != MemoryCopy::RANGE_CHECK);
@@ -431,7 +431,7 @@ template <typename T>
 STDGPU_NODISCARD T*
 safe_device_allocator<T>::allocate(index64_t n)
 {
-    return static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type));
+    return static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type)); //NOLINT(bugprone-sizeof-expression)
 }
 
 
@@ -440,7 +440,7 @@ void
 safe_device_allocator<T>::deallocate(T* p,
                                      index64_t n)
 {
-    detail::deallocate(static_cast<void*>(p), n * static_cast<index64_t>(sizeof(T)), memory_type);
+    detail::deallocate(static_cast<void*>(p), n * static_cast<index64_t>(sizeof(T)), memory_type); //NOLINT(bugprone-sizeof-expression)
 }
 
 
@@ -448,7 +448,7 @@ template <typename T>
 STDGPU_NODISCARD T*
 safe_host_allocator<T>::allocate(index64_t n)
 {
-    return static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type));
+    return static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type)); //NOLINT(bugprone-sizeof-expression)
 }
 
 
@@ -457,7 +457,7 @@ void
 safe_host_allocator<T>::deallocate(T* p,
                                    index64_t n)
 {
-    detail::deallocate(static_cast<void*>(p), n * static_cast<index64_t>(sizeof(T)), memory_type);
+    detail::deallocate(static_cast<void*>(p), n * static_cast<index64_t>(sizeof(T)), memory_type); //NOLINT(bugprone-sizeof-expression)
 }
 
 
@@ -465,7 +465,7 @@ template <typename T>
 STDGPU_NODISCARD T*
 safe_managed_allocator<T>::allocate(index64_t n)
 {
-    return static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type));
+    return static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type)); //NOLINT(bugprone-sizeof-expression)
 }
 
 
@@ -474,7 +474,7 @@ void
 safe_managed_allocator<T>::deallocate(T* p,
                                       index64_t n)
 {
-    detail::deallocate(static_cast<void*>(p), n * static_cast<index64_t>(sizeof(T)), memory_type);
+    detail::deallocate(static_cast<void*>(p), n * static_cast<index64_t>(sizeof(T)), memory_type); //NOLINT(bugprone-sizeof-expression)
 }
 
 

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -345,7 +345,7 @@ class values_unique
             {
                 auto block = _base._key_from_value(_base._values[i]);
 
-                auto it = _base.find(block);
+                auto it = _base.find(block); //NOLINT(readability-qualified-auto)
                 index_t position = static_cast<index_t>(thrust::distance(_base.begin(), it));
 
                 if (position != i)

--- a/test/stdgpu/contract.cpp
+++ b/test/stdgpu/contract.cpp
@@ -49,7 +49,7 @@ TEST_F(stdgpu_contract, expects_host_value)
 
         volatile bool false_value = false;
 
-        EXPECT_DEATH(STDGPU_EXPECTS(false_value), ""); //NOLINT(hicpp-no-array-decay)
+        EXPECT_DEATH(STDGPU_EXPECTS(false_value), ""); //NOLINT(hicpp-no-array-decay,hicpp-avoid-goto)
     #endif
 }
 
@@ -62,7 +62,7 @@ TEST_F(stdgpu_contract, expects_host_expression)
 
         STDGPU_EXPECTS(value_1 == 42 && value_2 > 0);
 
-        EXPECT_DEATH(STDGPU_EXPECTS(value_1 != 42 || value_2 <= 0), ""); //NOLINT(hicpp-no-array-decay)
+        EXPECT_DEATH(STDGPU_EXPECTS(value_1 != 42 || value_2 <= 0), ""); //NOLINT(hicpp-no-array-decay,hicpp-avoid-goto)
     #endif
 }
 
@@ -72,7 +72,7 @@ TEST_F(stdgpu_contract, expects_host_comma_expression)
     #if STDGPU_ENABLE_CONTRACT_CHECKS
         STDGPU_EXPECTS(std::is_same<int, int>::value); //NOLINT(hicpp-static-assert,misc-static-assert)
 
-        EXPECT_DEATH(STDGPU_EXPECTS(std::is_same<int, float>::value), ""); //NOLINT(hicpp-no-array-decay,hicpp-static-assert,misc-static-assert)
+        EXPECT_DEATH(STDGPU_EXPECTS(std::is_same<int, float>::value), ""); //NOLINT(hicpp-no-array-decay,hicpp-avoid-goto,hicpp-static-assert,misc-static-assert)
     #endif
 }
 
@@ -86,7 +86,7 @@ TEST_F(stdgpu_contract, ensures_host_value)
 
         volatile bool false_value = false;
 
-        EXPECT_DEATH(STDGPU_ENSURES(false_value), ""); //NOLINT(hicpp-no-array-decay)
+        EXPECT_DEATH(STDGPU_ENSURES(false_value), ""); //NOLINT(hicpp-no-array-decay,hicpp-avoid-goto)
     #endif
 }
 
@@ -99,7 +99,7 @@ TEST_F(stdgpu_contract, ensures_host_expression)
 
         STDGPU_ENSURES(value_1 == 42 && value_2 > 0);
 
-        EXPECT_DEATH(STDGPU_ENSURES(value_1 != 42 || value_2 <= 0), ""); //NOLINT(hicpp-no-array-decay)
+        EXPECT_DEATH(STDGPU_ENSURES(value_1 != 42 || value_2 <= 0), ""); //NOLINT(hicpp-no-array-decay,hicpp-avoid-goto)
     #endif
 }
 
@@ -109,7 +109,7 @@ TEST_F(stdgpu_contract, ensures_host_comma_expression)
     #if STDGPU_ENABLE_CONTRACT_CHECKS
         STDGPU_ENSURES(std::is_same<int, int>::value); //NOLINT(hicpp-static-assert,misc-static-assert)
 
-        EXPECT_DEATH(STDGPU_ENSURES(std::is_same<int, float>::value), ""); //NOLINT(hicpp-no-array-decay,hicpp-static-assert,misc-static-assert)
+        EXPECT_DEATH(STDGPU_ENSURES(std::is_same<int, float>::value), ""); //NOLINT(hicpp-no-array-decay,hicpp-avoid-goto,hicpp-static-assert,misc-static-assert)
     #endif
 }
 
@@ -123,7 +123,7 @@ TEST_F(stdgpu_contract, assert_host_value)
 
         volatile bool false_value = false;
 
-        EXPECT_DEATH(STDGPU_ASSERT(false_value), ""); //NOLINT(hicpp-no-array-decay)
+        EXPECT_DEATH(STDGPU_ASSERT(false_value), ""); //NOLINT(hicpp-no-array-decay,hicpp-avoid-goto)
     #endif
 }
 
@@ -136,7 +136,7 @@ TEST_F(stdgpu_contract, assert_host_expression)
 
         STDGPU_ASSERT(value_1 == 42 && value_2 > 0);
 
-        EXPECT_DEATH(STDGPU_ASSERT(value_1 != 42 || value_2 <= 0), ""); //NOLINT(hicpp-no-array-decay)
+        EXPECT_DEATH(STDGPU_ASSERT(value_1 != 42 || value_2 <= 0), ""); //NOLINT(hicpp-no-array-decay,hicpp-avoid-goto)
     #endif
 }
 
@@ -146,7 +146,7 @@ TEST_F(stdgpu_contract, assert_host_comma_expression)
     #if STDGPU_ENABLE_CONTRACT_CHECKS
         STDGPU_ASSERT(std::is_same<int, int>::value); //NOLINT(hicpp-static-assert,misc-static-assert)
 
-        EXPECT_DEATH(STDGPU_ASSERT(std::is_same<int, float>::value), ""); //NOLINT(hicpp-no-array-decay,hicpp-static-assert,misc-static-assert)
+        EXPECT_DEATH(STDGPU_ASSERT(std::is_same<int, float>::value), ""); //NOLINT(hicpp-no-array-decay,hicpp-avoid-goto,hicpp-static-assert,misc-static-assert)
     #endif
 }
 

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -59,7 +59,7 @@ class equal_to_number
         }
 
         STDGPU_HOST_DEVICE bool
-        operator()(const int value)
+        operator()(const int value) const
         {
             return (value == _number);
         }


### PR DESCRIPTION
As more recent versions of clang-tidy are available, e.g. through Ubuntu 20.04, and this tool comes with an increasing set of warnings, we should keep up the pace as well. Fix these new warnings to ensure clean builds with such recent versions. This is required to use newer CI images.