### PR TITLE
General: Optimize performance of destroy calls

### DIFF
--- a/src/stdgpu/impl/type_traits.h
+++ b/src/stdgpu/impl/type_traits.h
@@ -63,6 +63,8 @@ STDGPU_DETAIL_DEFINE_TRAIT(is_iterator, typename T::difference_type, typename T:
 
 STDGPU_DETAIL_DEFINE_TRAIT(is_transparent, typename T::is_transparent)
 
+STDGPU_DETAIL_DEFINE_TRAIT(is_base, typename T::is_base)
+
 } // namespace detail
 
 } // namespace stdgpu

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -409,6 +409,15 @@ struct safe_managed_allocator
 };
 
 
+namespace detail
+{
+
+template <typename T>
+struct allocator_traits_base;
+
+} // namespace detail
+
+
 /**
  * \ingroup memory
  * \brief A general allocator traitor
@@ -418,7 +427,7 @@ struct safe_managed_allocator
  *  - index_type instead of size_type
  */
 template <typename Allocator>
-struct allocator_traits
+struct allocator_traits : public detail::allocator_traits_base<Allocator>
 {
     using allocator_type                            = Allocator;                                                                /**< Allocator */
     using value_type                                = typename Allocator::value_type;                                           /**< Allocator::value_type */

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -243,6 +243,12 @@ class nondefault_int_deque
         }
 
         STDGPU_HOST_DEVICE
+        ~nondefault_int_deque() // NOLINT(hicpp-use-equals-default,modernize-use-equals-default)
+        {
+            // nontrivial destructor
+        }
+
+        STDGPU_HOST_DEVICE
         operator int() const // NOLINT(hicpp-explicit-conversions)
         {
             return _x;
@@ -1387,17 +1393,67 @@ TEST_F(stdgpu_deque, clear_nondefault_type)
 {
     const stdgpu::index_t N = 10000;
 
+    stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N + 1);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     push_back_deque<nondefault_int_deque>(pool));
+
+
+    pool.clear();
+
+
+    ASSERT_EQ(pool.size(), 0);
+    ASSERT_TRUE(pool.empty());
+    ASSERT_FALSE(pool.full());
+    ASSERT_TRUE(pool.valid());
+
+    stdgpu::deque<nondefault_int_deque>::destroyDeviceObject(pool);
+}
+
+
+TEST_F(stdgpu_deque, clear_nondefault_type_full)
+{
+    const stdgpu::index_t N = 10000;
+
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
     thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
                      push_back_deque<nondefault_int_deque>(pool));
 
-    ASSERT_EQ(pool.size(), N);
-    ASSERT_FALSE(pool.empty());
-    ASSERT_TRUE(pool.full());
-    ASSERT_TRUE(pool.valid());
 
     pool.clear();
+
+
+    ASSERT_EQ(pool.size(), 0);
+    ASSERT_TRUE(pool.empty());
+    ASSERT_FALSE(pool.full());
+    ASSERT_TRUE(pool.valid());
+
+    stdgpu::deque<nondefault_int_deque>::destroyDeviceObject(pool);
+}
+
+
+TEST_F(stdgpu_deque, clear_nondefault_type_circular)
+{
+    const stdgpu::index_t N = 10000;
+    const stdgpu::index_t N_offset = N / 4;
+
+    stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N + 1);
+
+    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N),
+                     push_back_deque<nondefault_int_deque>(pool));
+
+    const stdgpu::index_t init = 1;
+
+    thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(init + N_offset),
+                     pop_front_deque<nondefault_int_deque>(pool));
+
+    thrust::for_each(thrust::counting_iterator<int>(init), thrust::counting_iterator<int>(init + N_offset),
+                     push_back_deque<nondefault_int_deque>(pool));
+
+
+    pool.clear();
+
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -1374,13 +1374,19 @@ namespace
                 : _constructor_calls(constructor_calls),
                   _destructor_calls(destructor_calls)
             {
-                *_constructor_calls += 1;
+                if (_constructor_calls != nullptr)
+                {
+                    *_constructor_calls += 1;
+                }
             }
 
             STDGPU_HOST_DEVICE
             ~Counter()
             {
-                *_destructor_calls += 1;
+                if (_destructor_calls != nullptr)
+                {
+                    *_destructor_calls += 1;
+                }
             }
 
         private:
