### PR TITLE
type_traits: Add macro for conditional overloading and apply in atomic

### DIFF
--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -30,6 +30,7 @@
 #include <type_traits>
 
 #include <stdgpu/platform.h>
+#include <stdgpu/impl/type_traits.h>
 
 
 
@@ -217,7 +218,7 @@ class atomic
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_add(const T arg,
                   const memory_order order = memory_order_seq_cst);
@@ -228,7 +229,7 @@ class atomic
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_sub(const T arg,
                   const memory_order order = memory_order_seq_cst);
@@ -239,7 +240,7 @@ class atomic
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_and(const T arg,
                   const memory_order order = memory_order_seq_cst);
@@ -250,7 +251,7 @@ class atomic
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_or(const T arg,
                  const memory_order order = memory_order_seq_cst);
@@ -261,7 +262,7 @@ class atomic
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_xor(const T arg,
                   const memory_order order = memory_order_seq_cst);
@@ -273,7 +274,7 @@ class atomic
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_min(const T arg,
                   const memory_order order = memory_order_seq_cst);
@@ -284,7 +285,7 @@ class atomic
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_max(const T arg,
                   const memory_order order = memory_order_seq_cst);
@@ -295,7 +296,7 @@ class atomic
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_same<U, unsigned int>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_inc_mod(const T arg,
                       const memory_order order = memory_order_seq_cst);
@@ -306,7 +307,7 @@ class atomic
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_same<U, unsigned int>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_dec_mod(const T arg,
                       const memory_order order = memory_order_seq_cst);
@@ -316,7 +317,7 @@ class atomic
          * \brief Atomically increments the current value. Equivalent to fetch_add(1) + 1
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator++();
 
@@ -324,7 +325,7 @@ class atomic
          * \brief Atomically increments the current value. Equivalent to fetch_add(1)
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator++(int);
 
@@ -332,7 +333,7 @@ class atomic
          * \brief Atomically decrements the current value. Equivalent to fetch_sub(1) - 1
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator--();
 
@@ -340,7 +341,7 @@ class atomic
          * \brief Atomically decrements the current value. Equivalent to fetch_sub(1)
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator--(int);
 
@@ -350,7 +351,7 @@ class atomic
          * \param[in] arg The other argument of addition
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator+=(const T arg);
 
@@ -359,7 +360,7 @@ class atomic
          * \param[in] arg The other argument of subtraction
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator-=(const T arg);
 
@@ -368,7 +369,7 @@ class atomic
          * \param[in] arg The other argument of bitwise AND
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator&=(const T arg);
 
@@ -377,7 +378,7 @@ class atomic
          * \param[in] arg The other argument of bitwise OR
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator|=(const T arg);
 
@@ -386,7 +387,7 @@ class atomic
          * \param[in] arg The other argument of bitwise XOR
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator^=(const T arg);
 
@@ -537,7 +538,7 @@ class atomic_ref
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_add(const T arg,
                   const memory_order order = memory_order_seq_cst);
@@ -548,7 +549,7 @@ class atomic_ref
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_sub(const T arg,
                   const memory_order order = memory_order_seq_cst);
@@ -559,7 +560,7 @@ class atomic_ref
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_and(const T arg,
                   const memory_order order = memory_order_seq_cst);
@@ -570,7 +571,7 @@ class atomic_ref
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_or(const T arg,
                  const memory_order order = memory_order_seq_cst);
@@ -581,7 +582,7 @@ class atomic_ref
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_xor(const T arg,
                   const memory_order order = memory_order_seq_cst);
@@ -593,7 +594,7 @@ class atomic_ref
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_min(const T arg,
                   const memory_order order = memory_order_seq_cst);
@@ -604,7 +605,7 @@ class atomic_ref
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_max(const T arg,
                   const memory_order order = memory_order_seq_cst);
@@ -615,7 +616,7 @@ class atomic_ref
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_same<U, unsigned int>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_inc_mod(const T arg,
                       const memory_order order = memory_order_seq_cst);
