### PR TITLE
deque: Improve performance of device_range and fix some bugs

### DIFF
--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -56,15 +56,6 @@
 namespace stdgpu
 {
 
-namespace detail
-{
-
-template <typename T>
-class deque_collect_positions;
-
-} // namespace detail
-
-
 /**
  * \brief A generic container similar to std::deque on the GPU
  * \tparam T The type of the stored elements
@@ -321,9 +312,6 @@ class deque
         device_range() const;
 
     private:
-
-        template <typename T2>
-        friend class detail::deque_collect_positions;
 
         STDGPU_DEVICE_ONLY bool
         occupied(const index_t n) const;

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -205,18 +205,28 @@ class emplace_back_deque_const_type
 
 
 void
-fill_deque(stdgpu::deque<int>& pool)
+fill_deque(stdgpu::deque<int>& pool,
+           const stdgpu::index_t N)
 {
+    ASSERT_GE(N, 0);
+    ASSERT_LE(N, pool.capacity());
+
     const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(static_cast<int>(init)), thrust::counting_iterator<int>(static_cast<int>(pool.capacity() + init)),
+    thrust::for_each(thrust::counting_iterator<int>(static_cast<int>(init)), thrust::counting_iterator<int>(static_cast<int>(N + init)),
                      push_back_deque<int>(pool));
 
-    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
+    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data()) + N);
 
-    ASSERT_EQ(pool.size(), pool.capacity());
-    ASSERT_FALSE(pool.empty());
-    ASSERT_TRUE(pool.full());
+    ASSERT_EQ(pool.size(), N);
     ASSERT_TRUE(pool.valid());
+    ASSERT_TRUE((N == 0) ? pool.empty() : !pool.empty());
+    ASSERT_TRUE((N == pool.capacity()) ? pool.full() : !pool.full());
+}
+
+void
+fill_deque(stdgpu::deque<int>& pool)
+{
+    fill_deque(pool, pool.capacity());
 }
 
 
@@ -1305,9 +1315,60 @@ TEST_F(stdgpu_deque, clear)
 {
     const stdgpu::index_t N = 10000;
 
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N + 1);
+
+    fill_deque(pool, N);
+
+
+    pool.clear();
+
+
+    ASSERT_EQ(pool.size(), 0);
+    ASSERT_TRUE(pool.empty());
+    ASSERT_FALSE(pool.full());
+    ASSERT_TRUE(pool.valid());
+
+    stdgpu::deque<int>::destroyDeviceObject(pool);
+}
+
+
+TEST_F(stdgpu_deque, clear_full)
+{
+    const stdgpu::index_t N = 10000;
+
     stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
 
-    fill_deque(pool);
+    fill_deque(pool, N);
+
+
+    pool.clear();
+
+
+    ASSERT_EQ(pool.size(), 0);
+    ASSERT_TRUE(pool.empty());
+    ASSERT_FALSE(pool.full());
+    ASSERT_TRUE(pool.valid());
+
+    stdgpu::deque<int>::destroyDeviceObject(pool);
+}
+
+
+TEST_F(stdgpu_deque, clear_circular)
+{
+    const stdgpu::index_t N = 10000;
+    const stdgpu::index_t N_offset = N / 4;
+
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N + 1);
+
+    fill_deque(pool, N);
+
+    const stdgpu::index_t init = 1;
+
+    thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(init + N_offset),
+                     pop_front_deque<int>(pool));
+
+    thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(init + N_offset),
+                     push_back_deque<int>(pool));
 
 
     pool.clear();
@@ -2260,12 +2321,67 @@ TEST_F(stdgpu_deque, non_const_device_range)
 {
     const stdgpu::index_t N = 10000;
 
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N + 1);
+
+    fill_deque(pool, N);
+
+    ASSERT_EQ(pool.size(), N);
+    ASSERT_EQ(pool.capacity(), N + 1);
+    ASSERT_TRUE(pool.valid());
+
+    auto range = pool.device_range();
+    int sum = thrust::reduce(range.begin(), range.end(),
+                             0,
+                             thrust::plus<int>());
+
+    EXPECT_EQ(sum, N * (N + 1) / 2);
+
+    stdgpu::deque<int>::destroyDeviceObject(pool);
+}
+
+
+TEST_F(stdgpu_deque, non_const_device_range_full)
+{
+    const stdgpu::index_t N = 10000;
+
     stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
 
-    fill_deque(pool);
+    fill_deque(pool, N);
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_EQ(pool.capacity(), N);
+    ASSERT_TRUE(pool.valid());
+
+    auto range = pool.device_range();
+    int sum = thrust::reduce(range.begin(), range.end(),
+                             0,
+                             thrust::plus<int>());
+
+    EXPECT_EQ(sum, N * (N + 1) / 2);
+
+    stdgpu::deque<int>::destroyDeviceObject(pool);
+}
+
+
+TEST_F(stdgpu_deque, non_const_device_range_circular)
+{
+    const stdgpu::index_t N = 10000;
+    const stdgpu::index_t N_offset = N / 4;
+
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N + 1);
+
+    fill_deque(pool, N);
+
+    const stdgpu::index_t init = 1;
+
+    thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(init + N_offset),
+                     pop_front_deque<int>(pool));
+
+    thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(init + N_offset),
+                     push_back_deque<int>(pool));
+
+    ASSERT_EQ(pool.size(), N);
+    ASSERT_EQ(pool.capacity(), N + 1);
     ASSERT_TRUE(pool.valid());
 
     auto range = pool.device_range();
@@ -2283,12 +2399,67 @@ TEST_F(stdgpu_deque, const_device_range)
 {
     const stdgpu::index_t N = 10000;
 
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N + 1);
+
+    fill_deque(pool, N);
+
+    ASSERT_EQ(pool.size(), N);
+    ASSERT_EQ(pool.capacity(), N + 1);
+    ASSERT_TRUE(pool.valid());
+
+    auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range();
+    int sum = thrust::reduce(range.begin(), range.end(),
+                             0,
+                             thrust::plus<int>());
+
+    EXPECT_EQ(sum, N * (N + 1) / 2);
+
+    stdgpu::deque<int>::destroyDeviceObject(pool);
+}
+
+
+TEST_F(stdgpu_deque, const_device_range_full)
+{
+    const stdgpu::index_t N = 10000;
+
     stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
 
-    fill_deque(pool);
+    fill_deque(pool, N);
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_EQ(pool.capacity(), N);
+    ASSERT_TRUE(pool.valid());
+
+    auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range();
+    int sum = thrust::reduce(range.begin(), range.end(),
+                             0,
+                             thrust::plus<int>());
+
+    EXPECT_EQ(sum, N * (N + 1) / 2);
+
+    stdgpu::deque<int>::destroyDeviceObject(pool);
+}
+
+
+TEST_F(stdgpu_deque, const_device_range_circular)
+{
+    const stdgpu::index_t N = 10000;
+    const stdgpu::index_t N_offset = N / 4;
+
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N + 1);
+
+    fill_deque(pool, N);
+
+    const stdgpu::index_t init = 1;
+
+    thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(init + N_offset),
+                     pop_front_deque<int>(pool));
+
+    thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(init + N_offset),
+                     push_back_deque<int>(pool));
+
+    ASSERT_EQ(pool.size(), N);
+    ASSERT_EQ(pool.capacity(), N + 1);
     ASSERT_TRUE(pool.valid());
 
     auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range();

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -216,7 +216,7 @@ fill_vector(stdgpu::vector<int>& pool,
     thrust::for_each(thrust::counting_iterator<int>(static_cast<int>(init)), thrust::counting_iterator<int>(static_cast<int>(N + init)),
                      push_back_vector<int>(pool));
 
-    thrust::sort(stdgpu::device_begin(pool), stdgpu::device_end(pool));
+    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data()) + N);
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_TRUE(pool.valid());


### PR DESCRIPTION
The `device_range` function of `deque` internally uses `vector` to collect all indices. Improve the performance of this operation by using the `insert` function. This revealed two bugs in `device_range` itself as well as in `clear`. In the former case, some entries may be missed and not included into the range. In the latter case, the destruction of elements for a full container will be accidentally skipped. Fix these two bugs as well and extend the unit tests to cover these cases.