### PR TITLE
unordered_map,unordered_set: Add transparent count and contains functions

### DIFF
--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -191,6 +191,15 @@ class unordered_base
         STDGPU_DEVICE_ONLY index_type
         count(const key_type& key) const;
 
+        /**
+         * \brief Returns the number of elements with the given key-like value in the container
+         * \param[in] key The key-like value
+         * \return The number of elements with the given key-like value, i.e. 1 or 0
+         */
+        template <typename KeyLike, STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
+        STDGPU_DEVICE_ONLY index_type
+        count(const KeyLike& key) const;
+
 
         /**
          * \brief Determines if the given key is stored in the container
@@ -234,6 +243,15 @@ class unordered_base
          */
         STDGPU_DEVICE_ONLY bool
         contains(const key_type& key) const;
+
+        /**
+         * \brief Determines if the given key-like value is stored in the container
+         * \param[in] key The key-like value
+         * \return True if the requested key-like value was found, false otherwise
+         */
+        template <typename KeyLike, STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
+        STDGPU_DEVICE_ONLY bool
+        contains(const KeyLike& key) const;
 
 
         /**
@@ -406,8 +424,16 @@ class unordered_base
                                      const index_t linked_list_start);
 
         template <typename KeyLike>
+        STDGPU_DEVICE_ONLY index_type
+        count_impl(const KeyLike& key) const;
+
+        template <typename KeyLike>
         STDGPU_DEVICE_ONLY const_iterator
         find_impl(const KeyLike& key) const;
+
+        template <typename KeyLike>
+        STDGPU_DEVICE_ONLY bool
+        contains_impl(const KeyLike& key) const;
 
         template <typename KeyLike>
         STDGPU_HOST_DEVICE index_type

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -499,6 +499,24 @@ template <typename Key, typename Value, typename KeyFromValue, typename Hash, ty
 inline STDGPU_DEVICE_ONLY index_t
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::count(const key_type& key) const
 {
+    return count_impl(key);
+}
+
+
+template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
+template <typename KeyLike, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
+inline STDGPU_DEVICE_ONLY index_t
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::count(const KeyLike& key) const
+{
+    return count_impl(key);
+}
+
+
+template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
+template <typename KeyLike>
+inline STDGPU_DEVICE_ONLY index_t
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::count_impl(const KeyLike& key) const
+{
     return contains(key) ? index_t(1) : index_t(0);
 }
 
@@ -574,6 +592,24 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find_impl(const KeyLik
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
 inline STDGPU_DEVICE_ONLY bool
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::contains(const key_type& key) const
+{
+    return contains_impl(key);
+}
+
+
+template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
+template <typename KeyLike, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
+inline STDGPU_DEVICE_ONLY bool
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::contains(const KeyLike& key) const
+{
+    return contains_impl(key);
+}
+
+
+template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual>
+template <typename KeyLike>
+inline STDGPU_DEVICE_ONLY bool
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::contains_impl(const KeyLike& key) const
 {
     return find(key) != end();
 }

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -129,6 +129,15 @@ unordered_map<Key, T, Hash, KeyEqual>::count(const key_type& key) const
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
+template <typename KeyLike, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
+inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::index_type
+unordered_map<Key, T, Hash, KeyEqual>::count(const KeyLike& key) const
+{
+    return _base.count(key);
+}
+
+
+template <typename Key, typename T, typename Hash, typename KeyEqual>
 inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::iterator
 unordered_map<Key, T, Hash, KeyEqual>::find(const key_type& key)
 {
@@ -154,9 +163,9 @@ unordered_map<Key, T, Hash, KeyEqual>::find(const KeyLike& key)
 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual>
-template <typename K, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
+template <typename KeyLike, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
 inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual>::const_iterator
-unordered_map<Key, T, Hash, KeyEqual>::find(const K& key) const
+unordered_map<Key, T, Hash, KeyEqual>::find(const KeyLike& key) const
 {
     return _base.find(key);
 }
@@ -165,6 +174,15 @@ unordered_map<Key, T, Hash, KeyEqual>::find(const K& key) const
 template <typename Key, typename T, typename Hash, typename KeyEqual>
 inline STDGPU_DEVICE_ONLY bool
 unordered_map<Key, T, Hash, KeyEqual>::contains(const key_type& key) const
+{
+    return _base.contains(key);
+}
+
+
+template <typename Key, typename T, typename Hash, typename KeyEqual>
+template <typename KeyLike, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
+inline STDGPU_DEVICE_ONLY bool
+unordered_map<Key, T, Hash, KeyEqual>::contains(const KeyLike& key) const
 {
     return _base.contains(key);
 }

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -114,6 +114,15 @@ unordered_set<Key, Hash, KeyEqual>::count(const key_type& key) const
 
 
 template <typename Key, typename Hash, typename KeyEqual>
+template <typename KeyLike, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
+inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::index_type
+unordered_set<Key, Hash, KeyEqual>::count(const KeyLike& key) const
+{
+    return _base.count(key);
+}
+
+
+template <typename Key, typename Hash, typename KeyEqual>
 inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual>::iterator
 unordered_set<Key, Hash, KeyEqual>::find(const key_type& key)
 {
@@ -150,6 +159,15 @@ unordered_set<Key, Hash, KeyEqual>::find(const KeyLike& key) const
 template <typename Key, typename Hash, typename KeyEqual>
 inline STDGPU_DEVICE_ONLY bool
 unordered_set<Key, Hash, KeyEqual>::contains(const key_type& key) const
+{
+    return _base.contains(key);
+}
+
+
+template <typename Key, typename Hash, typename KeyEqual>
+template <typename KeyLike, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
+inline STDGPU_DEVICE_ONLY bool
+unordered_set<Key, Hash, KeyEqual>::contains(const KeyLike& key) const
 {
     return _base.contains(key);
 }

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -220,6 +220,15 @@ class unordered_map
         STDGPU_DEVICE_ONLY index_type
         count(const key_type& key) const;
 
+        /**
+         * \brief Returns the number of elements with the given key-like value in the container
+         * \param[in] key The key-like value
+         * \return The number of elements with the given key-like value, i.e. 1 or 0
+         */
+        template <typename KeyLike, STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
+        STDGPU_DEVICE_ONLY index_type
+        count(const KeyLike& key) const;
+
 
         /**
          * \brief Determines if the given key is stored in the container
@@ -263,6 +272,15 @@ class unordered_map
          */
         STDGPU_DEVICE_ONLY bool
         contains(const key_type& key) const;
