### PR TITLE
cmake: Fix compiler flags setup option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ project(stdgpu VERSION 1.3.0
                LANGUAGES CXX)
 
 
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(STDGPU_SETUP_COMPILER_FLAGS_DEFAULT ON)
+else()
+    set(STDGPU_SETUP_COMPILER_FLAGS_DEFAULT OFF)
+endif()
+
 option(STDGPU_BUILD_SHARED_LIBS "Builds the project as a shared library, if set to ON, or as a static library, if set to OFF, default: BUILD_SHARED_LIBS" ${BUILD_SHARED_LIBS})
 option(STDGPU_SETUP_COMPILER_FLAGS "Constructs the compiler flags, default: ON if standalone, OFF if included via add_subdirectory" ${STDGPU_SETUP_COMPILER_FLAGS_DEFAULT})
 option(STDGPU_TREAT_WARNINGS_AS_ERRORS "Treats compiler warnings as errors, default: OFF" OFF)
@@ -50,12 +56,6 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/${STDGPU_BACKEND_DIRECTORY}")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    set(STDGPU_SETUP_COMPILER_FLAGS_DEFAULT ON)
-else()
-    set(STDGPU_SETUP_COMPILER_FLAGS_DEFAULT OFF)
-endif()
 
 if(STDGPU_SETUP_COMPILER_FLAGS)
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/${STDGPU_BACKEND_DIRECTORY}/set_device_flags.cmake")

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -312,7 +312,7 @@ vector<T>::insert(device_ptr<const T> position,
         return;
     }
 
-    index_t new_size = size() + thrust::distance(begin, end);
+    index_t new_size = size() + static_cast<index_t>(thrust::distance(begin, end));
 
     if (new_size > capacity())
     {
@@ -339,7 +339,7 @@ vector<T>::erase(device_ptr<const T> begin,
         return;
     }
 
-    index_t new_size = size() - thrust::distance(begin, end);
+    index_t new_size = size() - static_cast<index_t>(thrust::distance(begin, end));
 
     if (new_size < 0)
     {

--- a/test/stdgpu/bit.cpp
+++ b/test/stdgpu/bit.cpp
@@ -351,7 +351,7 @@ thread_bit_cast_random(const stdgpu::index_t iterations)
         }
         else
         {
-            EXPECT_FLOAT_EQ(number_float, number_float_back);
+            EXPECT_DOUBLE_EQ(number_float, number_float_back);
         }
     }
 }


### PR DESCRIPTION
In #224, all options have been moved to a uniform place. However, this broke the default value of the `STDGPU_SETUP_COMPILER_FLAGS` option whose default value is determined dynamically. Fix its initialization and as well as all warnings introduced in the meantime.