### PR TITLE
unordered_map,unordered_set: Improve performance of clear

### DIFF
--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -2465,6 +2465,20 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_erase)
 }
 
 
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, clear_empty)
+{
+    EXPECT_EQ(hash_datastructure.size(), 0);
+    EXPECT_TRUE(hash_datastructure.valid());
+
+
+    hash_datastructure.clear();
+
+
+    EXPECT_EQ(hash_datastructure.size(), 0);
+    EXPECT_TRUE(hash_datastructure.valid());
+}
+
+
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, clear)
 {
     const stdgpu::index_t N = 100000;


### PR DESCRIPTION
The `clear` function of `unordered_base` uses the thread-based `erase` function. Since clearing a data structure is a special case of the general erase, we can exploit this knowledge to improve the performance. Change the approach to reset the state of all member variables separately using their optimized clear function. This results in a significant performance improvement for large containers.