### PR TITLE
atomic: Fix compilation for CC 3.2

### DIFF
--- a/src/stdgpu/cuda/impl/atomic_detail.cuh
+++ b/src/stdgpu/cuda/impl/atomic_detail.cuh
@@ -79,7 +79,9 @@ atomicMax(float* address,
 
 
 #if defined(__CUDA_ARCH__)
-    #if __CUDA_ARCH__ < 350
+    // According to the CUDA documentation, atomic operations for unsigned long long int
+    // are not supported for CC <3.5. However, CC 3.2 does support them.
+    #if __CUDA_ARCH__ < 320
         inline STDGPU_DEVICE_ONLY unsigned long long int
         atomicMin(unsigned long long int* address,
                   const unsigned long long int value)


### PR DESCRIPTION
Support for the CUDA Compute Capability 3.0 has been added in #153. However, the intermediate CC 3.2 has not been considered. Although the CUDA documentation states that it also lacks official support, compilation fails because it actually is officially defined. Fix this issue by only defining our fallback for CC 3.0.