### PR TITLE
unordered_map,unordered_set: Unify and relax range-based insert and erase

### DIFF
--- a/src/stdgpu/impl/type_traits.h
+++ b/src/stdgpu/impl/type_traits.h
@@ -40,6 +40,27 @@ namespace detail
  */
 #define STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(...) typename stdgpu_DummyType, std::enable_if_t<__VA_ARGS__, stdgpu_DummyType>*
 
+
+template <typename... Types>
+struct void_helper
+{
+    using type = void;
+};
+
+template <typename... Types>
+using void_t = typename void_helper<Types...>::type;
+
+
+#define STDGPU_DETAIL_DEFINE_TRAIT(name, ...) \
+template <typename T, typename = void> \
+struct name : std::false_type { }; \
+\
+template <typename T> \
+struct name<T, void_t<__VA_ARGS__>> : std::true_type { };
+
+// Clang does not detect T::pointer for thrust::device_pointer, so avoid checking it
+STDGPU_DETAIL_DEFINE_TRAIT(is_iterator, typename T::difference_type, typename T::value_type, /*typename T::pointer,*/ typename T::reference, typename T::iterator_category)
+
 } // namespace detail
 
 } // namespace stdgpu

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -30,6 +30,7 @@
 #include <stdgpu/platform.h>
 #include <stdgpu/ranges.h>
 #include <stdgpu/vector.cuh>
+#include <stdgpu/impl/type_traits.h>
 
 
 
@@ -259,19 +260,10 @@ class unordered_base
          * \param[in] begin The begin of the range
          * \param[in] end The end of the range
          */
+        template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator<ValueIterator>::value)>
         void
-        insert(device_ptr<value_type> begin,
-               device_ptr<value_type> end);
-
-
-        /**
-         * \brief Inserts the given range of elements into the container
-         * \param[in] begin The begin of the range
-         * \param[in] end The end of the range
-         */
-        void
-        insert(device_ptr<const value_type> begin,
-               device_ptr<const value_type> end);
+        insert(ValueIterator begin,
+               ValueIterator end);
 
 
         /**
@@ -288,19 +280,10 @@ class unordered_base
          * \param[in] begin The begin of the range
          * \param[in] end The end of the range
          */
+        template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator<KeyIterator>::value)>
         void
