### PR TITLE
cmake: Explicitly enforce CUDA standard

### DIFF
--- a/src/stdgpu/cuda/CMakeLists.txt
+++ b/src/stdgpu/cuda/CMakeLists.txt
@@ -7,6 +7,10 @@ find_dependency(CUDAToolkit 10.0 REQUIRED MODULE)
 
 target_sources(stdgpu PRIVATE impl/memory.cpp)
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+    target_compile_features(stdgpu PUBLIC cuda_std_14)
+endif()
+
 target_compile_definitions(stdgpu PUBLIC THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA)
 
 target_link_libraries(stdgpu PUBLIC CUDA::cudart)


### PR DESCRIPTION
CMake automatically infers the CUDA standard based on the specified value for the C++ standard. Although this provides a convenient default for most projects, it is better to explicitly specify it. This will ensure that a potential future behavioral change, e.g. via a policy, is already covered.