### PR TITLE
cmake: Fix build with ROCm 4.x

### DIFF
--- a/src/stdgpu/hip/CMakeLists.txt
+++ b/src/stdgpu/hip/CMakeLists.txt
@@ -1,9 +1,10 @@
 
 # NOTE For version checking only
+# HIP 4.x reports to be incompatible to HIP 3.x, so only check for existance
 find_package(hip REQUIRED)
 
 set(STDGPU_DEPENDENCIES_BACKEND_INIT "
-find_dependency(hip 3.5 REQUIRED)
+find_dependency(hip REQUIRED)
 " PARENT_SCOPE)
 
 target_sources(stdgpu PRIVATE impl/memory.cpp)


### PR DESCRIPTION
HIP's CMake support provides a version file to properly check for a minimal requirement. However, it is configured to report incompatibility between major versions. Since ROCm 4.0 has been released for a while, this breaks our compilation if nor ROCm 3.x version is installed in parallel. Remove the explicit version check for now to fix this issue.