### PR TITLE
src: Fix typo in allocator member names

### DIFF
--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -330,7 +330,7 @@ class deque
         atomic<unsigned int> _begin = {};
         atomic<unsigned int> _end = {};
         index_t _capacity = 0;
-        allocator_type _alloctor = {};
+        allocator_type _allocator = {};
 
         mutable vector<index_t> _range_indices = {};
 };

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -35,7 +35,7 @@ deque<T>::createDeviceObject(const index_t& capacity)
     STDGPU_EXPECTS(capacity > 0);
 
     deque<T> result;
-    result._data     = allocator_traits<allocator_type>::allocate(result._alloctor, capacity);
+    result._data     = allocator_traits<allocator_type>::allocate(result._allocator, capacity);
     result._locks    = mutex_array::createDeviceObject(capacity);
     result._occupied = bitset::createDeviceObject(capacity);
     result._size     = atomic<int>::createDeviceObject();
@@ -57,7 +57,7 @@ deque<T>::destroyDeviceObject(deque<T>& device_object)
         device_object.clear();
     }
 
-    allocator_traits<allocator_type>::deallocate(device_object._alloctor, device_object._data, device_object._capacity);
+    allocator_traits<allocator_type>::deallocate(device_object._allocator, device_object._data, device_object._capacity);
     mutex_array::destroyDeviceObject(device_object._locks);
     bitset::destroyDeviceObject(device_object._occupied);
     atomic<int>::destroyDeviceObject(device_object._size);
@@ -73,7 +73,7 @@ template <typename T>
 inline STDGPU_HOST_DEVICE typename deque<T>::allocator_type
 deque<T>::get_allocator() const
 {
-    return _alloctor;
+    return _allocator;
 }
 
 