+
+        /**
+         * \brief Determines if the given key-like value is stored in the container
+         * \param[in] key The key-like value
+         * \return True if the requested key-like value was found, false otherwise
+         */
+        template <typename KeyLike, STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
+        STDGPU_DEVICE_ONLY bool
+        contains(const KeyLike& key) const;
 
 
         /**

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -208,6 +208,15 @@ class unordered_set
         STDGPU_DEVICE_ONLY index_type
         count(const key_type& key) const;
 
+        /**
+         * \brief Returns the number of elements with the given key-like value in the container
+         * \param[in] key The key-like value
+         * \return The number of elements with the given key-like value, i.e. 1 or 0
+         */
+        template <typename KeyLike, STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
+        STDGPU_DEVICE_ONLY index_type
+        count(const KeyLike& key) const;
+
 
         /**
          * \brief Determines if the given key is stored in the container
@@ -251,6 +260,15 @@ class unordered_set
          */
         STDGPU_DEVICE_ONLY bool
         contains(const key_type& key) const;
+
+        /**
+         * \brief Determines if the given key-like value is stored in the container
+         * \param[in] key The key-like value
+         * \return True if the requested key-like value was found, false otherwise
+         */
+        template <typename KeyLike, STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value && detail::is_transparent<KeyEqual>::value)>
+        STDGPU_DEVICE_ONLY bool
+        contains(const KeyLike& key) const;
 
 
         /**

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -394,9 +394,35 @@ namespace
     };
 
 
+    class transparent_contains_key_functor
+    {
+        public:
+            transparent_contains_key_functor(const test_unordered_datastructure& hash_datastructure,
+                                             const test_unordered_datastructure::key_type& key,
+                                             stdgpu::index_t* contained)
+                : _hash_datastructure(hash_datastructure),
+                  _key(key),
+                  _contained(contained)
+            {
+
+            }
+
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_contained = _hash_datastructure.contains(STDGPU_UNORDERED_DATASTRUCTURE_KEY2KEYLIKE(_key)) ? 1 : 0;
+            }
+
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type _key;
+            stdgpu::index_t* _contained;
+    };
+
+
     bool
-    contains_key(const test_unordered_datastructure& hash_datastructure,
-                 const test_unordered_datastructure::key_type& key)
+    regular_contains_key(const test_unordered_datastructure& hash_datastructure,
+                         const test_unordered_datastructure::key_type& key)
     {
         stdgpu::index_t* contained = createDeviceArray<stdgpu::index_t>(1);
 
@@ -409,6 +435,37 @@ namespace
         destroyDeviceArray<stdgpu::index_t>(contained);
 
         return host_contained == 1;
+    }
+
+
+    bool
+    transparent_contains_key(const test_unordered_datastructure& hash_datastructure,
+                             const test_unordered_datastructure::key_type& key)
+    {
+        stdgpu::index_t* contained = createDeviceArray<stdgpu::index_t>(1);
+
+        thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
+                         transparent_contains_key_functor(hash_datastructure, key, contained));
+
+        stdgpu::index_t host_contained;
+        copyDevice2HostArray<stdgpu::index_t>(contained, 1, &host_contained, MemoryCopy::NO_CHECK);
+
+        destroyDeviceArray<stdgpu::index_t>(contained);
+
+        return host_contained == 1;
+    }
+
+
+    bool
+    contains_key(const test_unordered_datastructure& hash_datastructure,
+                 const test_unordered_datastructure::key_type& key)
+    {
+        bool regular_contained = regular_contains_key(hash_datastructure, key);
+        bool transparent_contained = transparent_contains_key(hash_datastructure, key);
+
+        EXPECT_EQ(regular_contained, transparent_contained);
+
+        return regular_contained;
     }
 
 
@@ -464,6 +521,58 @@ namespace
     };
 
 
+    class transparent_non_const_find_key_functor
+    {
+        public:
+            transparent_non_const_find_key_functor(const test_unordered_datastructure& hash_datastructure,
+                                                   const test_unordered_datastructure::key_type& key,
+                                                   test_unordered_datastructure::iterator* result)
+                : _hash_datastructure(hash_datastructure),
+                  _key(key),
+                  _result(result)
+            {
+
+            }
+
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _hash_datastructure.find(STDGPU_UNORDERED_DATASTRUCTURE_KEY2KEYLIKE(_key));
+            }
+
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type _key;
+            test_unordered_datastructure::iterator* _result;
+    };
+
+
+    class transparent_const_find_key_functor
+    {
+        public:
+            transparent_const_find_key_functor(const test_unordered_datastructure& hash_datastructure,
+                                               const test_unordered_datastructure::key_type& key,
+                                               test_unordered_datastructure::const_iterator* result)
+                : _hash_datastructure(hash_datastructure),
+                  _key(key),
+                  _result(result)
+            {
+
+            }
+
+            STDGPU_DEVICE_ONLY void
+            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
+            {
+                *_result = _hash_datastructure.find(STDGPU_UNORDERED_DATASTRUCTURE_KEY2KEYLIKE(_key));
+            }
+
+        private:
+            const test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type _key;
+            test_unordered_datastructure::const_iterator* _result;
+    };
+
+
     test_unordered_datastructure::iterator
     non_const_find_key(const test_unordered_datastructure& hash_datastructure,
                        const test_unordered_datastructure::key_type& key)
@@ -500,74 +609,9 @@ namespace
     }
 
 
-    test_unordered_datastructure::const_iterator
-    find_key(const test_unordered_datastructure& hash_datastructure,
-             const test_unordered_datastructure::key_type& key)
-    {
-        test_unordered_datastructure::iterator non_const_iterator   = non_const_find_key(hash_datastructure, key);
-        test_unordered_datastructure::const_iterator const_iterator = const_find_key(hash_datastructure, key);
-
-        EXPECT_EQ(non_const_iterator, const_iterator);
-
-        return const_iterator;
-    }
-
-
-    class transparent_non_const_find_key_functor
-    {
-        public:
-            transparent_non_const_find_key_functor(const test_unordered_datastructure& hash_datastructure,
-                                                   const STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE& key,
-                                                   test_unordered_datastructure::iterator* result)
-                : _hash_datastructure(hash_datastructure),
-                  _key(key),
-                  _result(result)
-            {
-
-            }
-
-            STDGPU_DEVICE_ONLY void
-            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-            {
-                *_result = _hash_datastructure.find(_key);
-            }
-
-        private:
-            test_unordered_datastructure _hash_datastructure;
-            STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE _key;
-            test_unordered_datastructure::iterator* _result;
-    };
-
-
-    class transparent_const_find_key_functor
-    {
-        public:
-            transparent_const_find_key_functor(const test_unordered_datastructure& hash_datastructure,
-                                               const STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE& key,
-                                               test_unordered_datastructure::const_iterator* result)
-                : _hash_datastructure(hash_datastructure),
-                  _key(key),
-                  _result(result)
-            {
-
-            }
-
-            STDGPU_DEVICE_ONLY void
-            operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
-            {
-                *_result = _hash_datastructure.find(_key);
-            }
-
-        private:
-            const test_unordered_datastructure _hash_datastructure;
-            STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE _key;
-            test_unordered_datastructure::const_iterator* _result;
-    };
-
-
     test_unordered_datastructure::iterator
     transparent_non_const_find_key(const test_unordered_datastructure& hash_datastructure,
-                                   const STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE& key)
+                                   const test_unordered_datastructure::key_type& key)
     {
         test_unordered_datastructure::iterator* result = createDeviceArray<test_unordered_datastructure::iterator>(1);
 
@@ -585,7 +629,7 @@ namespace
 
     test_unordered_datastructure::const_iterator
     transparent_const_find_key(const test_unordered_datastructure& hash_datastructure,
-                               const STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE& key)
+                               const test_unordered_datastructure::key_type& key)
     {
         test_unordered_datastructure::const_iterator* result = createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
@@ -602,13 +646,18 @@ namespace
 
 
     test_unordered_datastructure::const_iterator
-    transparent_find_key(const test_unordered_datastructure& hash_datastructure,
-                         const STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE& key)
+    find_key(const test_unordered_datastructure& hash_datastructure,
+             const test_unordered_datastructure::key_type& key)
     {
-        test_unordered_datastructure::iterator non_const_iterator   = transparent_non_const_find_key(hash_datastructure, key);
-        test_unordered_datastructure::const_iterator const_iterator = transparent_const_find_key(hash_datastructure, key);
+        test_unordered_datastructure::iterator non_const_iterator   = non_const_find_key(hash_datastructure, key);
+        test_unordered_datastructure::const_iterator const_iterator = const_find_key(hash_datastructure, key);
 
-        EXPECT_EQ(non_const_iterator, const_iterator);
+        test_unordered_datastructure::iterator transparent_non_const_iterator   = transparent_non_const_find_key(hash_datastructure, key);
+        test_unordered_datastructure::const_iterator transparent_const_iterator = transparent_const_find_key(hash_datastructure, key);
+
+        EXPECT_EQ(const_iterator, non_const_iterator);
+        EXPECT_EQ(const_iterator, transparent_non_const_iterator);
+        EXPECT_EQ(const_iterator, transparent_const_iterator);
 
         return const_iterator;
     }
@@ -888,38 +937,6 @@ namespace
     {
         return begin_iterator(hash_datastructure) + hash_datastructure.bucket(key);
     }
-}
-
-
-TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_no_collision_transparent_find)
-{
-    const test_unordered_datastructure::key_type position_1(-7, -3, 15);
-    const STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE transparent_position_1(-7, -3, 15);
-
-    const test_unordered_datastructure::key_type position_2(-5, -15, 13);
-    const STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE transparent_position_2(-5, -15, 13);
-
-
-    // Insert test data
-    bool inserted_1 = insert_key(hash_datastructure, position_1);
-    EXPECT_TRUE(inserted_1);
-    EXPECT_TRUE(hash_datastructure.valid());
-
-    bool inserted_2 = insert_key(hash_datastructure, position_2);
-    EXPECT_TRUE(inserted_2);
-    EXPECT_TRUE(hash_datastructure.valid());
-
-    // Find test data
-    test_unordered_datastructure::const_iterator index_1 = transparent_find_key(hash_datastructure, transparent_position_1);
-    test_unordered_datastructure::const_iterator index_2 = transparent_find_key(hash_datastructure, transparent_position_2);
-
-    // Found
-    EXPECT_NE(index_1, end_iterator(hash_datastructure));
-    EXPECT_NE(index_2, end_iterator(hash_datastructure));
-
-    // No collisions
-    EXPECT_EQ(index_1, bucket_iterator(hash_datastructure, position_1));
-    EXPECT_EQ(index_2, bucket_iterator(hash_datastructure, position_2));
 }
 
 
@@ -2206,6 +2223,32 @@ namespace
             test_unordered_datastructure::key_type* _keys;
             stdgpu::index_t* _counts;
     };
+
+
+    class transparent_store_counts
+    {
+        public:
+            transparent_store_counts(const test_unordered_datastructure& hash_datastructure,
+                                     test_unordered_datastructure::key_type* keys,
+                                     stdgpu::index_t* counts)
+                : _hash_datastructure(hash_datastructure),
+                  _keys(keys),
+                  _counts(counts)
+            {
+
+            }
+
+            STDGPU_DEVICE_ONLY void
+            operator()(const stdgpu::index_t i)
+            {
+                _counts[i] = _hash_datastructure.count(STDGPU_UNORDERED_DATASTRUCTURE_KEY2KEYLIKE(_keys[i]));
+            }
+
+        private:
+            test_unordered_datastructure _hash_datastructure;
+            test_unordered_datastructure::key_type* _keys;
+            stdgpu::index_t* _counts;
+    };
 }
 
 
@@ -2241,19 +2284,26 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, count_sum)
     test_unordered_datastructure::key_type* host_positions  = insert_unique_parallel(hash_datastructure, N);
     test_unordered_datastructure::key_type* positions       = copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-    stdgpu::index_t* counts = createDeviceArray<stdgpu::index_t>(N);
+    stdgpu::index_t* counts             = createDeviceArray<stdgpu::index_t>(N);
+    stdgpu::index_t* transparent_counts = createDeviceArray<stdgpu::index_t>(N);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
                      store_counts(hash_datastructure, positions, counts));
 
-    stdgpu::index_t counts_sum = thrust::reduce(stdgpu::device_cbegin(counts), stdgpu::device_cend(counts));
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     transparent_store_counts(hash_datastructure, positions, transparent_counts));
+
+    stdgpu::index_t counts_sum             = thrust::reduce(stdgpu::device_cbegin(counts), stdgpu::device_cend(counts));
+    stdgpu::index_t transparent_counts_sum = thrust::reduce(stdgpu::device_cbegin(transparent_counts), stdgpu::device_cend(transparent_counts));
 
     EXPECT_EQ(counts_sum, N);
+    EXPECT_EQ(transparent_counts_sum, N);
     EXPECT_FALSE(hash_datastructure.empty());
     EXPECT_EQ(hash_datastructure.size(), N);
     EXPECT_TRUE(hash_datastructure.valid());
 
     destroyDeviceArray<stdgpu::index_t>(counts);
+    destroyDeviceArray<stdgpu::index_t>(transparent_counts);
     destroyDeviceArray<test_unordered_datastructure::key_type>(positions);
     destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
 }

--- a/test/stdgpu/unordered_map.inc
+++ b/test/stdgpu/unordered_map.inc
@@ -57,12 +57,20 @@ void
 unordered_map<int, float>::erase(device_ptr<const typename unordered_map<int, float>::key_type>, device_ptr<const typename unordered_map<int, float>::key_type>);
 
 template
+STDGPU_DEVICE_ONLY typename unordered_map<int, float, int_hash, equal_to<>>::index_type
+unordered_map<int, float, int_hash, equal_to<>>::count<short>(const short&) const;
+
+template
 STDGPU_DEVICE_ONLY typename unordered_map<int, float, int_hash, equal_to<>>::iterator
 unordered_map<int, float, int_hash, equal_to<>>::find<short>(const short&);
 
 template
 STDGPU_DEVICE_ONLY typename unordered_map<int, float, int_hash, equal_to<>>::const_iterator
 unordered_map<int, float, int_hash, equal_to<>>::find<short>(const short&) const;
+
+template
+STDGPU_DEVICE_ONLY bool
+unordered_map<int, float, int_hash, equal_to<>>::contains<short>(const short&) const;
 
 } // namespace stdgpu
 
@@ -122,14 +130,14 @@ struct less
 };
 
 
-struct vec3int8
+struct vec3int32
 {
-    vec3int8() = default;
+    vec3int32() = default;
 
     STDGPU_HOST_DEVICE
-    vec3int8(const std::int8_t new_x,
-             const std::int8_t new_y,
-             const std::int8_t new_z)
+    vec3int32(const std::int32_t new_x,
+              const std::int32_t new_y,
+              const std::int32_t new_z)
         : x(new_x),
           y(new_y),
           z(new_z)
@@ -137,14 +145,14 @@ struct vec3int8
 
     }
 
-    std::int8_t x = 0; // NOLINT(misc-non-private-member-variables-in-classes)
-    std::int8_t y = 0; // NOLINT(misc-non-private-member-variables-in-classes)
-    std::int8_t z = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+    std::int32_t x = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+    std::int32_t y = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+    std::int32_t z = 0; // NOLINT(misc-non-private-member-variables-in-classes)
 };
 
 inline STDGPU_HOST_DEVICE bool
 operator==(const vec3int16& lhs,
-           const vec3int8& rhs)
+           const vec3int32& rhs)
 {
     return lhs.x == rhs.x
         && lhs.y == rhs.y
@@ -152,7 +160,7 @@ operator==(const vec3int16& lhs,
 }
 
 inline STDGPU_HOST_DEVICE bool
-operator==(const vec3int8& lhs,
+operator==(const vec3int32& lhs,
            const vec3int16& rhs)
 {
     return rhs == lhs;
@@ -164,7 +172,7 @@ struct vec_hash
     using is_transparent = void;
 
     inline STDGPU_HOST_DEVICE std::size_t
-    operator()(const vec3int8& key) const
+    operator()(const vec3int16& key) const
     {
         const std::size_t prime_x = static_cast<std::size_t>(73856093U);
         const std::size_t prime_y = static_cast<std::size_t>(19349669U);
@@ -176,7 +184,7 @@ struct vec_hash
     }
 
     inline STDGPU_HOST_DEVICE std::size_t
-    operator()(const vec3int16& key) const
+    operator()(const vec3int32& key) const
     {
         const std::size_t prime_x = static_cast<std::size_t>(73856093U);
         const std::size_t prime_y = static_cast<std::size_t>(19349669U);
@@ -203,11 +211,19 @@ value_to_key(const stdgpu::unordered_map<vec3int16, dummy, vec_hash>::value_type
 }
 
 
+inline STDGPU_HOST_DEVICE vec3int32
+key_to_keylike(const vec3int16& key)
+{
+    return vec3int32(key.x, key.y, key.z);
+}
+
+
 #define STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS stdgpu_unordered_map
 #define STDGPU_UNORDERED_DATASTRUCTURE_TYPE stdgpu::unordered_map<vec3int16, dummy, vec_hash, stdgpu::equal_to<>>
 #define STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE key_to_value
 #define STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY value_to_key
-#define STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE vec3int8
+#define STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE vec3int32
+#define STDGPU_UNORDERED_DATASTRUCTURE_KEY2KEYLIKE key_to_keylike
 
 
 #include "unordered_datastructure.inc"

--- a/test/stdgpu/unordered_set.inc
+++ b/test/stdgpu/unordered_set.inc
@@ -57,12 +57,20 @@ void
 unordered_set<int>::erase(device_ptr<const typename unordered_set<int>::key_type>, device_ptr<const typename unordered_set<int>::key_type>);
 
 template
+STDGPU_DEVICE_ONLY typename unordered_set<int, int_hash, equal_to<>>::index_type
+unordered_set<int, int_hash, equal_to<>>::count<short>(const short&) const;
+
+template
 STDGPU_DEVICE_ONLY typename unordered_set<int, int_hash, equal_to<>>::iterator
 unordered_set<int, int_hash, equal_to<>>::find<short>(const short&);
 
 template
 STDGPU_DEVICE_ONLY typename unordered_set<int, int_hash, equal_to<>>::const_iterator
 unordered_set<int, int_hash, equal_to<>>::find<short>(const short&) const;
+
+template
+STDGPU_DEVICE_ONLY bool
+unordered_set<int, int_hash, equal_to<>>::contains<short>(const short&) const;
 
 } // namespace stdgpu
 
@@ -118,14 +126,14 @@ struct less
 };
 
 
-struct vec3int8
+struct vec3int32
 {
-    vec3int8() = default;
+    vec3int32() = default;
 
     STDGPU_HOST_DEVICE
-    vec3int8(const std::int8_t new_x,
-             const std::int8_t new_y,
-             const std::int8_t new_z)
+    vec3int32(const std::int32_t new_x,
+              const std::int32_t new_y,
+              const std::int32_t new_z)
         : x(new_x),
           y(new_y),
           z(new_z)
@@ -133,14 +141,14 @@ struct vec3int8
 
     }
 
-    std::int8_t x = 0; // NOLINT(misc-non-private-member-variables-in-classes)
-    std::int8_t y = 0; // NOLINT(misc-non-private-member-variables-in-classes)
-    std::int8_t z = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+    std::int32_t x = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+    std::int32_t y = 0; // NOLINT(misc-non-private-member-variables-in-classes)
+    std::int32_t z = 0; // NOLINT(misc-non-private-member-variables-in-classes)
 };
 
 inline STDGPU_HOST_DEVICE bool
 operator==(const vec3int16& lhs,
-           const vec3int8& rhs)
+           const vec3int32& rhs)
 {
     return lhs.x == rhs.x
         && lhs.y == rhs.y
@@ -148,7 +156,7 @@ operator==(const vec3int16& lhs,
 }
 
 inline STDGPU_HOST_DEVICE bool
-operator==(const vec3int8& lhs,
+operator==(const vec3int32& lhs,
            const vec3int16& rhs)
 {
     return rhs == lhs;
@@ -160,7 +168,7 @@ struct vec_hash
     using is_transparent = void;
 
     inline STDGPU_HOST_DEVICE std::size_t
-    operator()(const vec3int8& key) const
+    operator()(const vec3int16& key) const
     {
         const std::size_t prime_x = static_cast<std::size_t>(73856093U);
         const std::size_t prime_y = static_cast<std::size_t>(19349669U);
@@ -172,7 +180,7 @@ struct vec_hash
     }
 
     inline STDGPU_HOST_DEVICE std::size_t
-    operator()(const vec3int16& key) const
+    operator()(const vec3int32& key) const
     {
         const std::size_t prime_x = static_cast<std::size_t>(73856093U);
         const std::size_t prime_y = static_cast<std::size_t>(19349669U);
@@ -199,11 +207,19 @@ value_to_key(const vec3int16& key)
 }
 
 
+inline STDGPU_HOST_DEVICE vec3int32
+key_to_keylike(const vec3int16& key)
+{
+    return vec3int32(key.x, key.y, key.z);
+}
+
+
 #define STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS stdgpu_unordered_set
 #define STDGPU_UNORDERED_DATASTRUCTURE_TYPE stdgpu::unordered_set<vec3int16, vec_hash, stdgpu::equal_to<>>
 #define STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE key_to_value
 #define STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY value_to_key
-#define STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE vec3int8
+#define STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE vec3int32
+#define STDGPU_UNORDERED_DATASTRUCTURE_KEY2KEYLIKE key_to_keylike
 
 
 #include "unordered_datastructure.inc"


### PR DESCRIPTION
In #220 support for the transparent `find` function has been added to `unordered_map` and `unordered_set`. Extend this by also providing transparent `count` and `contains` functions in a similar way. Furthermore, simplify the tests by automatically checking the transparent versions in the helper functions as well.