### PR TITLE
cmake: Improve detection of CUDA architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,10 @@ string(TOUPPER ${STDGPU_BACKEND_MACRO_NAMESPACE} STDGPU_BACKEND_MACRO_NAMESPACE)
 
 # Enable backend-specific languages
 if(STDGPU_BACKEND STREQUAL STDGPU_BACKEND_CUDA)
+    if(DEFINED CMAKE_CUDA_ARCHITECTURES)
+        set(STDGPU_CUDA_ARCHITECTURE_FLAGS_USER ${CMAKE_CUDA_ARCHITECTURES})
+    endif()
+
     enable_language(CUDA)
 endif()
 
@@ -65,13 +69,21 @@ if(STDGPU_SETUP_COMPILER_FLAGS)
     message(STATUS "Created test device flags : ${STDGPU_TEST_DEVICE_FLAGS}")
 
     if(STDGPU_BACKEND STREQUAL STDGPU_BACKEND_CUDA)
-        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
-            stdgpu_cuda_set_architecture_flags(STDGPU_CUDA_ARCHITECTURES)
-            set(CMAKE_CUDA_ARCHITECTURES ${STDGPU_CUDA_ARCHITECTURES})
+        if(STDGPU_CUDA_ARCHITECTURE_FLAGS_USER AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+            # CMAKE_CUDA_ARCHITECTURES already set by the user
+            message(STATUS "Detected user-provided CCs : ${STDGPU_CUDA_ARCHITECTURE_FLAGS_USER}")
         else()
-            stdgpu_cuda_set_architecture_flags(STDGPU_DEVICE_COMPILE_AND_LINK_FLAGS)
-            string(APPEND CMAKE_CUDA_FLAGS "${STDGPU_DEVICE_COMPILE_AND_LINK_FLAGS}")
-            message(STATUS "Building with modified CMAKE_CUDA_FLAGS : ${CMAKE_CUDA_FLAGS}")
+            stdgpu_cuda_set_architecture_flags(STDGPU_CUDA_ARCHITECTURE_FLAGS)
+            if(STDGPU_CUDA_ARCHITECTURE_FLAGS)
+                if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+                    set(CMAKE_CUDA_ARCHITECTURES ${STDGPU_CUDA_ARCHITECTURE_FLAGS})
+                else()
+                    string(APPEND CMAKE_CUDA_FLAGS "${STDGPU_CUDA_ARCHITECTURE_FLAGS}")
+                    message(STATUS "Building with modified CMAKE_CUDA_FLAGS : ${CMAKE_CUDA_FLAGS}")
+                endif()
+            else()
+                message(WARNING "Falling back to default CCs : ${CMAKE_CUDA_ARCHITECTURES}")
+            endif()
         endif()
 
         # Workaround for bug in libstdc++ (see https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4442#note_737136)

--- a/cmake/cuda/set_device_flags.cmake
+++ b/cmake/cuda/set_device_flags.cmake
@@ -59,31 +59,26 @@ endfunction()
 
 
 function(stdgpu_cuda_set_architecture_flags STDGPU_OUTPUT_ARCHITECTURE_FLAGS)
+    # Clear list before appending flags
+    unset(${STDGPU_OUTPUT_ARCHITECTURE_FLAGS})
+
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
         include("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/check_compute_capability.cmake")
     else()
         include("${stdgpu_SOURCE_DIR}/cmake/${STDGPU_BACKEND_DIRECTORY}/check_compute_capability.cmake")
     endif()
 
-    set(STDGPU_CUDA_HAVE_SUITABLE_GPU FALSE)
-
     foreach(STDGPU_CUDA_CC IN LISTS STDGPU_CUDA_COMPUTE_CAPABILITIES)
         if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
             list(APPEND ${STDGPU_OUTPUT_ARCHITECTURE_FLAGS} ${STDGPU_CUDA_CC})
             message(STATUS "Enabled compilation for CC ${STDGPU_CUDA_CC}")
-            set(STDGPU_CUDA_HAVE_SUITABLE_GPU TRUE)
         else()
             if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
                 string(APPEND ${STDGPU_OUTPUT_ARCHITECTURE_FLAGS} " --generate-code arch=compute_${STDGPU_CUDA_CC},code=sm_${STDGPU_CUDA_CC}")
                 message(STATUS "Enabled compilation for CC ${STDGPU_CUDA_CC}")
-                set(STDGPU_CUDA_HAVE_SUITABLE_GPU TRUE)
             endif()
         endif()
     endforeach()
-
-    if(NOT STDGPU_CUDA_HAVE_SUITABLE_GPU)
-        message(FATAL_ERROR "No CUDA-capable GPU detected")
-    endif()
 
     # Make output variable visible
     set(${STDGPU_OUTPUT_ARCHITECTURE_FLAGS} ${${STDGPU_OUTPUT_ARCHITECTURE_FLAGS}} PARENT_SCOPE)


### PR DESCRIPTION
The CUDA CC detection helps to automatically select a suitable architecture for the current machine. Although this provides an optimal value if the detection succeeds, failures result in errors during generation. This prevents several use cases such as build testing the library and any dependents e.g. using CI. Improve the architecture detection by explicitly respecting any user-specified values and falling back to CMake's default architectures if no GPU can be detected.