### PR TITLE
General: Improve support for CUDA Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,12 @@ if(STDGPU_SETUP_COMPILER_FLAGS)
             string(APPEND CMAKE_CUDA_FLAGS "${STDGPU_DEVICE_COMPILE_AND_LINK_FLAGS}")
             message(STATUS "Building with modified CMAKE_CUDA_FLAGS : ${CMAKE_CUDA_FLAGS}")
         endif()
+
+        # Workaround for bug in libstdc++ (see https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4442#note_737136)
+        if(CMAKE_CUDA_COMPILER_ID STREQUAL "Clang")
+            message(STATUS "Building with disabled CXX extensions")
+            set(CMAKE_CXX_EXTENSIONS OFF)
+        endif()
     endif()
 
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/set_host_flags.cmake")

--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ Before building the library, please make sure that all required tools and depend
 - CUDA compiler
     - NVCC
         - Already included in CUDA Toolkit
-    - Clang 11
-        - (Ubuntu 18.04/20.04) https://apt.llvm.org/
+    - Clang 10
+        - (Ubuntu 18.04/20.04) `sudo apt install clang-10` or https://apt.llvm.org/
         - Requires at least CMake 3.18
 - CUDA Toolkit 10.0
     - (Ubuntu/Windows) https://developer.nvidia.com/cuda-downloads

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -128,13 +128,14 @@ Before building the library, please make sure that all required tools and depend
 
 - C++14 compiler
     - GCC 7
-        - (Ubuntu 18.04) `sudo apt install g++ make`
+        - (Ubuntu 18.04/20.04) `sudo apt install g++ make`
     - Clang 6
-        - (Ubuntu 18.04) `sudo apt install clang make`
+        - (Ubuntu 18.04/20.04) `sudo apt install clang make`
     - MSVC 19.20
         - (Windows) Visual Studio 2019 https://visualstudio.microsoft.com/downloads/
 - CMake 3.15
     - (Ubuntu 18.04) https://apt.kitware.com
+    - (Ubuntu 20.04) `sudo apt install cmake`
     - (Windows) https://cmake.org/download
 - thrust 1.9.2
     - (Ubuntu/Windows) https://github.com/thrust/thrust
@@ -145,8 +146,8 @@ Before building the library, please make sure that all required tools and depend
 - CUDA compiler
     - NVCC
         - Already included in CUDA Toolkit
-    - Clang 11
-        - (Ubuntu 18.04) https://apt.llvm.org/
+    - Clang 10
+        - (Ubuntu 18.04/20.04) `sudo apt install clang-10` or https://apt.llvm.org/
         - Requires at least CMake 3.18
 - CUDA Toolkit 10.0
     - (Ubuntu/Windows) https://developer.nvidia.com/cuda-downloads
@@ -156,9 +157,9 @@ Before building the library, please make sure that all required tools and depend
 
 - OpenMP 2.0
     - GCC 7
-        - (Ubuntu 18.04) Already installed
+        - (Ubuntu 18.04/20.04) Already installed
     - Clang 6
-        - (Ubuntu 18.04) `sudo apt install libomp-dev`
+        - (Ubuntu 18.04/20.04) `sudo apt install libomp-dev`
     - MSVC 19.20
         - (Windows) Already installed
 


### PR DESCRIPTION
Clang as the CUDA compiler has been supported for a while. In the meantime, not only Clang 11 has been backported to Ubuntu 20.04, but unfortunately some regressions in libstdc++ 10 slipped in as well. Improve the CUDA Clang support by disabling C++ extensions which workarounds compilation errors. With this workaround enabled, Clang 10 can also be supported.