### PR TITLE
atomic: Use OpenMP atomic clauses if available

### DIFF
--- a/src/stdgpu/openmp/impl/atomic_detail.h
+++ b/src/stdgpu/openmp/impl/atomic_detail.h
@@ -40,9 +40,7 @@ atomic_load(T* address)
 {
     T current;
     #pragma omp critical
-    {
-        current = *address;
-    }
+    current = *address;
     return current;
 }
 
@@ -53,9 +51,7 @@ atomic_store(T* address,
              const T desired)
 {
     #pragma omp critical
-    {
-        *address = desired;
-    }
+    *address = desired;
 }
 
 
@@ -96,10 +92,14 @@ atomic_fetch_add(T* address,
                  const T arg)
 {
     T old;
-    #pragma omp critical
+    #if STDGPU_OPENMP_DETAIL_VERSION >= STDGPU_OPENMP_DETAIL_VERSION_3_1
+        #pragma omp atomic capture
+    #else
+        #pragma omp critical
+    #endif
     {
         old = *address;
-        *address = old + arg;
+        *address += arg;
     }
     return old;
 }
@@ -111,10 +111,14 @@ atomic_fetch_sub(T* address,
                  const T arg)
 {
     T old;
-    #pragma omp critical
+    #if STDGPU_OPENMP_DETAIL_VERSION >= STDGPU_OPENMP_DETAIL_VERSION_3_1
+        #pragma omp atomic capture
+    #else
+        #pragma omp critical
+    #endif
     {
         old = *address;
-        *address = old - arg;
+        *address -= arg;
     }
     return old;
 }
@@ -126,10 +130,14 @@ atomic_fetch_and(T* address,
                  const T arg)
 {
     T old;
-    #pragma omp critical
+    #if STDGPU_OPENMP_DETAIL_VERSION >= STDGPU_OPENMP_DETAIL_VERSION_3_1
+        #pragma omp atomic capture
+    #else
+        #pragma omp critical
+    #endif
     {
         old = *address;
-        *address = old & arg; // NOLINT(hicpp-signed-bitwise)
+        *address &= arg; // NOLINT(hicpp-signed-bitwise)
     }
     return old;
 }
@@ -141,10 +149,14 @@ atomic_fetch_or(T* address,
                  const T arg)
 {
     T old;
-    #pragma omp critical
+    #if STDGPU_OPENMP_DETAIL_VERSION >= STDGPU_OPENMP_DETAIL_VERSION_3_1
+        #pragma omp atomic capture
+    #else
+        #pragma omp critical
+    #endif
     {
         old = *address;
-        *address = old | arg; // NOLINT(hicpp-signed-bitwise)
+        *address |= arg; // NOLINT(hicpp-signed-bitwise)
     }
     return old;
 }
@@ -156,10 +168,14 @@ atomic_fetch_xor(T* address,
                  const T arg)
 {
     T old;
-    #pragma omp critical
+    #if STDGPU_OPENMP_DETAIL_VERSION >= STDGPU_OPENMP_DETAIL_VERSION_3_1
+        #pragma omp atomic capture
+    #else
+        #pragma omp critical
+    #endif
     {
         old = *address;
-        *address = old ^ arg; // NOLINT(hicpp-signed-bitwise)
+        *address ^= arg; // NOLINT(hicpp-signed-bitwise)
     }
     return old;
 }

--- a/src/stdgpu/openmp/platform.h
+++ b/src/stdgpu/openmp/platform.h
@@ -58,6 +58,29 @@ namespace openmp
 #define STDGPU_OPENMP_IS_DEVICE_COMPILED 1
 
 
+namespace detail
+{
+
+//! @cond Doxygen_Suppress
+#ifdef _OPENMP
+    #define STDGPU_OPENMP_DETAIL_VERSION _OPENMP
+#else
+    #error OpenMP version not defined!
+#endif
+
+#define STDGPU_OPENMP_DETAIL_VERSION_5_1 202011
+#define STDGPU_OPENMP_DETAIL_VERSION_5_0 201811
+#define STDGPU_OPENMP_DETAIL_VERSION_4_5 201511
+#define STDGPU_OPENMP_DETAIL_VERSION_4_0 201307
+#define STDGPU_OPENMP_DETAIL_VERSION_3_1 201107
+#define STDGPU_OPENMP_DETAIL_VERSION_3_0 200805
+#define STDGPU_OPENMP_DETAIL_VERSION_2_5 200505
+#define STDGPU_OPENMP_DETAIL_VERSION_2_0 200203
+//! @endcond
+
+} // namespace detail
+
+
 } // namespace openmp
 
 } // namespace stdgpu


### PR DESCRIPTION
Refactoring the backend interface of `atomic` in #214 led to simpler code and relaxed requirements to the implementation. Add internal detection for the OpenMP version and conditionally make use of atomic clauses for any suitable operation if such clauses are available. This improves the performance for some atomic operations.