### PR TITLE
scripts: Upgrade to thrust 1.13

### DIFF
--- a/scripts/utils/download_thrust.sh
+++ b/scripts/utils/download_thrust.sh
@@ -4,4 +4,4 @@ set -e
 cmake -E cmake_echo_color --blue ">>>>> Download thrust"
 cmake -E chdir external git clone https://github.com/NVIDIA/thrust
 cmake -E chdir external/thrust git fetch --all --tags --prune
-cmake -E chdir external/thrust git checkout tags/1.11.0
+cmake -E chdir external/thrust git checkout tags/1.13.0


### PR DESCRIPTION
thrust 1.13 has been recently released. In order to check compatibility with their recent developments, upgrade out scripts to use this version over the older 1.11 release.