### PR TITLE
unordered_map,unordered_set: Further improve performance of clear

### DIFF
--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -16,7 +16,6 @@
 #ifndef STDGPU_DEQUE_DETAIL_H
 #define STDGPU_DEQUE_DETAIL_H
 
-#include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 
 #include <stdgpu/contract.h>

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <cmath>
 
-#include <thrust/copy.h>
 #include <thrust/distance.h>
 #include <thrust/execution_policy.h>
 #include <thrust/for_each.h>
@@ -1073,10 +1072,8 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::clear()
     _occupied_count.store(0);
 
     _excess_list_positions.clear();
-    thrust::copy(thrust::device,
-                 thrust::counting_iterator<index_t>(bucket_count()), thrust::counting_iterator<index_t>(total_count()),
-                 stdgpu::back_inserter(_excess_list_positions));
-
+    _excess_list_positions.insert(_excess_list_positions.device_end(),
+                                  thrust::counting_iterator<index_t>(bucket_count()), thrust::counting_iterator<index_t>(total_count()));
 }
 
 
@@ -1109,9 +1106,8 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::createDeviceObject(con
 
     result._range_indices           = vector<index_t>::createDeviceObject(total_count);
 
-    thrust::copy(thrust::device,
-                 thrust::counting_iterator<index_t>(bucket_count), thrust::counting_iterator<index_t>(bucket_count + excess_count),
-                 stdgpu::back_inserter(result._excess_list_positions));
+    result._excess_list_positions.insert(result._excess_list_positions.device_end(),
+                                         thrust::counting_iterator<index_t>(bucket_count), thrust::counting_iterator<index_t>(bucket_count + excess_count));
 
     STDGPU_ENSURES(result._excess_list_positions.full());
 


### PR DESCRIPTION
As a follow up on #226, we can now also make use of the more efficient `insert` function of `vector`. Replace the copy call, which effectively just uses `push_back`, with that. This further improves the performance of `clear` as well as `createDeviceObject`.