### PR TITLE
bit: Add bit_cast

### DIFF
--- a/src/stdgpu/bit.h
+++ b/src/stdgpu/bit.h
@@ -29,6 +29,7 @@
 #include <type_traits>
 
 #include <stdgpu/platform.h>
+#include <stdgpu/impl/type_traits.h>
 
 
 
@@ -41,7 +42,7 @@ namespace stdgpu
  * \param[in] number A number
  * \return True if number is a power of two, false otherwise
  */
-template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE bool
 has_single_bit(const T number);
 
@@ -51,7 +52,7 @@ has_single_bit(const T number);
  * \param[in] number A number
  * \return The smallest power of two which is larger than the given number
  */
-template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
 bit_ceil(const T number);
 
@@ -61,7 +62,7 @@ bit_ceil(const T number);
  * \param[in] number A number
  * \return The largest power of two which is smaller than the given number
  */
-template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
 bit_floor(const T number);
 
@@ -75,7 +76,7 @@ bit_floor(const T number);
  * \post result >= 0
  * \post result < divider
  */
-template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
 bit_mod(const T number,
         const T divider);
@@ -88,7 +89,7 @@ bit_mod(const T number,
  * \post result >= 0
  * \post result <= numeric_limits<T>::digits
  */
-template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
 bit_width(const T number);
 
@@ -100,7 +101,7 @@ bit_width(const T number);
  * \post result >= 0
  * \post result <= numeric_limits<T>::digits
  */
-template <typename T, typename = typename std::enable_if<std::is_unsigned<T>::value>::type>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE int
 popcount(const T number);
 

--- a/src/stdgpu/bit.h
+++ b/src/stdgpu/bit.h
@@ -105,6 +105,16 @@ template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE int
 popcount(const T number);
 
+/**
+ * \ingroup bit
+ * \brief Reinterprets the object of the given type as an instance of the desired type
+ * \param[in] object An object
+ * \return The same object reinterpreted as an instance of the desired type
+ */
+template <typename To, typename From, STDGPU_DETAIL_OVERLOAD_IF(sizeof(To) == sizeof(From) && std::is_trivially_copyable<To>::value && std::is_trivially_copyable<From>::value)>
+STDGPU_HOST_DEVICE To
+bit_cast(const From& object);
+
 } // namespace stdgpu
 
 

--- a/src/stdgpu/cuda/atomic.cuh
+++ b/src/stdgpu/cuda/atomic.cuh
@@ -19,6 +19,8 @@
 
 #include <type_traits>
 
+#include <stdgpu/impl/type_traits.h>
+
 
 
 namespace stdgpu