@@ -1431,6 +1437,16 @@ namespace
         private:
             Allocator a;
     };
+}
+
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, create_destroy_nontrivial)
+{
+    const stdgpu::index64_t size = 42;
+
+    Counter* array = createDeviceArray<Counter>(size, Counter(nullptr, nullptr));
+
+    destroyDeviceArray<Counter>(array);
 }
 
 

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -49,6 +49,7 @@
 
 // convenience wrapper to improve readability
 using test_unordered_datastructure = STDGPU_UNORDERED_DATASTRUCTURE_TYPE;
+using test_nontrivial_unordered_datastructure = STDGPU_UNORDERED_DATASTRUCTURE_NONTRIVIAL_TYPE;
 
 
 
@@ -278,11 +279,12 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, hash_objects)
 
 namespace
 {
+    template <typename HashDataStructure>
     class insert_single
     {
         public:
-            insert_single(const test_unordered_datastructure& hash_datastructure,
-                          const test_unordered_datastructure::key_type& key,
+            insert_single(const HashDataStructure& hash_datastructure,
+                          const typename HashDataStructure::key_type& key,
                           stdgpu::index_t* inserted)
                 : _hash_datastructure(hash_datastructure),
                   _key(key),
@@ -294,26 +296,27 @@ namespace
             STDGPU_DEVICE_ONLY void
             operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
             {
-                thrust::pair<test_unordered_datastructure::iterator, bool> success = _hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(_key));
+                thrust::pair<typename HashDataStructure::iterator, bool> success = _hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(_key));
 
                 *_inserted = success.second ? 1 : 0;
             }
 
         private:
-            test_unordered_datastructure _hash_datastructure;
-            test_unordered_datastructure::key_type _key;
+            HashDataStructure _hash_datastructure;
+            typename HashDataStructure::key_type _key;
             stdgpu::index_t* _inserted;
     };
 
 
+    template <typename HashDataStructure>
     bool
-    insert_key(test_unordered_datastructure& hash_datastructure,
-               const test_unordered_datastructure::key_type& key)
+    insert_key(HashDataStructure& hash_datastructure,
+               const typename HashDataStructure::key_type& key)
     {
         stdgpu::index_t* inserted = createDeviceArray<stdgpu::index_t>(1);
 
         thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(1),
-                         insert_single(hash_datastructure, key, inserted));
+                         insert_single<HashDataStructure>(hash_datastructure, key, inserted));
 
         stdgpu::index_t host_inserted;
         copyDevice2HostArray<stdgpu::index_t>(inserted, 1, &host_inserted, MemoryCopy::NO_CHECK);
@@ -2476,6 +2479,28 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, clear_empty)
 
     EXPECT_EQ(hash_datastructure.size(), 0);
     EXPECT_TRUE(hash_datastructure.valid());
+}
+
+
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, clear_nontrivial)
+{
+    test_nontrivial_unordered_datastructure nontrivial_hash_datastructure = test_nontrivial_unordered_datastructure::createDeviceObject(hash_datastructure_size);
+
+    const test_nontrivial_unordered_datastructure::key_type position(-7, -3, 15);
+    bool inserted = insert_key(nontrivial_hash_datastructure, position);
+    EXPECT_TRUE(inserted);
+    EXPECT_EQ(nontrivial_hash_datastructure.size(), 1);
+    EXPECT_TRUE(nontrivial_hash_datastructure.valid());
+
+
+    nontrivial_hash_datastructure.clear();
+
+
+    EXPECT_EQ(nontrivial_hash_datastructure.size(), 0);
+    EXPECT_TRUE(nontrivial_hash_datastructure.valid());
+
+
+    test_nontrivial_unordered_datastructure::destroyDeviceObject(nontrivial_hash_datastructure);
 }
 
 

--- a/test/stdgpu/unordered_map.inc
+++ b/test/stdgpu/unordered_map.inc
@@ -145,10 +145,25 @@ struct vec3int32
 
     }
 
+    STDGPU_HOST_DEVICE
+    ~vec3int32() // NOLINT(hicpp-use-equals-default,modernize-use-equals-default)
+    {
+        // nontrivial destructor
+    }
+
     std::int32_t x = 0; // NOLINT(misc-non-private-member-variables-in-classes)
     std::int32_t y = 0; // NOLINT(misc-non-private-member-variables-in-classes)
     std::int32_t z = 0; // NOLINT(misc-non-private-member-variables-in-classes)
 };
