### PR TITLE
memory: Add register memory API

### DIFF
--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -35,20 +35,20 @@ namespace detail
 {
 
 /**
- * \brief A class to manage allocated memory for size and leak detection
+ * \brief A class to manage memory for size and leak detection
  */
-class allocation_manager
+class memory_manager
 {
     public:
         /**
          * \brief Constructor
          */
-        allocation_manager() = default;
+        memory_manager() = default;
 
         /**
          * \brief Destructor
          */
-        ~allocation_manager() = default;
+        ~memory_manager() = default;
 
         /**
          * \brief Registers the allocated memory block
@@ -136,27 +136,133 @@ class allocation_manager
         index64_t _number_erasures = 0;
 };
 
+void
+memory_manager::register_memory(void* pointer,
+                                index64_t size)
+{
+    std::lock_guard<std::recursive_mutex> lock(_mutex);
 
-allocation_manager&
+    STDGPU_EXPECTS(!contains_memory(pointer));
+    STDGPU_EXPECTS(valid());
+
+    _pointers[pointer] = size;
+    _number_insertions++;
+
+    STDGPU_ENSURES(contains_memory(pointer));
+    STDGPU_ENSURES(valid());
+}
+
+void
+memory_manager::deregister_memory(void* pointer,
+                                  STDGPU_MAYBE_UNUSED index64_t size)
+{
+    std::lock_guard<std::recursive_mutex> lock(_mutex);
+
+    STDGPU_EXPECTS(contains_memory(pointer));
+    STDGPU_EXPECTS(valid());
+
+    _pointers.erase(pointer);
+    _number_erasures++;
+
+    STDGPU_ENSURES(!contains_memory(pointer));
+    STDGPU_ENSURES(valid());
+}
+
+bool
+memory_manager::contains_memory(void* pointer) const
+{
+    std::lock_guard<std::recursive_mutex> lock(_mutex);
+
+    return _pointers.find(pointer) != std::cend(_pointers);
+}
+
+bool
+memory_manager::contains_submemory(void* pointer,
+                                   const index64_t size) const
+{
+    std::lock_guard<std::recursive_mutex> lock(_mutex);
+
+    std::uint8_t* pointer_query = static_cast<std::uint8_t*>(pointer);
+
+    for (auto it = std::cbegin(_pointers), end = _pointers.lower_bound(static_cast<void*>(pointer_query + size));
+         it != end;
+         ++it)
+    {
+        std::uint8_t* pointer_it = static_cast<std::uint8_t*>(it->first);
+        index64_t size_it = it->second;
+
+        if (pointer_it <= pointer_query && pointer_query + size <= pointer_it + size_it)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+index64_t
+memory_manager::find_size(void* pointer) const
+{
+    std::lock_guard<std::recursive_mutex> lock(_mutex);
+
+    auto it = _pointers.find(pointer);
+
+    return (it != std::cend(_pointers)) ? it->second : 0;
+}
+
+index64_t
+memory_manager::size() const
+{
+    std::lock_guard<std::recursive_mutex> lock(_mutex);
+
+    return static_cast<index64_t>(_pointers.size());
+}
+
+index64_t
+memory_manager::total_registrations() const
+{
+    std::lock_guard<std::recursive_mutex> lock(_mutex);
+
+    return _number_insertions;
+}
+
+index64_t
+memory_manager::total_deregistrations() const
+{
+    std::lock_guard<std::recursive_mutex> lock(_mutex);
+
+    return _number_erasures;
+}
+
+bool
+memory_manager::valid() const
+{
+    std::lock_guard<std::recursive_mutex> lock(_mutex);
+
+    return total_registrations() - total_deregistrations() == size();
+}
+
+
+memory_manager&
 dispatch_allocation_manager(const dynamic_memory_type type)
 {
     switch (type)
     {
         case dynamic_memory_type::device :
         {
-            static allocation_manager manager_device;
+            static memory_manager manager_device;
             return manager_device;
         }
 
         case dynamic_memory_type::host :
         {
-            static allocation_manager manager_host;
+            static memory_manager manager_host;
             return manager_host;
         }
 
         case dynamic_memory_type::managed :
         {
-            static allocation_manager manager_managed;
+            static memory_manager manager_managed;
             return manager_managed;
         }
 
@@ -164,7 +270,7 @@ dispatch_allocation_manager(const dynamic_memory_type type)
         default :
         {
             printf("stdgpu::detail::dispatch_allocation_manager : Unsupported dynamic memory type\n");
-            static allocation_manager pointer_null;
+            static memory_manager pointer_null;
             return pointer_null;
         }
     }
@@ -201,113 +307,6 @@ dispatch_memcpy(void* destination,
                                                       bytes,
                                                       destination_type,
                                                       source_type);
-}
-
-
-void
-allocation_manager::register_memory(void* pointer,
-                                    index64_t size)
-{
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
-
-    STDGPU_EXPECTS(!contains_memory(pointer));
-    STDGPU_EXPECTS(valid());
-
-    _pointers[pointer] = size;
-    _number_insertions++;
-
-    STDGPU_ENSURES(contains_memory(pointer));
-    STDGPU_ENSURES(valid());
-}
-
-void
-allocation_manager::deregister_memory(void* pointer,
-                                      STDGPU_MAYBE_UNUSED index64_t size)
-{
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
-
-    STDGPU_EXPECTS(contains_memory(pointer));
-    STDGPU_EXPECTS(valid());
-
-    _pointers.erase(pointer);
-    _number_erasures++;
-
-    STDGPU_ENSURES(!contains_memory(pointer));
-    STDGPU_ENSURES(valid());
-}
-
-bool
-allocation_manager::contains_memory(void* pointer) const
-{
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
-
-    return _pointers.find(pointer) != std::cend(_pointers);
-}
-
-bool
-allocation_manager::contains_submemory(void* pointer,
-                                       const index64_t size) const
-{
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
-
-    std::uint8_t* pointer_query = static_cast<std::uint8_t*>(pointer);
-
-    for (auto it = std::cbegin(_pointers), end = _pointers.lower_bound(static_cast<void*>(pointer_query + size));
-         it != end;
-         ++it)
-    {
-        std::uint8_t* pointer_it = static_cast<std::uint8_t*>(it->first);
-        index64_t size_it = it->second;
-
-        if (pointer_it <= pointer_query && pointer_query + size <= pointer_it + size_it)
-        {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-index64_t
-allocation_manager::find_size(void* pointer) const
-{
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
-
-    auto it = _pointers.find(pointer);
-
-    return (it != std::cend(_pointers)) ? it->second : 0;
-}
-
-index64_t
-allocation_manager::size() const
-{
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
-
-    return static_cast<index64_t>(_pointers.size());
-}
-
-index64_t
-allocation_manager::total_registrations() const
-{
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
-
-    return _number_insertions;
-}
-
-index64_t
-allocation_manager::total_deregistrations() const
-{
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
-
-    return _number_erasures;
-}
-
-bool
-allocation_manager::valid() const
-{
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
-
-    return total_registrations() - total_deregistrations() == size();
 }
 
 
@@ -396,6 +395,40 @@ memcpy(void* destination,
     dispatch_memcpy(destination, source, bytes, destination_type, source_type);
 }
 
+
+memory_manager&
+dispatch_size_manager(const dynamic_memory_type type)
+{
+    switch (type)
+    {
+        case dynamic_memory_type::device :
+        {
+            static memory_manager manager_device;
+            return manager_device;
+        }
+
+        case dynamic_memory_type::host :
+        {
+            static memory_manager manager_host;
+            return manager_host;
+        }
+
+        case dynamic_memory_type::managed :
+        {
+            static memory_manager manager_managed;
+            return manager_managed;
+        }
+
+        case dynamic_memory_type::invalid :
+        default :
+        {
+            printf("stdgpu::detail::dispatch_size_manager : Unsupported dynamic memory type\n");
+            static memory_manager pointer_null;
+            return pointer_null;
+        }
+    }
+}
+
 } // namespace detail
 
 
@@ -403,20 +436,60 @@ template <>
 dynamic_memory_type
 get_dynamic_memory_type(void* array)
 {
-    if (detail::dispatch_allocation_manager(dynamic_memory_type::device).contains_memory(array))
+    if (detail::dispatch_size_manager(dynamic_memory_type::device).contains_memory(array))
     {
         return dynamic_memory_type::device;
     }
-    if (detail::dispatch_allocation_manager(dynamic_memory_type::host).contains_memory(array))
+    if (detail::dispatch_size_manager(dynamic_memory_type::host).contains_memory(array))
     {
         return dynamic_memory_type::host;
     }
-    if (detail::dispatch_allocation_manager(dynamic_memory_type::managed).contains_memory(array))
+    if (detail::dispatch_size_manager(dynamic_memory_type::managed).contains_memory(array))
     {
         return dynamic_memory_type::managed;
     }
 
     return dynamic_memory_type::invalid;
+}
+
+
+template <>
+void
+register_memory(void* p,
+                index64_t n,
+                dynamic_memory_type memory_type)
+{
+    if (p == nullptr)
+    {
+        printf("stdgpu::register_memory : Registering a null pointer not possible\n");
+        return;
+    }
+    if (n <= 0)
+    {
+        printf("stdgpu::register_memory : Registering pointer with number of bytes <= 0 not possible\n");
+        return;
+    }
+    if (detail::dispatch_size_manager(memory_type).contains_memory(p))
+    {
+        printf("stdgpu::register_memory : Registering already known pointer not possible\n");
+        return;
+    }
+    detail::dispatch_size_manager(memory_type).register_memory(p, n);
+}
+
+
+template <>
+void
+deregister_memory(void* p,
+                  index64_t n,
+                  dynamic_memory_type memory_type)
+{
+    if (!detail::dispatch_size_manager(memory_type).contains_memory(p))
+    {
+        printf("stdgpu::deregister_memory : Deregistering unknown pointer not possible\n");
+        return;
+    }
+    detail::dispatch_size_manager(memory_type).deregister_memory(p, n);
 }
 
 
@@ -440,10 +513,10 @@ size_bytes(void* array)
 {
     dynamic_memory_type type = get_dynamic_memory_type(array);
 
-    index64_t array_size_bytes = detail::dispatch_allocation_manager(type).find_size(array);
+    index64_t array_size_bytes = detail::dispatch_size_manager(type).find_size(array);
     if (array_size_bytes == 0)
     {
-        printf("stdgpu::size_bytes : Array not allocated by this API or not pointing to the first element. Returning 0 ...\n");
+        printf("stdgpu::size_bytes : Array not registered or not pointing to the first element. Returning 0 ...\n");
         return 0;
     }
 

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -465,7 +465,9 @@ template <typename T>
 STDGPU_NODISCARD T*
 safe_device_allocator<T>::allocate(index64_t n)
 {
-    return static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type)); //NOLINT(bugprone-sizeof-expression)
+    T* p = static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type)); //NOLINT(bugprone-sizeof-expression)
+    register_memory(p, n, memory_type);
+    return p;
 }
 
 
@@ -474,6 +476,7 @@ void
 safe_device_allocator<T>::deallocate(T* p,
                                      index64_t n)
 {
+    deregister_memory(p, n, memory_type);
     detail::deallocate(static_cast<void*>(p), n * static_cast<index64_t>(sizeof(T)), memory_type); //NOLINT(bugprone-sizeof-expression)
 }
 
@@ -482,7 +485,9 @@ template <typename T>
 STDGPU_NODISCARD T*
 safe_host_allocator<T>::allocate(index64_t n)
 {
-    return static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type)); //NOLINT(bugprone-sizeof-expression)
+    T* p = static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type)); //NOLINT(bugprone-sizeof-expression)
+    register_memory(p, n, memory_type);
+    return p;
 }
 
 
@@ -491,6 +496,7 @@ void
 safe_host_allocator<T>::deallocate(T* p,
                                    index64_t n)
 {
+    deregister_memory(p, n, memory_type);
     detail::deallocate(static_cast<void*>(p), n * static_cast<index64_t>(sizeof(T)), memory_type); //NOLINT(bugprone-sizeof-expression)
 }
 
@@ -499,7 +505,9 @@ template <typename T>
 STDGPU_NODISCARD T*
 safe_managed_allocator<T>::allocate(index64_t n)
 {
-    return static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type)); //NOLINT(bugprone-sizeof-expression)
+    T* p = static_cast<T*>(detail::allocate(n * static_cast<index64_t>(sizeof(T)), memory_type)); //NOLINT(bugprone-sizeof-expression)
+    register_memory(p, n, memory_type);
+    return p;
 }
 
 
@@ -508,6 +516,7 @@ void
 safe_managed_allocator<T>::deallocate(T* p,
                                       index64_t n)
 {
+    deregister_memory(p, n, memory_type);
     detail::deallocate(static_cast<void*>(p), n * static_cast<index64_t>(sizeof(T)), memory_type); //NOLINT(bugprone-sizeof-expression)
 }
 
@@ -634,6 +643,40 @@ dynamic_memory_type
 get_dynamic_memory_type(T* array)
 {
     return get_dynamic_memory_type<void>(static_cast<void*>(const_cast<std::remove_cv_t<T>*>(array)));
+}
+
+
+template <>
+void
+register_memory(void* p,
+                index64_t n,
+                dynamic_memory_type memory_type);
+
+
+template <typename T>
+void
+register_memory(T* p,
+                index64_t n,
+                dynamic_memory_type memory_type)
+{
+    register_memory<void>(static_cast<void*>(const_cast<std::remove_cv_t<T>*>(p)), n * static_cast<index64_t>(sizeof(T)), memory_type); //NOLINT(bugprone-sizeof-expression)
+}
+
+
+template <>
+void
+deregister_memory(void* p,
+                  index64_t n,
+                  dynamic_memory_type memory_type);
+
+
+template <typename T>
+void
+deregister_memory(T* p,
+                  index64_t n,
+                  dynamic_memory_type memory_type)
+{
+    deregister_memory<void>(static_cast<void*>(const_cast<std::remove_cv_t<T>*>(p)), n * static_cast<index64_t>(sizeof(T)), memory_type); //NOLINT(bugprone-sizeof-expression)
 }
 
 

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -292,7 +292,7 @@ enum class dynamic_memory_type
     host,           /**< The array is allocated on the host (CPU) */
     device,         /**< The array is allocated on the device (GPU) */
     managed,        /**< The array is allocated on both the host (CPU) and device (GPU) and managed internally by the driver via paging */
-    invalid         /**< The array is not dynamically allocated by our API */
+    invalid         /**< The array is not registered by our API */
 };
 
 
@@ -575,9 +575,38 @@ destroy_n(Iterator first,
 
 /**
  * \ingroup memory
- * \brief Returns the total number of allocations of a specific memory type
+ * \brief Registers the given memory block into the internal memory size manger
+ * \param[in] p A pointer to the memory block
+ * \param[in] n The size of the memory block in bytes
+ * \param[in] memory_type The dynamic memory type of the memory block
+ * \note Automatically called by safe_device_allocator, safe_host_allocator, safe_managed_allocator
+ */
+template <typename T>
+void
+register_memory(T* p,
+                index64_t n,
+                dynamic_memory_type memory_type);
+
+/**
+ * \ingroup memory
+ * \brief Deregisters the given memory block into the internal memory size manger
+ * \param[in] p A pointer to the memory block
+ * \param[in] n The size of the memory block in bytes (must match the size during registration)
+ * \param[in] memory_type The dynamic memory type of the memory block
+ * \note Automatically called by safe_device_allocator, safe_host_allocator, safe_managed_allocator
+ * \note Only thread-safe if called before the memory block is actually freed
+ */
+template <typename T>
+void
+deregister_memory(T* p,
+                  index64_t n,
+                  dynamic_memory_type memory_type);
+
+/**
+ * \ingroup memory
+ * \brief Returns the total number of registered allocations of a specific memory type
  * \param[in] memory_type A dynamic memory type
- * \return The total number of allocation for the given type of memory if available, 0 otherwise
+ * \return The total number of allocations for the given type of memory if available, 0 otherwise
  */
 index64_t
 get_allocation_count(dynamic_memory_type memory_type);
@@ -585,9 +614,9 @@ get_allocation_count(dynamic_memory_type memory_type);
 
 /**
  * \ingroup memory
- * \brief Returns the total number of deallocations of a specific memory type
+ * \brief Returns the total number of registered deallocations of a specific memory type
  * \param[in] memory_type A dynamic memory type
- * \return The total number of deallocation for the given type of memory if available, 0 otherwise
+ * \return The total number of deallocations for the given type of memory if available, 0 otherwise
  */
 index64_t
 get_deallocation_count(dynamic_memory_type memory_type);
@@ -598,7 +627,7 @@ get_deallocation_count(dynamic_memory_type memory_type);
  * \brief Finds the size (in bytes) of the given dynamically allocated array
  * \tparam T The type of the array
  * \param[in] array An array
- * \return The size (in bytes) of the given array if it was created by our API, 0 otherwise
+ * \return The size (in bytes) of the given array if it was registered by our API, 0 otherwise
  */
 template <typename T>
 index64_t

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -198,6 +198,18 @@ dynamic_memory_type
 get_dynamic_memory_type<int>(int*);
 
 template
+void
+register_memory<int>(int* p,
+                     index64_t n,
+                     dynamic_memory_type memory_type);
+
+template
+void
+deregister_memory<int>(int* p,
+                       index64_t n,
+                       dynamic_memory_type memory_type);
+
+template
 index64_t
 size_bytes<int>(int*);
 
@@ -1606,6 +1618,102 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroy_at)
     EXPECT_EQ(destructor_calls, size);
 
     stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
+}
+
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory)
+{
+    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    const stdgpu::index64_t n = 24;
+
+    stdgpu::register_memory(p, n, stdgpu::dynamic_memory_type::host);
+
+    EXPECT_EQ(stdgpu::size(p), n);
+
+    stdgpu::deregister_memory(p, n, stdgpu::dynamic_memory_type::host);
+
+    EXPECT_EQ(stdgpu::size(p), 0);
+}
+
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory_double_register)
+{
+    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    const stdgpu::index64_t n = 24;
+
+    stdgpu::register_memory(p, n, stdgpu::dynamic_memory_type::host);
+
+    EXPECT_EQ(stdgpu::size(p), n);
+
+    stdgpu::register_memory(p, n, stdgpu::dynamic_memory_type::host);
+
+    EXPECT_EQ(stdgpu::size(p), n);
+
+    stdgpu::deregister_memory(p, n, stdgpu::dynamic_memory_type::host);
+
+    EXPECT_EQ(stdgpu::size(p), 0);
+}
+
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory_double_deregister)
+{
+    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    const stdgpu::index64_t n = 24;
+
+    stdgpu::register_memory(p, n, stdgpu::dynamic_memory_type::host);
+
+    EXPECT_EQ(stdgpu::size(p), n);
+
+    stdgpu::deregister_memory(p, n, stdgpu::dynamic_memory_type::host);
+
+    EXPECT_EQ(stdgpu::size(p), 0);
+
+    stdgpu::deregister_memory(p, n, stdgpu::dynamic_memory_type::host);
+
+    EXPECT_EQ(stdgpu::size(p), 0);
+}
+
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory_unknown_deregister)
+{
+    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    const stdgpu::index64_t n = 24;
+
+    EXPECT_EQ(stdgpu::size(p), 0);
+
+    stdgpu::deregister_memory(p, n, stdgpu::dynamic_memory_type::host);
+
+    EXPECT_EQ(stdgpu::size(p), 0);
+}
+
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory_nullptr)
+{
+    int* p = nullptr;
+    const stdgpu::index64_t n = 24;
+
+    stdgpu::register_memory(p, n, stdgpu::dynamic_memory_type::host);
+
+    EXPECT_EQ(stdgpu::size(p), 0);
+
+    stdgpu::deregister_memory(p, n, stdgpu::dynamic_memory_type::host);
+
+    EXPECT_EQ(stdgpu::size(p), 0);
+}
+
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory_empty_size)
+{
+    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    const stdgpu::index64_t n = 0;
+
+    stdgpu::register_memory(p, n, stdgpu::dynamic_memory_type::host);
+
+    EXPECT_EQ(stdgpu::size(p), 0);
+
+    stdgpu::deregister_memory(p, n, stdgpu::dynamic_memory_type::host);
+
+    EXPECT_EQ(stdgpu::size(p), 0);
 }
 
 


### PR DESCRIPTION
The `iterator` API including the `size()` request function are tightly coupled to the internal memory (leak) detection system. While is a suitable solution if only the `safe_{device,host,managed}_allocator` classes are supported, it prevents opening up the API for external memory. Split the internal memory management into independent allocation and a size parts and add functions to register external memory into the size manager. This allows for further changes to open up the API.