-        erase(device_ptr<key_type> begin,
-              device_ptr<key_type> end);
-
-
-        /**
-         * \brief Deletes the values with the given range of keys from the container
-         * \param[in] begin The begin of the range
-         * \param[in] end The end of the range
-         */
-        void
-        erase(device_ptr<const key_type> begin,
-              device_ptr<const key_type> end);
+        erase(KeyIterator begin,
+              KeyIterator end);
 
 
         /**

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -842,21 +842,13 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::insert(const unordered
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
+template <typename InputIt, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator<InputIt>::value)>
 inline void
-unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::insert(device_ptr<unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::value_type> begin,
-                                                                 device_ptr<unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::value_type> end)
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::insert(InputIt begin,
+                                                                 InputIt end)
 {
-    thrust::for_each(begin, end,
-                     insert_value<Key, Value, KeyFromValue, Hash, KeyEqual>(*this));
-}
-
-
-template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline void
-unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::insert(device_ptr<const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::value_type> begin,
-                                                                 device_ptr<const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::value_type> end)
-{
-    thrust::for_each(begin, end,
+    thrust::for_each(thrust::device,
+                     begin, end,
                      insert_value<Key, Value, KeyFromValue, Hash, KeyEqual>(*this));
 }
 
@@ -884,21 +876,13 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::erase(const unordered_
 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
+template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator<KeyIterator>::value)>
 inline void
-unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::erase(device_ptr<unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::key_type> begin,
-                                                                device_ptr<unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::key_type> end)
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::erase(KeyIterator begin,
+                                                                KeyIterator end)
 {
-    thrust::for_each(begin, end,
-                     erase_from_key<Key, Value, KeyFromValue, Hash, KeyEqual>(*this));
-}
-
-
-template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
-inline void
-unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::erase(device_ptr<const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::key_type> begin,
-                                                                device_ptr<const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::key_type> end)
-{
-    thrust::for_each(begin, end,
+    thrust::for_each(thrust::device,
+                     begin, end,
                      erase_from_key<Key, Value, KeyFromValue, Hash, KeyEqual>(*this));
 }
 

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -170,18 +170,10 @@ unordered_map<Key, T, Hash, KeyEqual>::insert(const unordered_map<Key, T, Hash, 
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
+template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator<ValueIterator>::value)>
 inline void
-unordered_map<Key, T, Hash, KeyEqual>::insert(device_ptr<unordered_map<Key, T, Hash, KeyEqual>::value_type> begin,
-                                              device_ptr<unordered_map<Key, T, Hash, KeyEqual>::value_type> end)
-{
-    _base.insert(begin, end);
-}
-
-
-template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline void
-unordered_map<Key, T, Hash, KeyEqual>::insert(device_ptr<const unordered_map<Key, T, Hash, KeyEqual>::value_type> begin,
-                                              device_ptr<const unordered_map<Key, T, Hash, KeyEqual>::value_type> end)
+unordered_map<Key, T, Hash, KeyEqual>::insert(ValueIterator begin,
+                                              ValueIterator end)
 {
     _base.insert(begin, end);
 }
@@ -196,18 +188,10 @@ unordered_map<Key, T, Hash, KeyEqual>::erase(const unordered_map<Key, T, Hash, K
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
+template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator<KeyIterator>::value)>
 inline void
-unordered_map<Key, T, Hash, KeyEqual>::erase(device_ptr<unordered_map<Key, T, Hash, KeyEqual>::key_type> begin,
-                                             device_ptr<unordered_map<Key, T, Hash, KeyEqual>::key_type> end)
-{
-    _base.erase(begin, end);
-}
-
-
-template <typename Key, typename T, typename Hash, typename KeyEqual>
-inline void
-unordered_map<Key, T, Hash, KeyEqual>::erase(device_ptr<const unordered_map<Key, T, Hash, KeyEqual>::key_type> begin,
-                                             device_ptr<const unordered_map<Key, T, Hash, KeyEqual>::key_type> end)
+unordered_map<Key, T, Hash, KeyEqual>::erase(KeyIterator begin,
+                                             KeyIterator end)
 {
     _base.erase(begin, end);
 }

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -155,18 +155,10 @@ unordered_set<Key, Hash, KeyEqual>::insert(const unordered_set<Key, Hash, KeyEqu
 
 
 template <typename Key, typename Hash, typename KeyEqual>
+template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator<ValueIterator>::value)>
 inline void
-unordered_set<Key, Hash, KeyEqual>::insert(device_ptr<unordered_set<Key, Hash, KeyEqual>::value_type> begin,
-                                           device_ptr<unordered_set<Key, Hash, KeyEqual>::value_type> end)
-{
-    _base.insert(begin, end);
-}
-
-
-template <typename Key, typename Hash, typename KeyEqual>
-inline void
-unordered_set<Key, Hash, KeyEqual>::insert(device_ptr<const unordered_set<Key, Hash, KeyEqual>::value_type> begin,
-                                           device_ptr<const unordered_set<Key, Hash, KeyEqual>::value_type> end)
+unordered_set<Key, Hash, KeyEqual>::insert(ValueIterator begin,
+                                           ValueIterator end)
 {
     _base.insert(begin, end);
 }
@@ -181,18 +173,10 @@ unordered_set<Key, Hash, KeyEqual>::erase(const unordered_set<Key, Hash, KeyEqua
 
 
 template <typename Key, typename Hash, typename KeyEqual>
+template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator<KeyIterator>::value)>
 inline void
-unordered_set<Key, Hash, KeyEqual>::erase(device_ptr<unordered_set<Key, Hash, KeyEqual>::key_type> begin,
-                                          device_ptr<unordered_set<Key, Hash, KeyEqual>::key_type> end)
-{
-    _base.erase(begin, end);
-}
-
-
-template <typename Key, typename Hash, typename KeyEqual>
-inline void
-unordered_set<Key, Hash, KeyEqual>::erase(device_ptr<const unordered_set<Key, Hash, KeyEqual>::key_type> begin,
-                                          device_ptr<const unordered_set<Key, Hash, KeyEqual>::key_type> end)
+unordered_set<Key, Hash, KeyEqual>::erase(KeyIterator begin,
+                                          KeyIterator end)
 {
     _base.erase(begin, end);
 }

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -33,6 +33,7 @@
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
 #include <stdgpu/impl/unordered_base.cuh>
+#include <stdgpu/impl/type_traits.h>
 
 
 
@@ -270,19 +271,10 @@ class unordered_map
          * \param[in] begin The begin of the range
          * \param[in] end The end of the range
          */
