### PR TITLE
unordered_base: Fix fluctuating coverage

### DIFF
--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -845,14 +845,14 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::find_previous_entry_po
 
         if (position_found)
         {
-            return previous_position;
+            break;
         }
 
         // Increment previous (--> equal to key_index)
         previous_position = key_index;
     }
 
-    return key_index;
+    return previous_position;
 }
 
 


### PR DESCRIPTION
We often observed fluctuating code coverage in `unordered_base`'s internal `find_previous_entry_position` function. Due to the inherent multi-threading nature of the algorithms we test, there has been significant likelihood that the fallback path will not be triggered. Fix this problem by unifying the two possible code paths through a single return statement.