### PR TITLE
unordered_map,unordered_set: Further improve performance of clear

### DIFF
--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -1064,7 +1064,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::clear()
     {
         thrust::for_each(thrust::device,
                          thrust::counting_iterator<index_t>(0), thrust::counting_iterator<index_t>(total_count()),
-                          destroy_values<Key, Value, KeyFromValue, Hash, KeyEqual>(*this));
+                         destroy_values<Key, Value, KeyFromValue, Hash, KeyEqual>(*this));
     }
 
     thrust::fill(device_begin(_offsets), device_end(_offsets),
@@ -1074,9 +1074,8 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::clear()
 
     _occupied_count.store(0);
 
-    _excess_list_positions.clear();
-    _excess_list_positions.insert(_excess_list_positions.device_end(),
-                                  thrust::counting_iterator<index_t>(bucket_count()), thrust::counting_iterator<index_t>(total_count()));
+    auto reset_excess_list_positions = detail::vector_clear_fill<index_t>(_excess_list_positions);
+    reset_excess_list_positions(thrust::counting_iterator<index_t>(bucket_count()), thrust::counting_iterator<index_t>(total_count()));
 }
 
 

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -59,11 +59,14 @@ namespace stdgpu
 namespace detail
 {
 
-template <typename T>
+template <typename T, bool>
 class vector_insert;
 
-template <typename T>
+template <typename T, bool>
 class vector_erase;
+
+template <typename T>
+class vector_clear_fill;
 
 } // namespace detail
 
@@ -368,11 +371,14 @@ class vector
 
     private:
 
-        template <typename T2>
+        template <typename T2, bool>
         friend class detail::vector_insert;
 
-        template <typename T2>
+        template <typename T2, bool>
         friend class detail::vector_erase;
+
+        template <typename T2>
+        friend class detail::vector_clear_fill;
 
         STDGPU_DEVICE_ONLY bool
         occupied(const index_t n) const;


### PR DESCRIPTION
The general performance of all `clear()` container functions have been improved in #239. However, the respective version in `unordered_map` and `unordered_set` involves resetting the internal excess list which is done in two steps. Further improve the performance by defining an internal single-step reset function in `vector` and use it in the `clear()` function.