### PR TITLE
src,test: Handle more recent cppcheck warnings

### DIFF
--- a/cmake/setup_cppcheck.cmake
+++ b/cmake/setup_cppcheck.cmake
@@ -7,7 +7,8 @@ function(stdgpu_setup_cppcheck STDGPU_OUTPUT_PROPERTY_CPPCHECK)
         message(FATAL_ERROR "cppcheck not found.")
     endif()
 
-    set(${STDGPU_OUTPUT_PROPERTY_CPPCHECK} "${STDGPU_CPPCHECK}" "--enable=warning,style,performance,portability" "--force" "--inline-suppr" "--quiet")
+    # Do not enable noisy "style" checks
+    set(${STDGPU_OUTPUT_PROPERTY_CPPCHECK} "${STDGPU_CPPCHECK}" "--enable=warning,performance,portability" "--force" "--inline-suppr" "--quiet")
 
     if(NOT DEFINED STDGPU_TREAT_WARNINGS_AS_ERRORS)
         message(FATAL_ERROR "STDGPU_TREAT_WARNINGS_AS_ERRORS not defined.")

--- a/examples/contract.cpp
+++ b/examples/contract.cpp
@@ -25,6 +25,7 @@ safe_sqrt(const float x)
 {
     STDGPU_EXPECTS(x >= 0.0F);
 
+    // cppcheck-suppress invalidFunctionArg
     float result = std::sqrt(x);
 
     STDGPU_ENSURES(result >= 0.0F);

--- a/src/stdgpu/impl/iterator_detail.h
+++ b/src/stdgpu/impl/iterator_detail.h
@@ -46,15 +46,15 @@ template <typename T>
 index64_t
 size(T* array)
 {
-    index64_t size_bytes = size<void>(static_cast<void*>(const_cast<std::remove_cv_t<T>*>(array)));
+    index64_t array_size_bytes = size<void>(static_cast<void*>(const_cast<std::remove_cv_t<T>*>(array)));
 
-    if (size_bytes % static_cast<index64_t>(sizeof(T)) != 0) //NOLINT(bugprone-sizeof-expression)
+    if (array_size_bytes % static_cast<index64_t>(sizeof(T)) != 0) //NOLINT(bugprone-sizeof-expression)
     {
         printf("stdgpu::size : Array type not matching the memory alignment. Returning 0 ...\n");
         return 0;
     }
 
-    return size_bytes / static_cast<index64_t>(sizeof(T)); //NOLINT(bugprone-sizeof-expression)
+    return array_size_bytes / static_cast<index64_t>(sizeof(T)); //NOLINT(bugprone-sizeof-expression)
 }
 
 

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -440,14 +440,14 @@ size_bytes(void* array)
 {
     dynamic_memory_type type = get_dynamic_memory_type(array);
 
-    index64_t size_bytes = detail::dispatch_allocation_manager(type).find_size(array);
-    if (size_bytes == 0)
+    index64_t array_size_bytes = detail::dispatch_allocation_manager(type).find_size(array);
+    if (array_size_bytes == 0)
     {
         printf("stdgpu::size_bytes : Array not allocated by this API or not pointing to the first element. Returning 0 ...\n");
         return 0;
     }
 
-    return size_bytes;
+    return array_size_bytes;
 }
 
 } // namespace stdgpu

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -491,6 +491,7 @@ template <typename Allocator>
 typename allocator_traits<Allocator>::pointer
 allocator_traits<Allocator>::allocate(Allocator& a,
                                       typename allocator_traits<Allocator>::index_type n,
+                                      // cppcheck-suppress syntaxError
                                       STDGPU_MAYBE_UNUSED typename allocator_traits<Allocator>::const_void_pointer hint)
 {
     return a.allocate(n);

--- a/test/stdgpu/functional.cpp
+++ b/test/stdgpu/functional.cpp
@@ -268,6 +268,7 @@ enum old_enum
 };
 
 
+// cppcheck-suppress syntaxError
 TEST_F(stdgpu_functional, enum)
 {
     std::unordered_set<std::size_t> hashes;


### PR DESCRIPTION
Similar to #211, recent versions of cppcheck detect more potential bugs. Fix these new warnings to ensure clean builds and prepare for upgrading to new CI images.