### PR TITLE
README,doc: Update link to thrust repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Before building the library, please make sure that all required tools and depend
     - (Ubuntu 20.04) `sudo apt install cmake`
     - (Windows) https://cmake.org/download
 - thrust 1.9.2
-    - (Ubuntu/Windows) https://github.com/thrust/thrust
+    - (Ubuntu/Windows) https://github.com/NVIDIA/thrust
     - May already be installed by backend dependencies
 
 <b>Required for CUDA backend</b>

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -138,7 +138,7 @@ Before building the library, please make sure that all required tools and depend
     - (Ubuntu 20.04) `sudo apt install cmake`
     - (Windows) https://cmake.org/download
 - thrust 1.9.2
-    - (Ubuntu/Windows) https://github.com/thrust/thrust
+    - (Ubuntu/Windows) https://github.com/NVIDIA/thrust
     - May already be installed by backend dependencies
 
 <b>Required for CUDA backend</b>


### PR DESCRIPTION
The thrust repository has been moved so the original link changed as well. Although there is automatic redirection in place, update the link to point to the new location.