### PR TITLE
General: Improve compilation error generation for wrong device compiler

### DIFF
--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -16,6 +16,8 @@
 #ifndef STDGPU_ATOMIC_H
 #define STDGPU_ATOMIC_H
 
+#include <stdgpu/impl/platform_check.h>
+
 /**
  * \addtogroup atomic atomic
  * \ingroup data_structures

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -16,6 +16,8 @@
 #ifndef STDGPU_BITSET_H
 #define STDGPU_BITSET_H
 
+#include <stdgpu/impl/platform_check.h>
+
 /**
  * \addtogroup bitset bitset
  * \ingroup data_structures

--- a/src/stdgpu/cuda/platform.h
+++ b/src/stdgpu/cuda/platform.h
@@ -44,8 +44,7 @@ namespace cuda
 #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_NVCC || STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_CUDACLANG
     #define STDGPU_CUDA_DEVICE_ONLY __device__
 #else
-    // Should trigger a compact error message containing the error string
-    #define STDGPU_CUDA_DEVICE_ONLY sizeof("STDGPU ERROR: Wrong compiler detected! Device-only functions must be compiled with the device compiler!")
+    // Undefined
 #endif
 
 

--- a/src/stdgpu/cuda/platform_check.h
+++ b/src/stdgpu/cuda/platform_check.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2021 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_CUDA_PLATFORM_CHECK_H
+#define STDGPU_CUDA_PLATFORM_CHECK_H
+
+
+#include <stdgpu/compiler.h>
+
+
+
+namespace stdgpu
+{
+namespace cuda
+{
+
+#if STDGPU_DEVICE_COMPILER != STDGPU_DEVICE_COMPILER_NVCC && STDGPU_DEVICE_COMPILER != STDGPU_DEVICE_COMPILER_CUDACLANG
+    #error STDGPU ERROR: Wrong compiler detected! You are including a file with functions that must be compiled with the device compiler!
+    #include <stdgpu/this_include_error_is_intended/take_a_look_at_the_error_above> // Helper to stop compilation as early as possible
+#endif
+
+} // namespace cuda
+
+} // namespace stdgpu
+
+
+
+#endif // STDGPU_CUDA_PLATFORM_CHECK_H

--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -16,6 +16,8 @@
 #ifndef STDGPU_DEQUE_H
 #define STDGPU_DEQUE_H
 
+#include <stdgpu/impl/platform_check.h>
+
 /**
  * \addtogroup deque deque
  * \ingroup data_structures

--- a/src/stdgpu/hip/platform.h
+++ b/src/stdgpu/hip/platform.h
@@ -47,8 +47,7 @@ namespace hip
 #if STDGPU_DEVICE_COMPILER == STDGPU_DEVICE_COMPILER_HIPCLANG
     #define STDGPU_HIP_DEVICE_ONLY __device__
 #else
-    // Should trigger a compact error message containing the error string
-    #define STDGPU_HIP_DEVICE_ONLY sizeof("STDGPU ERROR: Wrong compiler detected! Device-only functions must be compiled with the device compiler!")
+    // Undefined
 #endif
 
 

--- a/src/stdgpu/hip/platform_check.h
+++ b/src/stdgpu/hip/platform_check.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2021 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_HIP_PLATFORM_CHECK_H
+#define STDGPU_HIP_PLATFORM_CHECK_H
+
+
+#include <stdgpu/compiler.h>
+
+
+
+namespace stdgpu
+{
+namespace hip
+{
+
+#if STDGPU_DEVICE_COMPILER != STDGPU_DEVICE_COMPILER_HIPCLANG
+    #error STDGPU ERROR: Wrong compiler detected! You are including a file with functions that must be compiled with the device compiler!
+    #include <stdgpu/this_include_error_is_intended/take_a_look_at_the_error_above> // Helper to stop compilation as early as possible
+#endif
+
+} // namespace hip
+
+} // namespace stdgpu
+
+
+
+#endif // STDGPU_HIP_PLATFORM_CHECK_H

--- a/src/stdgpu/impl/platform_check.h
+++ b/src/stdgpu/impl/platform_check.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2021 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_PLATFORM_CHECK_H
+#define STDGPU_PLATFORM_CHECK_H
+
+
+#include <stdgpu/config.h>
+
+//! @cond Doxygen_Suppress
+#define STDGPU_BACKEND_PLATFORM_CHECK_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/platform_check.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
+// cppcheck-suppress preprocessorErrorDirective
+#include STDGPU_BACKEND_PLATFORM_CHECK_HEADER
+#undef STDGPU_BACKEND_PLATFORM_CHECK_HEADER
+//! @endcond
+
+
+
+#endif // STDGPU_PLATFORM_CHECK_H

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -16,6 +16,8 @@
 #ifndef STDGPU_MUTEX_H
 #define STDGPU_MUTEX_H
 
+#include <stdgpu/impl/platform_check.h>
+
 
 /**
  * \addtogroup mutex mutex

--- a/src/stdgpu/openmp/platform_check.h
+++ b/src/stdgpu/openmp/platform_check.h
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2021 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_OPENMP_PLATFORM_CHECK_H
+#define STDGPU_OPENMP_PLATFORM_CHECK_H
+
+
+
+namespace stdgpu
+{
+namespace openmp
+{
+
+// No check required
+
+} // namespace openmp
+
+} // namespace stdgpu
+
+
+
+#endif // STDGPU_OPENMP_PLATFORM_CHECK_H

--- a/src/stdgpu/queue.cuh
+++ b/src/stdgpu/queue.cuh
@@ -16,6 +16,8 @@
 #ifndef STDGPU_QUEUE_H
 #define STDGPU_QUEUE_H
 
+#include <stdgpu/impl/platform_check.h>
+
 /**
  * \addtogroup queue queue
  * \ingroup data_structures

--- a/src/stdgpu/stack.cuh
+++ b/src/stdgpu/stack.cuh
@@ -16,6 +16,8 @@
 #ifndef STDGPU_STACK_H
 #define STDGPU_STACK_H
 
+#include <stdgpu/impl/platform_check.h>
+
 /**
  * \addtogroup stack stack
  * \ingroup data_structures

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -16,6 +16,8 @@
 #ifndef STDGPU_UNORDERED_MAP_H
 #define STDGPU_UNORDERED_MAP_H
 
+#include <stdgpu/impl/platform_check.h>
+
 /**
  * \addtogroup unordered_map unordered_map
  * \ingroup data_structures

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -16,6 +16,8 @@
 #ifndef STDGPU_UNORDERED_SET_H
 #define STDGPU_UNORDERED_SET_H
 
+#include <stdgpu/impl/platform_check.h>
+
 /**
  * \addtogroup unordered_set unordered_set
  * \ingroup data_structures

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -16,6 +16,8 @@
 #ifndef STDGPU_VECTOR_H
 #define STDGPU_VECTOR_H
 
+#include <stdgpu/impl/platform_check.h>
+
 /**
  * \addtogroup vector vector
  * \ingroup data_structures


### PR DESCRIPTION
The cross-platform attribute `STDGPU_DEVICE_ONLY` requires compilation of the file, where it is used, with the appropriate device compiler. Although the `sizeof` approach prints the included error message, it still produces much duplicates and noise making the error hard to understand. Replace this check with a preprocessor error that must be explicitly included in the related header files. This approach produces quite short and descriptive error messages at the cost that it must be applied manually. However, this advantages outweigh the slightly increased maintenance burden.

Issue #187 #209