### PR TITLE
atomic: Add control for memory ordering

### DIFF
--- a/src/stdgpu/cuda/atomic.cuh
+++ b/src/stdgpu/cuda/atomic.cuh
@@ -28,6 +28,12 @@ namespace cuda
 {
 
 /**
+ * \brief A synchronization fence enforcing sequentially consistent memory ordering
+ */
+STDGPU_DEVICE_ONLY void
+atomic_thread_fence();
+
+/**
  * \brief Atomically loads and returns the current value of the atomic object
  * \tparam T The type of the atomically managed object
  * \param[in] address A pointer to a value

--- a/src/stdgpu/cuda/impl/atomic_detail.cuh
+++ b/src/stdgpu/cuda/impl/atomic_detail.cuh
@@ -178,16 +178,19 @@ namespace stdgpu
 namespace cuda
 {
 
+inline STDGPU_DEVICE_ONLY void
+atomic_thread_fence()
+{
+    __threadfence();
+}
+
+
 template <typename T>
 STDGPU_DEVICE_ONLY T
 atomic_load(T* address)
 {
-    __threadfence();
-
     volatile T* volatile_address = address;
     T current = *volatile_address;
-
-    __threadfence();
 
     return current;
 }
@@ -198,12 +201,8 @@ STDGPU_DEVICE_ONLY void
 atomic_store(T* address,
              const T desired)
 {
-    __threadfence();
-
     volatile T* volatile_address = address;
     *volatile_address = desired;
-
-    __threadfence();
 }
 
 
@@ -212,13 +211,7 @@ STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired)
 {
-    __threadfence();
-
-    T old = atomicExch(address, desired);
-
-    __threadfence();
-
-    return old;
+    return atomicExch(address, desired);
 }
 
 
@@ -228,13 +221,7 @@ atomic_compare_exchange(T* address,
                         const T expected,
                         const T desired)
 {
-    __threadfence();
-
-    T old = atomicCAS(address, expected, desired);
-
-    __threadfence();
-
-    return old;
+    return atomicCAS(address, expected, desired);
 }
 
 
@@ -243,13 +230,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicAdd(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicAdd(address, arg);
 }
 
 
@@ -258,13 +239,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicSub(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicSub(address, arg);
 }
 
 
@@ -273,13 +248,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicAnd(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicAnd(address, arg);
 }
 
 
@@ -288,13 +257,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicOr(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicOr(address, arg);
 }
 
 
@@ -303,13 +266,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicXor(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicXor(address, arg);
 }
 
 
@@ -318,13 +275,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicMin(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicMin(address, arg);
 }
 
 
@@ -333,13 +284,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicMax(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicMax(address, arg);
 }
 
 
@@ -348,13 +293,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg)
 {
-    __threadfence();
-
-    T old = atomicInc(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicInc(address, arg);
 }
 
 
@@ -363,13 +302,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg)
 {
-    __threadfence();
-
-    T old = atomicDec(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicDec(address, arg);
 }
 
 } // namespace cuda

--- a/src/stdgpu/hip/CMakeLists.txt
+++ b/src/stdgpu/hip/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # NOTE For version checking only
-find_package(hip 3.5 REQUIRED)
+find_package(hip REQUIRED)
 
 set(STDGPU_DEPENDENCIES_BACKEND_INIT "
 find_dependency(hip 3.5 REQUIRED)

--- a/src/stdgpu/hip/atomic.h
+++ b/src/stdgpu/hip/atomic.h
@@ -28,6 +28,12 @@ namespace hip
 {
 
 /**
+ * \brief A synchronization fence enforcing sequentially consistent memory ordering
+ */
+STDGPU_DEVICE_ONLY void
+atomic_thread_fence();
+
+/**
  * \brief Atomically loads and returns the current value of the atomic object
  * \tparam T The type of the atomically managed object
  * \param[in] address A pointer to a value

--- a/src/stdgpu/hip/impl/atomic_detail.h
+++ b/src/stdgpu/hip/impl/atomic_detail.h
@@ -84,16 +84,19 @@ namespace stdgpu
 namespace hip
 {
 
+inline STDGPU_DEVICE_ONLY void
+atomic_thread_fence()
+{
+    __threadfence();
+}
+
+
 template <typename T>
 STDGPU_DEVICE_ONLY T
 atomic_load(T* address)
 {
-    __threadfence();
-
     volatile T* volatile_address = address;
     T current = *volatile_address;
-
-    __threadfence();
 
     return current;
 }
@@ -104,12 +107,8 @@ STDGPU_DEVICE_ONLY void
 atomic_store(T* address,
              const T desired)
 {
-    __threadfence();
-
     volatile T* volatile_address = address;
     *volatile_address = desired;
-
-    __threadfence();
 }
 
 
@@ -118,13 +117,7 @@ STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired)
 {
-    __threadfence();
-
-    T old = atomicExch(address, desired);
-
-    __threadfence();
-
-    return old;
+    return atomicExch(address, desired);
 }
 
 
@@ -134,13 +127,7 @@ atomic_compare_exchange(T* address,
                         const T expected,
                         const T desired)
 {
-    __threadfence();
-
-    T old = atomicCAS(address, expected, desired);
-
-    __threadfence();
-
-    return old;
+    return atomicCAS(address, expected, desired);
 }
 
 
@@ -149,13 +136,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicAdd(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicAdd(address, arg);
 }
 
 
@@ -164,13 +145,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicSub(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicSub(address, arg);
 }
 
 
@@ -179,13 +154,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicAnd(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicAnd(address, arg);
 }
 
 
@@ -194,13 +163,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicOr(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicOr(address, arg);
 }
 
 
@@ -209,13 +172,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicXor(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicXor(address, arg);
 }
 
 
@@ -224,13 +181,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicMin(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicMin(address, arg);
 }
 
 
@@ -239,13 +190,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg)
 {
-    __threadfence();
-
-    T old = atomicMax(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicMax(address, arg);
 }
 
 
@@ -254,13 +199,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg)
 {
-    __threadfence();
-
-    T old = atomicInc(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicInc(address, arg);
 }
 
 
@@ -269,13 +208,7 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg)
 {
-    __threadfence();
-
-    T old = atomicDec(address, arg);
-
-    __threadfence();
-
-    return old;
+    return atomicDec(address, arg);
 }
 
 } // namespace hip

--- a/src/stdgpu/openmp/atomic.h
+++ b/src/stdgpu/openmp/atomic.h
@@ -28,6 +28,12 @@ namespace openmp
 {
 
 /**
+ * \brief A synchronization fence enforcing sequentially consistent memory ordering
+ */
+STDGPU_DEVICE_ONLY void
+atomic_thread_fence();
+
+/**
  * \brief Atomically loads and returns the current value of the atomic object
  * \tparam T The type of the atomically managed object
  * \param[in] address A pointer to a value

--- a/src/stdgpu/openmp/impl/atomic_detail.h
+++ b/src/stdgpu/openmp/impl/atomic_detail.h
@@ -28,20 +28,21 @@ namespace stdgpu
 namespace openmp
 {
 
+inline STDGPU_DEVICE_ONLY void
+atomic_thread_fence()
+{
+    #pragma omp flush
+}
+
 template <typename T>
 STDGPU_DEVICE_ONLY T
 atomic_load(T* address)
 {
-    // Implicit flush due to omp critical
-
     T current;
     #pragma omp critical
     {
         current = *address;
     }
-
-    // Implicit flush due to omp critical
-
     return current;
 }
 
@@ -51,14 +52,10 @@ STDGPU_DEVICE_ONLY void
 atomic_store(T* address,
              const T desired)
 {
-    // Implicit flush due to omp critical
-
     #pragma omp critical
     {
         *address = desired;
     }
-
-    // Implicit flush due to omp critical
 }
 
 
@@ -67,17 +64,12 @@ STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired)
 {
-    // Implicit flush due to omp critical
-
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = desired;
     }
-
-    // Implicit flush due to omp critical
-
     return old;
 }
 
@@ -88,17 +80,12 @@ atomic_compare_exchange(T* address,
                         const T expected,
                         const T desired)
 {
-    // Implicit flush due to omp critical
-
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = (old == expected) ? desired : old;
     }
-
-    // Implicit flush due to omp critical
-
     return old;
 }
 
@@ -108,17 +95,12 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg)
 {
-    // Implicit flush due to omp critical
-
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = old + arg;
     }
-
-    // Implicit flush due to omp critical
-
     return old;
 }
 
@@ -128,17 +110,12 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg)
 {
-    // Implicit flush due to omp critical
-
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = old - arg;
     }
-
-    // Implicit flush due to omp critical
-
     return old;
 }
 
@@ -148,17 +125,12 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg)
 {
-    // Implicit flush due to omp critical
-
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = old & arg; // NOLINT(hicpp-signed-bitwise)
     }
-
-    // Implicit flush due to omp critical
-
     return old;
 }
 
@@ -168,17 +140,12 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg)
 {
-    // Implicit flush due to omp critical
-
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = old | arg; // NOLINT(hicpp-signed-bitwise)
     }
-
-    // Implicit flush due to omp critical
-
     return old;
 }
 
@@ -188,17 +155,12 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg)
 {
-    // Implicit flush due to omp critical
-
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = old ^ arg; // NOLINT(hicpp-signed-bitwise)
     }
-
-    // Implicit flush due to omp critical
-
     return old;
 }
 
@@ -208,17 +170,12 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg)
 {
-    // Implicit flush due to omp critical
-
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = std::min(old, arg);
     }
-
-    // Implicit flush due to omp critical
-
     return old;
 }
 
@@ -228,17 +185,12 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg)
 {
-    // Implicit flush due to omp critical
-
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = std::max(old, arg);
     }
-
-    // Implicit flush due to omp critical
-
     return old;
 }
 
@@ -248,17 +200,12 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg)
 {
-    // Implicit flush due to omp critical
-
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = (old >= arg) ? T(0) : old + T(1);
     }
-
-    // Implicit flush due to omp critical
-
     return old;
 }
 
@@ -268,17 +215,12 @@ STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg)
 {
-    // Implicit flush due to omp critical
-
     T old;
     #pragma omp critical
     {
         old = *address;
         *address = (old == T(0) || old > arg) ? arg : old - T(1);
     }
-
-    // Implicit flush due to omp critical
-
     return old;
 }
 

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -57,39 +57,39 @@ class atomic<unsigned int>;
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_add<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::fetch_add<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_sub<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::fetch_sub<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_and<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::fetch_and<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_or<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::fetch_or<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_xor<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::fetch_xor<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_min<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::fetch_min<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_max<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::fetch_max<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_inc_mod<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::fetch_inc_mod<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_dec_mod<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::fetch_dec_mod<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
@@ -132,39 +132,39 @@ class atomic_ref<unsigned int>;
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_add<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::fetch_add<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_sub<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::fetch_sub<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_and<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::fetch_and<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_or<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::fetch_or<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_xor<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::fetch_xor<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_min<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::fetch_min<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_max<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::fetch_max<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_inc_mod<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::fetch_inc_mod<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_dec_mod<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::fetch_dec_mod<unsigned int, void>(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
@@ -1637,6 +1637,80 @@ TEST_F(stdgpu_atomic, post_dec_operator_unsigned_int)
 TEST_F(stdgpu_atomic, post_dec_operator_unsigned_long_long_int)
 {
     sequence_post_dec<unsigned long long int>();
+}
+
+
+template <typename T>
+class fence_sequence
+{
+    public:
+        explicit fence_sequence(const stdgpu::atomic<T>& value)
+            : _value(value)
+        {
+
+        }
+
+        STDGPU_DEVICE_ONLY T
+        operator()()
+        {
+            stdgpu::atomic_thread_fence(stdgpu::memory_order_seq_cst);
+            stdgpu::atomic_signal_fence(stdgpu::memory_order_seq_cst);
+
+            T result = _value.fetch_add(1, stdgpu::memory_order_relaxed);
+
+            stdgpu::atomic_thread_fence(stdgpu::memory_order_seq_cst);
+            stdgpu::atomic_signal_fence(stdgpu::memory_order_seq_cst);
+
+            return result;
+        }
+
+    private:
+        stdgpu::atomic<T> _value;
+};
+
+
+template <typename T>
+void
+sequence_fence()
+{
+    const stdgpu::index_t N = 100000;
+    T* sequence = createDeviceArray<T>(N);
+
+    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+
+    thrust::generate(stdgpu::device_begin(sequence), stdgpu::device_end(sequence),
+                     fence_sequence<T>(value));
+
+    ASSERT_EQ(value.load(), T(N));
+
+    thrust::sort(stdgpu::device_begin(sequence), stdgpu::device_end(sequence));
+
+    T* host_sequence = copyCreateDevice2HostArray<T>(sequence, N);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(host_sequence[i], static_cast<T>(i));
+    }
+
+    destroyDeviceArray<T>(sequence);
+    destroyHostArray<T>(host_sequence);
+    stdgpu::atomic<T>::destroyDeviceObject(value);
+}
+
+
+TEST_F(stdgpu_atomic, fence_int)
+{
+    sequence_fence<int>();
+}
+
+TEST_F(stdgpu_atomic, fence_unsigned_int)
+{
+    sequence_fence<unsigned int>();
+}
+
+TEST_F(stdgpu_atomic, fence_unsigned_long_long_int)
+{
+    sequence_fence<unsigned long long int>();
 }
 
 


### PR DESCRIPTION
In #176, we changed the enforced memory ordering in `atomic` and `atomic_ref` to be sequentially consistent. Although implementing precise control over the memory order without having access to compiler internals is extremely difficult and often not possible. Extend the expected backend interface to also provide a synchronization primitive for sequential consistency. Based on this, try to mimic the all memory orders as close as possible with stricter or equal semantics. This gives more fine-grained control over the memory ordering.

Note that stricter memory orderings than requested are often imposed due to above limitations. Using too weak orderings in user code may lead to unexpected failures. It is generally recommended to use sequentially consistent ordering, which is still the default memory order, unless you know what you are doing.