@@ -183,7 +183,7 @@ deque<T>::push_back(const T& element)
 
                 if (!occupied(push_position))
                 {
-                    allocator_traits<allocator_type>::construct(_alloctor, &(_data[push_position]), element);
+                    allocator_traits<allocator_type>::construct(_allocator, &(_data[push_position]), element);
                     bool was_occupied = _occupied.set(push_position);
                     pushed = true;
 
@@ -238,8 +238,8 @@ deque<T>::pop_back()
                 if (occupied(pop_position))
                 {
                     bool was_occupied = _occupied.reset(pop_position);
-                    allocator_traits<allocator_type>::construct(_alloctor, &popped, _data[pop_position], true);
-                    allocator_traits<allocator_type>::destroy(_alloctor, &(_data[pop_position]));
+                    allocator_traits<allocator_type>::construct(_allocator, &popped, _data[pop_position], true);
+                    allocator_traits<allocator_type>::destroy(_allocator, &(_data[pop_position]));
 
                     if (!was_occupied)
                     {
@@ -299,7 +299,7 @@ deque<T>::push_front(const T& element)
 
                 if (!occupied(push_position))
                 {
-                    allocator_traits<allocator_type>::construct(_alloctor, &(_data[push_position]), element);
+                    allocator_traits<allocator_type>::construct(_allocator, &(_data[push_position]), element);
                     bool was_occupied = _occupied.set(push_position);
                     pushed = true;
 
@@ -353,8 +353,8 @@ deque<T>::pop_front()
                 if (occupied(pop_position))
                 {
                     bool was_occupied = _occupied.reset(pop_position);
-                    allocator_traits<allocator_type>::construct(_alloctor, &popped, _data[pop_position], true);
-                    allocator_traits<allocator_type>::destroy(_alloctor, &(_data[pop_position]));
+                    allocator_traits<allocator_type>::construct(_allocator, &popped, _data[pop_position], true);
+                    allocator_traits<allocator_type>::destroy(_allocator, &(_data[pop_position]));
 
                     if (!was_occupied)
                     {

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -416,7 +416,7 @@ class unordered_base
         key_from_value _key_from_value = {};            /**< The value to key functor */                    // NOLINT(misc-non-private-member-variables-in-classes)
         key_equal _key_equal = {};                      /**< The key comparison functor */                  // NOLINT(misc-non-private-member-variables-in-classes)
         hasher _hash = {};                              /**< The hashing function */                        // NOLINT(misc-non-private-member-variables-in-classes)
-        allocator_type _alloctor = {};                  /**< The allocator */                               // NOLINT(misc-non-private-member-variables-in-classes)
+        allocator_type _allocator = {};                 /**< The allocator */                               // NOLINT(misc-non-private-member-variables-in-classes)
 
         mutable vector<index_t> _range_indices = {};    /**< The buffer of range indices */                 // NOLINT(misc-non-private-member-variables-in-classes)
 

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -98,7 +98,7 @@ template <typename Key, typename Value, typename KeyFromValue, typename Hash, ty
 inline STDGPU_HOST_DEVICE typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::allocator_type
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::get_allocator() const
 {
-    return _alloctor;
+    return _allocator;
 }
 
 
@@ -437,7 +437,7 @@ class destroy_values
         {
             if (_base.occupied(n))
             {
-                allocator_traits<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::allocator_type>::destroy(_base._alloctor, &(_base._values[n]));
+                allocator_traits<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::allocator_type>::destroy(_base._allocator, &(_base._values[n]));
             }
         }
 
@@ -640,7 +640,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_insert(const unord
                 // !!! VERIFY CONDITIONS HAVE NOT CHANGED !!!
                 if (!contains(block) && !occupied(bucket_index))
                 {
-                    allocator_traits<allocator_type>::construct(_alloctor, &(_values[bucket_index]), value);
+                    allocator_traits<allocator_type>::construct(_allocator, &(_values[bucket_index]), value);
                     // Do not touch the linked list
                     //_offsets[bucket_index] = 0;
 
@@ -684,7 +684,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_insert(const unord
                     {
                         index_t new_linked_list_end = popped.first;
 
-                        allocator_traits<allocator_type>::construct(_alloctor, &(_values[new_linked_list_end]), value);
+                        allocator_traits<allocator_type>::construct(_allocator, &(_values[new_linked_list_end]), value);
                         _offsets[new_linked_list_end] = 0;
 
                         // Set occupied status after entry has been fully constructed
@@ -748,7 +748,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_erase(const unorde
                     --_occupied_count;
 
                     // Default values
-                    allocator_traits<allocator_type>::destroy(_alloctor, &(_values[position]));
+                    allocator_traits<allocator_type>::destroy(_allocator, &(_values[position]));
                     // Do not touch the linked list
                     //_offsets[position] = 0;
 
@@ -794,7 +794,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::try_erase(const unorde
                     --_occupied_count;
 
                     // Default values
-                    allocator_traits<allocator_type>::destroy(_alloctor, &(_values[position]));
+                    allocator_traits<allocator_type>::destroy(_allocator, &(_values[position]));
                     // Do not reset the offset of the erased linked list entry as another thread executing find() might still need it, so make try_insert responsible for resetting it
                     //_offsets[position] = 0;
                     _excess_list_positions.push_back(position);
@@ -1104,7 +1104,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::createDeviceObject(con
     unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual> result;
     result._bucket_count            = bucket_count;
     result._excess_count            = excess_count;
-    result._values                  = allocator_traits<allocator_type>::allocate(result._alloctor, total_count);
+    result._values                  = allocator_traits<allocator_type>::allocate(result._allocator, total_count);
     result._offsets                 = createDeviceArray<index_t>(total_count, 0);
     result._occupied                = bitset::createDeviceObject(total_count);
     result._occupied_count          = atomic<int>::createDeviceObject();
@@ -1135,7 +1135,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::destroyDeviceObject(un
     }
 
     index_t total_count = device_object._bucket_count + device_object._excess_count;
-    allocator_traits<allocator_type>::deallocate(device_object._alloctor, device_object._values, total_count);
+    allocator_traits<allocator_type>::deallocate(device_object._allocator, device_object._values, total_count);
 
     device_object._bucket_count = 0;
     device_object._excess_count = 0;

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -394,7 +394,7 @@ class vector
         bitset _occupied = {};
         atomic<int> _size = {};
         index_t _capacity = 0;
-        allocator_type _alloctor = {};
+        allocator_type _allocator = {};
 };
 
 } // namespace stdgpu


### PR DESCRIPTION
When introducing the allocator member variable for all containers in #191, a typo in their name was introduced. Fix this by renaming the variables to from `_alloctor` to `_allocator`.