@@ -626,7 +627,7 @@ class atomic_ref
          * \param[in] order The memory order
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_same<U, unsigned int>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
         STDGPU_DEVICE_ONLY T
         fetch_dec_mod(const T arg,
                       const memory_order order = memory_order_seq_cst);
@@ -636,7 +637,7 @@ class atomic_ref
          * \brief Atomically increments the current value. Equivalent to fetch_add(1) + 1
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator++();
 
@@ -644,7 +645,7 @@ class atomic_ref
          * \brief Atomically increments the current value. Equivalent to fetch_add(1)
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator++(int);
 
@@ -652,7 +653,7 @@ class atomic_ref
          * \brief Atomically decrements the current value. Equivalent to fetch_sub(1) - 1
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator--();
 
@@ -660,7 +661,7 @@ class atomic_ref
          * \brief Atomically decrements the current value. Equivalent to fetch_sub(1)
          * \return The old value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator--(int);
 
@@ -670,7 +671,7 @@ class atomic_ref
          * \param[in] arg The other argument of addition
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator+=(const T arg);
 
@@ -679,7 +680,7 @@ class atomic_ref
          * \param[in] arg The other argument of subtraction
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value || std::is_floating_point<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator-=(const T arg);
 
@@ -688,7 +689,7 @@ class atomic_ref
          * \param[in] arg The other argument of bitwise AND
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator&=(const T arg);
 
@@ -697,7 +698,7 @@ class atomic_ref
          * \param[in] arg The other argument of bitwise OR
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator|=(const T arg);
 
@@ -706,7 +707,7 @@ class atomic_ref
          * \param[in] arg The other argument of bitwise XOR
          * \return The new value
          */