@@ -68,7 +70,7 @@ atomic_store(T* address,
  * \param[in] desired The desired argument to store
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired);
@@ -81,7 +83,7 @@ atomic_exchange(T* address,
  * \param[in] desired The desired argument to store
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address,
                         const T expected,
@@ -94,7 +96,7 @@ atomic_compare_exchange(T* address,
  * \param[in] arg The other argument of addition
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg);
@@ -106,7 +108,7 @@ atomic_fetch_add(T* address,
  * \param[in] arg The other argument of subtraction
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg);
@@ -118,7 +120,7 @@ atomic_fetch_sub(T* address,
  * \param[in] arg The other argument of bitwise AND
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg);
@@ -130,7 +132,7 @@ atomic_fetch_and(T* address,
  * \param[in] arg The other argument of bitwise OR
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg);
@@ -142,7 +144,7 @@ atomic_fetch_or(T* address,
  * \param[in] arg The other argument of bitwise XOR
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg);
@@ -154,7 +156,7 @@ atomic_fetch_xor(T* address,
  * \param[in] arg The other argument of minimum
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg);
@@ -166,7 +168,7 @@ atomic_fetch_min(T* address,
  * \param[in] arg The other argument of maximum
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg);
@@ -178,7 +180,7 @@ atomic_fetch_max(T* address,
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_same<T, unsigned int>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg);
@@ -190,7 +192,7 @@ atomic_fetch_inc_mod(T* address,
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_same<T, unsigned int>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg);

--- a/src/stdgpu/cuda/impl/atomic_detail.cuh
+++ b/src/stdgpu/cuda/impl/atomic_detail.cuh
@@ -213,7 +213,7 @@ atomic_store(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired)
@@ -222,7 +222,7 @@ atomic_exchange(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address,
                         const T expected,
@@ -232,7 +232,7 @@ atomic_compare_exchange(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg)
@@ -241,7 +241,7 @@ atomic_fetch_add(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg)
@@ -250,7 +250,7 @@ atomic_fetch_sub(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg)
@@ -259,7 +259,7 @@ atomic_fetch_and(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg)
@@ -268,7 +268,7 @@ atomic_fetch_or(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg)
@@ -277,7 +277,7 @@ atomic_fetch_xor(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg)
@@ -286,7 +286,7 @@ atomic_fetch_min(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg)
@@ -295,7 +295,7 @@ atomic_fetch_max(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg)
@@ -304,7 +304,7 @@ atomic_fetch_inc_mod(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg)

--- a/src/stdgpu/hip/atomic.h
+++ b/src/stdgpu/hip/atomic.h
@@ -19,6 +19,8 @@
 
 #include <type_traits>
 
+#include <stdgpu/impl/type_traits.h>
+
 
 
 namespace stdgpu
@@ -68,7 +70,7 @@ atomic_store(T* address,
  * \param[in] desired The desired argument to store
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired);
@@ -81,7 +83,7 @@ atomic_exchange(T* address,
  * \param[in] desired The desired argument to store
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address,
                         const T expected,
@@ -94,7 +96,7 @@ atomic_compare_exchange(T* address,
  * \param[in] arg The other argument of addition
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg);
@@ -106,7 +108,7 @@ atomic_fetch_add(T* address,
  * \param[in] arg The other argument of subtraction
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg);
@@ -118,7 +120,7 @@ atomic_fetch_sub(T* address,
  * \param[in] arg The other argument of bitwise AND
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg);
@@ -130,7 +132,7 @@ atomic_fetch_and(T* address,
  * \param[in] arg The other argument of bitwise OR
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg);
@@ -142,7 +144,7 @@ atomic_fetch_or(T* address,
  * \param[in] arg The other argument of bitwise XOR
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg);
@@ -154,7 +156,7 @@ atomic_fetch_xor(T* address,
  * \param[in] arg The other argument of minimum
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg);
@@ -166,7 +168,7 @@ atomic_fetch_min(T* address,
  * \param[in] arg The other argument of maximum
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg);
@@ -178,7 +180,7 @@ atomic_fetch_max(T* address,
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_same<T, unsigned int>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg);
@@ -190,7 +192,7 @@ atomic_fetch_inc_mod(T* address,
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_same<T, unsigned int>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg);

--- a/src/stdgpu/hip/impl/atomic_detail.h
+++ b/src/stdgpu/hip/impl/atomic_detail.h
@@ -119,7 +119,7 @@ atomic_store(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired)
@@ -128,7 +128,7 @@ atomic_exchange(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address,
                         const T expected,
@@ -138,7 +138,7 @@ atomic_compare_exchange(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg)
@@ -147,7 +147,7 @@ atomic_fetch_add(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg)
@@ -156,7 +156,7 @@ atomic_fetch_sub(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg)
@@ -165,7 +165,7 @@ atomic_fetch_and(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg)
@@ -174,7 +174,7 @@ atomic_fetch_or(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg)
@@ -183,7 +183,7 @@ atomic_fetch_xor(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg)
@@ -192,7 +192,7 @@ atomic_fetch_min(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg)
@@ -201,7 +201,7 @@ atomic_fetch_max(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg)
@@ -210,7 +210,7 @@ atomic_fetch_inc_mod(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg)

--- a/src/stdgpu/impl/bit_detail.h
+++ b/src/stdgpu/impl/bit_detail.h
@@ -134,6 +134,24 @@ popcount(const T number)
     return result;
 }
 
+
+template <typename To, typename From, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(sizeof(To) == sizeof(From) && std::is_trivially_copyable<To>::value && std::is_trivially_copyable<From>::value)>
+STDGPU_HOST_DEVICE To
+bit_cast(const From& object)
+{
+    To result;
+
+    auto* result_bytes = reinterpret_cast<unsigned char*>(&result);
+    const auto* object_bytes = reinterpret_cast<const unsigned char*>(&object);
+
+    for (unsigned int i = 0; i < sizeof(To); ++i)
+    {
+        result_bytes[i] = object_bytes[i];
+    }
+
+    return result;
+}
+
 } // namespace stdgpu
 
 

--- a/src/stdgpu/impl/bit_detail.h
+++ b/src/stdgpu/impl/bit_detail.h
@@ -24,7 +24,7 @@
 namespace stdgpu
 {
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE bool
 has_single_bit(const T number)
 {
@@ -32,7 +32,7 @@ has_single_bit(const T number)
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
 bit_ceil(const T number)
 {
@@ -56,7 +56,7 @@ bit_ceil(const T number)
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
 bit_floor(const T number)
 {
@@ -79,7 +79,7 @@ bit_floor(const T number)
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
 bit_mod(const T number,
         const T divider)
@@ -94,7 +94,7 @@ bit_mod(const T number,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
 bit_width(const T number)
 {
@@ -116,7 +116,7 @@ bit_width(const T number)
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE int
 popcount(const T number)
 {

--- a/src/stdgpu/impl/functional_detail.h
+++ b/src/stdgpu/impl/functional_detail.h
@@ -19,6 +19,7 @@
 #include <type_traits>
 
 #include <stdgpu/cstddef.h>
+#include <stdgpu/bit.h>
 
 
 
@@ -53,19 +54,19 @@ STDGPU_DETAIL_COMPOUND_HASH_BASIC_INTEGER_TYPE(unsigned long long)
 inline STDGPU_HOST_DEVICE std::size_t
 hash<float>::operator()(const float& key) const
 {
-    return reinterpret_cast<const std::uint32_t&>(key);
+    return hash<std::uint32_t>()(bit_cast<std::uint32_t>(key));
 }
 
 inline STDGPU_HOST_DEVICE std::size_t
 hash<double>::operator()(const double& key) const
 {
-    return reinterpret_cast<const std::uint64_t&>(key);
+    return hash<std::uint64_t>()(bit_cast<std::uint64_t>(key));
 }
 
 inline STDGPU_HOST_DEVICE std::size_t
 hash<long double>::operator()(const long double& key) const
 {
-    return reinterpret_cast<const std::uint64_t&>(key);
+    return hash<double>()(static_cast<double>(key));
 }
 
 

--- a/src/stdgpu/openmp/atomic.h
+++ b/src/stdgpu/openmp/atomic.h
@@ -19,6 +19,8 @@
 
 #include <type_traits>
 
+#include <stdgpu/impl/type_traits.h>
+
 
 
 namespace stdgpu
@@ -68,7 +70,7 @@ atomic_store(T* address,
  * \param[in] desired The desired argument to store
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired);
@@ -81,7 +83,7 @@ atomic_exchange(T* address,
  * \param[in] desired The desired argument to store
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address,
                         const T expected,
@@ -94,7 +96,7 @@ atomic_compare_exchange(T* address,
  * \param[in] arg The other argument of addition
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg);
@@ -106,7 +108,7 @@ atomic_fetch_add(T* address,
  * \param[in] arg The other argument of subtraction
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg);
@@ -118,7 +120,7 @@ atomic_fetch_sub(T* address,
  * \param[in] arg The other argument of bitwise AND
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg);
@@ -130,7 +132,7 @@ atomic_fetch_and(T* address,
  * \param[in] arg The other argument of bitwise OR
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg);
@@ -142,7 +144,7 @@ atomic_fetch_or(T* address,
  * \param[in] arg The other argument of bitwise XOR
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg);
@@ -154,7 +156,7 @@ atomic_fetch_xor(T* address,
  * \param[in] arg The other argument of minimum
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg);
@@ -166,7 +168,7 @@ atomic_fetch_min(T* address,
  * \param[in] arg The other argument of maximum
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg);
@@ -178,7 +180,7 @@ atomic_fetch_max(T* address,
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_same<T, unsigned int>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg);
@@ -190,7 +192,7 @@ atomic_fetch_inc_mod(T* address,
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
-template <typename T, typename = std::enable_if_t<std::is_same<T, unsigned int>::value>>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg);

--- a/src/stdgpu/openmp/impl/atomic_detail.h
+++ b/src/stdgpu/openmp/impl/atomic_detail.h
@@ -63,7 +63,7 @@ atomic_store(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address,
                 const T desired)
@@ -78,7 +78,7 @@ atomic_exchange(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address,
                         const T expected,
@@ -94,7 +94,7 @@ atomic_compare_exchange(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address,
                  const T arg)
@@ -113,7 +113,7 @@ atomic_fetch_add(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address,
                  const T arg)
@@ -132,7 +132,7 @@ atomic_fetch_sub(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address,
                  const T arg)
@@ -151,7 +151,7 @@ atomic_fetch_and(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address,
                  const T arg)
@@ -170,7 +170,7 @@ atomic_fetch_or(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address,
                  const T arg)
@@ -189,7 +189,7 @@ atomic_fetch_xor(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address,
                  const T arg)
@@ -204,7 +204,7 @@ atomic_fetch_min(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address,
                  const T arg)
@@ -219,7 +219,7 @@ atomic_fetch_max(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address,
                      const T arg)
@@ -234,7 +234,7 @@ atomic_fetch_inc_mod(T* address,
 }
 
 
-template <typename T, typename>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address,
                      const T arg)


### PR DESCRIPTION
Reinterpreting an object, e.g. an `int`, as another object, e.g. a `float`, may easily result in undefined behavior due to type aliasing rules. Add `bit_cast` as a safe alternative to cast between types. This fixes undefined behavior for the `float`, `double`, and `long double` specializations of `hash`.

In addition to the above changes, also clean up the conditional overloading mechanism by using the recently introduced `STDGPU_DETAIL_OVERLOAD_IF` macro.