### PR TITLE
bitset: Improve performance of set, reset, flip

### DIFF
--- a/src/stdgpu/functional.h
+++ b/src/stdgpu/functional.h
@@ -377,6 +377,42 @@ struct equal_to<void>
                U&& rhs) const -> decltype(forward<T>(lhs) == forward<U>(rhs));
 };
 
+
+/**
+ * \brief A function to compute bitwise NOT of values
+ * \tparam T The type of the values
+ */
+template <typename T = void>
+struct bit_not
+{
+    /**
+     * \brief Computes the bitwise NOT on the given value
+     * \param[in] value The value
+     * \return The result of the operation
+     */
+    STDGPU_HOST_DEVICE T
+    operator()(const T value) const;
+};
+
+/**
+ * \brief A transparent specialization of bit_not
+ */
+template <>
+struct bit_not<void>
+{
+    using is_transparent = void;    /**< unspecified */
+
+    /**
+     * \brief Computes the bitwise NOT on the given value
+     * \tparam T The class of the value
+     * \param[in] value The value
+     * \return The result of the operation
+     */
+    template <typename T>
+    STDGPU_HOST_DEVICE auto
+    operator()(T&& value) const -> decltype(~forward<T>(value));
+};
+
 } // namespace stdgpu
 
 

--- a/src/stdgpu/impl/functional_detail.h
+++ b/src/stdgpu/impl/functional_detail.h
@@ -94,6 +94,21 @@ equal_to<void>::operator()(T&& lhs,
     return forward<T>(lhs) == forward<U>(rhs);
 }
 
+
+template <typename T>
+inline STDGPU_HOST_DEVICE T
+bit_not<T>::operator()(const T value) const
+{
+    return ~value;
+}
+
+template <typename T>
+inline STDGPU_HOST_DEVICE auto
+bit_not<void>::operator()(T&& value) const -> decltype(~forward<T>(value))
+{
+    return ~forward<T>(value);
+}
+
 } // namespace stdgpu
 
 

--- a/test/stdgpu/functional.cpp
+++ b/test/stdgpu/functional.cpp
@@ -105,6 +105,9 @@ struct hash<long double>;
 template
 struct equal_to<int>;
 
+template
+struct bit_not<unsigned int>;
+
 } // namespace stdgpu
 
 
@@ -361,6 +364,58 @@ equal_to_transparent_check_integer_random()
 TEST_F(stdgpu_functional, equal_to_transparent)
 {
     equal_to_transparent_check_integer_random<int, long>();
+}
+
+
+template <typename T>
+void
+bit_not_check_integer_random()
+{
+    const stdgpu::index_t N = 1000000;
+
+    // Generate true random numbers
+    std::size_t seed = test_utils::random_seed();
+
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
+    std::uniform_int_distribution<T> dist(std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
+
+    stdgpu::bit_not<T> bit_not_function;
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        T value = dist(rng);
+        EXPECT_EQ(bit_not_function(value), ~value);
+    }
+}
+
+TEST_F(stdgpu_functional, bit_not_unsigned_int)
+{
+    bit_not_check_integer_random<unsigned int>();
+}
+
+
+template <typename T>
+void
+bit_not_transparent_check_integer_random()
+{
+    const stdgpu::index_t N = 1000000;
+
+    // Generate true random numbers
+    std::size_t seed = test_utils::random_seed();
+
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
+    std::uniform_int_distribution<T> dist(std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
+
+    stdgpu::bit_not<> bit_not_function;
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        T value = dist(rng);
+        EXPECT_EQ(bit_not_function(value), ~value);
+    }
+}
+
+TEST_F(stdgpu_functional, bit_not_transparent)
+{
+    bit_not_transparent_check_integer_random<unsigned int>();
 }
 
 


### PR DESCRIPTION
Similar to #226, `bitset` uses the thread-based versions of the `set` , `reset`, and `flip` functions to implement to variants operating on all bits. Exploit this knowledge to change the state without atomic operations. This significantly improves the performance by a large factor.