+        template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator<ValueIterator>::value)>
         void
-        insert(device_ptr<value_type> begin,
-               device_ptr<value_type> end);
-
-
-        /**
-         * \brief Inserts the given range of elements into the container
-         * \param[in] begin The begin of the range
-         * \param[in] end The end of the range
-         */
-        void
-        insert(device_ptr<const value_type> begin,
-               device_ptr<const value_type> end);
+        insert(ValueIterator begin,
+               ValueIterator end);
 
 
         /**
@@ -299,19 +291,10 @@ class unordered_map
          * \param[in] begin The begin of the range
          * \param[in] end The end of the range
          */
+        template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator<KeyIterator>::value)>
         void
-        erase(device_ptr<key_type> begin,
-              device_ptr<key_type> end);
-
-
-        /**
-         * \brief Deletes the values with the given range of keys from the container
-         * \param[in] begin The begin of the range
-         * \param[in] end The end of the range
-         */
-        void
-        erase(device_ptr<const key_type> begin,
-              device_ptr<const key_type> end);
+        erase(KeyIterator begin,
+              KeyIterator end);
 
 
         /**

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -33,6 +33,7 @@
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
 #include <stdgpu/impl/unordered_base.cuh>
+#include <stdgpu/impl/type_traits.h>
 
 
 
@@ -258,19 +259,10 @@ class unordered_set
          * \param[in] begin The begin of the range
          * \param[in] end The end of the range
          */
+        template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator<ValueIterator>::value)>
         void
-        insert(device_ptr<value_type> begin,
-               device_ptr<value_type> end);
-
-
-        /**
-         * \brief Inserts the given range of elements into the container
-         * \param[in] begin The begin of the range
-         * \param[in] end The end of the range
-         */
-        void
-        insert(device_ptr<const value_type> begin,
-               device_ptr<const value_type> end);
+        insert(ValueIterator begin,
+               ValueIterator end);
 
 
         /**
@@ -287,19 +279,10 @@ class unordered_set
          * \param[in] begin The begin of the range
          * \param[in] end The end of the range
          */
+        template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator<KeyIterator>::value)>
         void
-        erase(device_ptr<key_type> begin,
-              device_ptr<key_type> end);
-
-
-        /**
-         * \brief Deletes the values with the given range of keys from the container
-         * \param[in] begin The begin of the range
-         * \param[in] end The end of the range
-         */
-        void
-        erase(device_ptr<const key_type> begin,
-              device_ptr<const key_type> end);
+        erase(KeyIterator begin,
+              KeyIterator end);
 
 
         /**

--- a/test/stdgpu/unordered_map.inc
+++ b/test/stdgpu/unordered_map.inc
@@ -35,6 +35,14 @@ STDGPU_DEVICE_ONLY thrust::pair<typename unordered_map<int, float>::iterator, bo
 unordered_map<int, float>::emplace<int, float>(int&&, float&&);
 */
 
+template
+void
+unordered_map<int, float>::insert(device_ptr<const typename unordered_map<int, float>::value_type>, device_ptr<const typename unordered_map<int, float>::value_type>);
+
+template
+void
+unordered_map<int, float>::erase(device_ptr<const typename unordered_map<int, float>::key_type>, device_ptr<const typename unordered_map<int, float>::key_type>);
+
 } // namespace stdgpu
 
 

--- a/test/stdgpu/unordered_set.inc
+++ b/test/stdgpu/unordered_set.inc
@@ -35,6 +35,14 @@ STDGPU_DEVICE_ONLY thrust::pair<typename unordered_set<int>::iterator, bool>
 unordered_set<int>::emplace<int>(int&&);
 */
 
+template
+void
+unordered_set<int>::insert(device_ptr<const typename unordered_set<int>::value_type>, device_ptr<const typename unordered_set<int>::value_type>);
+
+template
+void
+unordered_set<int>::erase(device_ptr<const typename unordered_set<int>::key_type>, device_ptr<const typename unordered_set<int>::key_type>);
+
 } // namespace stdgpu
 
 


### PR DESCRIPTION
The range-based `insert` and `erase` functions of `unordered_map` and `unordered_set` currently allow to pass device pointers of the key or value types or const qualified versions thereof. This not only limits their usability but also results in duplicated code. Unify them to a template based version as defined in the C++ standard to overcome this limitation.