### PR TITLE
cmake: Update support for CMake 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.18)
+cmake_minimum_required(VERSION 3.15...3.20)
 
 
 project(stdgpu VERSION 1.3.0


### PR DESCRIPTION
CMake 3.19 and 3.20 are out for quite some time. After reviewing the newly introduced policies, bump the maximum supported policy version to the currently most recent CMake version.