-        template <typename U = T, typename = std::enable_if_t<std::is_integral<U>::value>>
+        template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
         STDGPU_DEVICE_ONLY T
         operator^=(const T arg);
 

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -252,7 +252,7 @@ atomic<T>::compare_exchange_strong(T& expected,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_add(const T arg,
                      const memory_order order)
@@ -262,7 +262,7 @@ atomic<T>::fetch_add(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_sub(const T arg,
                      const memory_order order)
@@ -272,7 +272,7 @@ atomic<T>::fetch_sub(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_and(const T arg,
                      const memory_order order)
@@ -282,7 +282,7 @@ atomic<T>::fetch_and(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_or(const T arg,
                     const memory_order order)
@@ -292,7 +292,7 @@ atomic<T>::fetch_or(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_xor(const T arg,
                      const memory_order order)
@@ -302,7 +302,7 @@ atomic<T>::fetch_xor(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_min(const T arg,
                      const memory_order order)
@@ -312,7 +312,7 @@ atomic<T>::fetch_min(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_max(const T arg,
                      const memory_order order)
@@ -322,7 +322,7 @@ atomic<T>::fetch_max(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_inc_mod(const T arg,
                          const memory_order order)
@@ -332,7 +332,7 @@ atomic<T>::fetch_inc_mod(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::fetch_dec_mod(const T arg,
                          const memory_order order)
@@ -342,7 +342,7 @@ atomic<T>::fetch_dec_mod(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator++()
 {
@@ -351,7 +351,7 @@ atomic<T>::operator++()
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator++(int)
 {
@@ -360,7 +360,7 @@ atomic<T>::operator++(int)
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator--()
 {
@@ -369,7 +369,7 @@ atomic<T>::operator--()
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator--(int)
 {
@@ -378,7 +378,7 @@ atomic<T>::operator--(int)
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator+=(const T arg)
 {
@@ -387,7 +387,7 @@ atomic<T>::operator+=(const T arg)
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator-=(const T arg)
 {
@@ -396,7 +396,7 @@ atomic<T>::operator-=(const T arg)
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator&=(const T arg)
 {
@@ -405,7 +405,7 @@ atomic<T>::operator&=(const T arg)
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator|=(const T arg)
 {
@@ -414,7 +414,7 @@ atomic<T>::operator|=(const T arg)
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T>::operator^=(const T arg)
 {
@@ -560,7 +560,7 @@ atomic_ref<T>::compare_exchange_strong(T& expected,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_add(const T arg,
                          const memory_order order)
@@ -576,7 +576,7 @@ atomic_ref<T>::fetch_add(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_sub(const T arg,
                          const memory_order order)
@@ -592,7 +592,7 @@ atomic_ref<T>::fetch_sub(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_and(const T arg,
                          const memory_order order)
@@ -608,7 +608,7 @@ atomic_ref<T>::fetch_and(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_or(const T arg,
                         const memory_order order)
@@ -624,7 +624,7 @@ atomic_ref<T>::fetch_or(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_xor(const T arg,
                          const memory_order order)
@@ -640,7 +640,7 @@ atomic_ref<T>::fetch_xor(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_min(const T arg,
                          const memory_order order)
@@ -656,7 +656,7 @@ atomic_ref<T>::fetch_min(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_max(const T arg,
                          const memory_order order)
@@ -672,7 +672,7 @@ atomic_ref<T>::fetch_max(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_inc_mod(const T arg,
                              const memory_order order)
@@ -688,7 +688,7 @@ atomic_ref<T>::fetch_inc_mod(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_dec_mod(const T arg,
                              const memory_order order)
@@ -704,7 +704,7 @@ atomic_ref<T>::fetch_dec_mod(const T arg,
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator++()
 {
@@ -713,7 +713,7 @@ atomic_ref<T>::operator++()
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator++(int)
 {
@@ -722,7 +722,7 @@ atomic_ref<T>::operator++(int)
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator--()
 {
@@ -731,7 +731,7 @@ atomic_ref<T>::operator--()
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator--(int)
 {
@@ -740,7 +740,7 @@ atomic_ref<T>::operator--(int)
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator+=(const T arg)
 {
@@ -749,7 +749,7 @@ atomic_ref<T>::operator+=(const T arg)
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator-=(const T arg)
 {
@@ -758,7 +758,7 @@ atomic_ref<T>::operator-=(const T arg)
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator&=(const T arg)
 {
@@ -767,7 +767,7 @@ atomic_ref<T>::operator&=(const T arg)
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator|=(const T arg)
 {
@@ -776,7 +776,7 @@ atomic_ref<T>::operator|=(const T arg)
 
 
 template <typename T>
-template <typename U, typename>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator^=(const T arg)
 {

--- a/src/stdgpu/impl/type_traits.h
+++ b/src/stdgpu/impl/type_traits.h
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2021 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_TYPE_TRAITS_H
+#define STDGPU_TYPE_TRAITS_H
+
+#include <type_traits>
+
+
+
+namespace stdgpu
+{
+
+namespace detail
+{
+
+/**
+ * \brief Macro to conditionally enable overloads
+ *
+ * Usage and limitations:
+ *  - Must be used as last argument within a template argument list
+ *  - Can be used in up to 2 function overloads with identical signature
+ */
+#define STDGPU_DETAIL_OVERLOAD_IF(...) typename stdgpu_DummyType = void, std::enable_if_t<__VA_ARGS__, stdgpu_DummyType>* = nullptr
+
+/**
+ * \brief Corresponding overload macro used for out-of-class member function definitions
+ */
+#define STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(...) typename stdgpu_DummyType, std::enable_if_t<__VA_ARGS__, stdgpu_DummyType>*
+
+} // namespace detail
+
+} // namespace stdgpu
+
+
+
+#endif // STDGPU_TYPE_TRAITS_H

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -57,150 +57,150 @@ class atomic<unsigned int>;
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_add<unsigned int, void>(const unsigned int, const memory_order order);
+atomic<unsigned int>::fetch_add(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_sub<unsigned int, void>(const unsigned int, const memory_order order);
+atomic<unsigned int>::fetch_sub(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_and<unsigned int, void>(const unsigned int, const memory_order order);
+atomic<unsigned int>::fetch_and(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_or<unsigned int, void>(const unsigned int, const memory_order order);
+atomic<unsigned int>::fetch_or(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_xor<unsigned int, void>(const unsigned int, const memory_order order);
+atomic<unsigned int>::fetch_xor(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_min<unsigned int, void>(const unsigned int, const memory_order order);
+atomic<unsigned int>::fetch_min(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_max<unsigned int, void>(const unsigned int, const memory_order order);
+atomic<unsigned int>::fetch_max(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_inc_mod<unsigned int, void>(const unsigned int, const memory_order order);
+atomic<unsigned int>::fetch_inc_mod(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::fetch_dec_mod<unsigned int, void>(const unsigned int, const memory_order order);
+atomic<unsigned int>::fetch_dec_mod(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::operator++<unsigned int, void>();
+atomic<unsigned int>::operator++();
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::operator++<unsigned int, void>(int);
+atomic<unsigned int>::operator++(int);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::operator--<unsigned int, void>();
+atomic<unsigned int>::operator--();
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::operator--<unsigned int, void>(int);
+atomic<unsigned int>::operator--(int);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::operator+=<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::operator+=(const unsigned int);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::operator-=<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::operator-=(const unsigned int);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::operator&=<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::operator&=(const unsigned int);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::operator|=<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::operator|=(const unsigned int);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic<unsigned int>::operator^=<unsigned int, void>(const unsigned int);
+atomic<unsigned int>::operator^=(const unsigned int);
 
 template
 class atomic_ref<unsigned int>;
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_add<unsigned int, void>(const unsigned int, const memory_order order);
+atomic_ref<unsigned int>::fetch_add(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_sub<unsigned int, void>(const unsigned int, const memory_order order);
+atomic_ref<unsigned int>::fetch_sub(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_and<unsigned int, void>(const unsigned int, const memory_order order);
+atomic_ref<unsigned int>::fetch_and(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_or<unsigned int, void>(const unsigned int, const memory_order order);
+atomic_ref<unsigned int>::fetch_or(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_xor<unsigned int, void>(const unsigned int, const memory_order order);
+atomic_ref<unsigned int>::fetch_xor(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_min<unsigned int, void>(const unsigned int, const memory_order order);
+atomic_ref<unsigned int>::fetch_min(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_max<unsigned int, void>(const unsigned int, const memory_order order);
+atomic_ref<unsigned int>::fetch_max(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_inc_mod<unsigned int, void>(const unsigned int, const memory_order order);
+atomic_ref<unsigned int>::fetch_inc_mod(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::fetch_dec_mod<unsigned int, void>(const unsigned int, const memory_order order);
+atomic_ref<unsigned int>::fetch_dec_mod(const unsigned int, const memory_order order);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::operator++<unsigned int, void>();
+atomic_ref<unsigned int>::operator++();
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::operator++<unsigned int, void>(int);
+atomic_ref<unsigned int>::operator++(int);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::operator--<unsigned int, void>();
+atomic_ref<unsigned int>::operator--();
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::operator--<unsigned int, void>(int);
+atomic_ref<unsigned int>::operator--(int);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::operator+=<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::operator+=(const unsigned int);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::operator-=<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::operator-=(const unsigned int);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::operator&=<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::operator&=(const unsigned int);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::operator|=<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::operator|=(const unsigned int);
 
 template
 STDGPU_DEVICE_ONLY unsigned int
-atomic_ref<unsigned int>::operator^=<unsigned int, void>(const unsigned int);
+atomic_ref<unsigned int>::operator^=(const unsigned int);
 
 } // namespace stdgpu
 


### PR DESCRIPTION
Some member functions of `atomic` are conditionally enabled based on its template type `T`. Although we already use a quite readable version to implement this without making the interface too ugly, there is still some room for improvement. Factor out the implementation of the conditional check and move it a new macro `STDGPU_DETAIL_OVERLOAD_IF()` and a corresponding version for out-of-class function definitions. This makes function signatures much easier to read.