+
+inline STDGPU_HOST_DEVICE bool
+operator==(const vec3int32& lhs,
+           const vec3int32& rhs)
+{
+    return lhs.x == rhs.x
+        && lhs.y == rhs.y
+        && lhs.z == rhs.z;
+}
 
 inline STDGPU_HOST_DEVICE bool
 operator==(const vec3int16& lhs,
@@ -204,6 +219,13 @@ key_to_value(const vec3int16& key)
 }
 
 
+inline STDGPU_HOST_DEVICE stdgpu::unordered_map<vec3int32, dummy, vec_hash>::value_type
+key_to_value(const vec3int32& key)
+{
+    return stdgpu::unordered_map<vec3int32, dummy, vec_hash>::value_type(key, dummy());
+}
+
+
 inline STDGPU_HOST_DEVICE vec3int16
 value_to_key(const stdgpu::unordered_map<vec3int16, dummy, vec_hash>::value_type& value)
 {
@@ -224,6 +246,7 @@ key_to_keylike(const vec3int16& key)
 #define STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY value_to_key
 #define STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE vec3int32
 #define STDGPU_UNORDERED_DATASTRUCTURE_KEY2KEYLIKE key_to_keylike
+#define STDGPU_UNORDERED_DATASTRUCTURE_NONTRIVIAL_TYPE stdgpu::unordered_map<vec3int32, dummy, vec_hash, stdgpu::equal_to<>>
 
 
 #include "unordered_datastructure.inc"

--- a/test/stdgpu/unordered_set.inc
+++ b/test/stdgpu/unordered_set.inc
@@ -141,10 +141,25 @@ struct vec3int32
 
     }
 
+    STDGPU_HOST_DEVICE
+    ~vec3int32() // NOLINT(hicpp-use-equals-default,modernize-use-equals-default)
+    {
+        // nontrivial destructor
+    }
+
     std::int32_t x = 0; // NOLINT(misc-non-private-member-variables-in-classes)
     std::int32_t y = 0; // NOLINT(misc-non-private-member-variables-in-classes)
     std::int32_t z = 0; // NOLINT(misc-non-private-member-variables-in-classes)
 };
+
+inline STDGPU_HOST_DEVICE bool
+operator==(const vec3int32& lhs,
+           const vec3int32& rhs)
+{
+    return lhs.x == rhs.x
+        && lhs.y == rhs.y
+        && lhs.z == rhs.z;
+}
 
 inline STDGPU_HOST_DEVICE bool
 operator==(const vec3int16& lhs,
@@ -200,6 +215,13 @@ key_to_value(const vec3int16& key)
 }
 
 
+inline STDGPU_HOST_DEVICE vec3int32
+key_to_value(const vec3int32& key)
+{
+    return key;
+}
+
+
 inline STDGPU_HOST_DEVICE vec3int16
 value_to_key(const vec3int16& key)
 {
@@ -220,6 +242,7 @@ key_to_keylike(const vec3int16& key)
 #define STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY value_to_key
 #define STDGPU_UNORDERED_DATASTRUCTURE_TRANSPARENT_KEYTYPE vec3int32
 #define STDGPU_UNORDERED_DATASTRUCTURE_KEY2KEYLIKE key_to_keylike
+#define STDGPU_UNORDERED_DATASTRUCTURE_NONTRIVIAL_TYPE stdgpu::unordered_set<vec3int32, vec_hash, stdgpu::equal_to<>>
 
 
 #include "unordered_datastructure.inc"

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -244,6 +244,12 @@ class nondefault_int_vector
         }
 
         STDGPU_HOST_DEVICE
+        ~nondefault_int_vector() // NOLINT(hicpp-use-equals-default,modernize-use-equals-default)
+        {
+            // nontrivial destructor
+        }
+
+        STDGPU_HOST_DEVICE
         operator int() const // NOLINT(hicpp-explicit-conversions)
         {
             return _x;


### PR DESCRIPTION
In compliance with the C++ standard, our containers as well as the memory API perform destruction operations on deletion. However for trivially destructible types, this results in a no-op for each element, but the underlying loop cannot always be automatically optimized away. Improve the performance by detecting this case and skipping the whole operation.