### PR TITLE
 memory: Add allocator-based create/destroy functions

### DIFF
--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -64,6 +64,24 @@ createDeviceArray(const stdgpu::index64_t count,
 
 /**
  * \ingroup memory
+ * \brief Creates a new device array and initializes (fills) it with the given default value
+ * \tparam T The type of the array
+ * \tparam Allocator An allocator for device memory
+ * \param[in] device_allocator The device allocator to use
+ * \param[in] count The number of elements of the new array
+ * \param[in] default_value A default value, that should be stored in every array entry
+ * \return The allocated device array if count > 0, nullptr otherwise
+ * \note Must only be used in device-compiled code
+ */
+template <typename T, typename Allocator>
+T*
+createDeviceArray(Allocator& device_allocator,
+                  const stdgpu::index64_t count,
+                  const T default_value);
+
+
+/**
+ * \ingroup memory
  * \brief Creates a new host array and initializes (fills) it with the given default value
  * \tparam T The type of the array
  * \param[in] count The number of elements of the new array
@@ -75,6 +93,23 @@ template <typename T>
 T*
 createHostArray(const stdgpu::index64_t count,
                 const T default_value = T());
+
+
+/**
+ * \ingroup memory
+ * \brief Creates a new host array and initializes (fills) it with the given default value
+ * \tparam T The type of the array
+ * \tparam Allocator An allocator for host memory
+ * \param[in] host_allocator The host allocator to use
+ * \param[in] count The number of elements of the new array
+ * \param[in] default_value A default value, that should be stored in every array entry
+ * \return The allocated host array if count > 0, nullptr otherwise
+ */
+template <typename T, typename Allocator>
+T*
+createHostArray(Allocator& host_allocator,
+                const stdgpu::index64_t count,
+                const T default_value);
 
 
 /**
@@ -96,6 +131,25 @@ createManagedArray(const stdgpu::index64_t count,
 
 /**
  * \ingroup memory
+ * \brief Creates a new managed array and initializes (fills) it with the given default value
+ * \tparam T The type of the array
+ * \tparam Allocator An allocator for managed memory
+ * \param[in] managed_allocator The managed allocator to use
+ * \param[in] count The number of elements of the new array
+ * \param[in] default_value A default value, that should be stored in every array entry
+ * \param[in] initialize_on The device on which the fill operation is performed
+ * \return The allocated managed array if count > 0, nullptr otherwise
+ */
+template <typename T, typename Allocator>
+T*
+createManagedArray(Allocator& managed_allocator,
+                   const stdgpu::index64_t count,
+                   const T default_value,
+                   const Initialization initialize_on = Initialization::DEVICE);
+
+
+/**
+ * \ingroup memory
  * \brief Destroys the given device array
  * \tparam T The type of the array
  * \param[in] device_array A device array
@@ -103,6 +157,20 @@ createManagedArray(const stdgpu::index64_t count,
 template <typename T>
 void
 destroyDeviceArray(T*& device_array);
+
+
+/**
+ * \ingroup memory
+ * \brief Destroys the given device array
+ * \tparam T The type of the array
+ * \tparam Allocator An allocator for device memory
+ * \param[in] device_allocator The device allocator to use
+ * \param[in] device_array A device array
+ */
+template <typename T, typename Allocator>
+void
+destroyDeviceArray(Allocator& device_allocator,
+                   T*& device_array);
 
 
 /**
@@ -118,6 +186,20 @@ destroyHostArray(T*& host_array);
 
 /**
  * \ingroup memory
+ * \brief Destroys the given host array
+ * \tparam T The type of the array
+ * \tparam Allocator An allocator for host memory
+ * \param[in] host_allocator The host allocator to use
+ * \param[in] host_array A host array
+ */
+template <typename T, typename Allocator>
+void
+destroyHostArray(Allocator& host_allocator,
+                 T*& host_array);
+
+
+/**
+ * \ingroup memory
  * \brief Destroys the given managed array
  * \tparam T The type of the array
  * \param[in] managed_array A managed array
@@ -126,6 +208,19 @@ template <typename T>
 void
 destroyManagedArray(T*& managed_array);
 
+
+/**
+ * \ingroup memory
+ * \brief Destroys the given managed array
+ * \tparam T The type of the array
+ * \tparam Allocator An allocator for managed memory
+ * \param[in] managed_allocator The managed allocator to use
+ * \param[in] managed_array A managed array
+ */
+template <typename T, typename Allocator>
+void
+destroyManagedArray(Allocator& managed_allocator,
+                    T*& managed_array);
 
 
 /**
@@ -158,6 +253,26 @@ copyCreateDevice2HostArray(const T* device_array,
 
 /**
  * \ingroup memory
+ * \brief Creates and copies the given device array to the host
+ * \tparam T The type of the array
+ * \tparam Allocator An allocator for host memory
+ * \param[in] host_allocator The host allocator to use
+ * \param[in] device_array The device array
+ * \param[in] count The number of elements of device_array
+ * \param[in] check_safety True if this function should check whether copying is safe, false otherwise
+ * \return The same array allocated on the host
+ * \note The source array might also be a managed array
+ */
+template <typename T, typename Allocator>
+T*
+copyCreateDevice2HostArray(Allocator& host_allocator,
+                           const T* device_array,
+                           const stdgpu::index64_t count,
+                           const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
+
+
+/**
+ * \ingroup memory
  * \brief Creates and copies the given host array to the device
  * \tparam T The type of the array
  * \param[in] host_array The host array
@@ -169,6 +284,26 @@ copyCreateDevice2HostArray(const T* device_array,
 template <typename T>
 T*
 copyCreateHost2DeviceArray(const T* host_array,
+                           const stdgpu::index64_t count,
+                           const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
+
+
+/**
+ * \ingroup memory
+ * \brief Creates and copies the given host array to the device
+ * \tparam T The type of the array
+ * \tparam Allocator An allocator for device memory
+ * \param[in] device_allocator The host allocator to use
+ * \param[in] host_array The host array
+ * \param[in] count The number of elements of host_array
+ * \param[in] check_safety True if this function should check whether copying is safe, false otherwise
+ * \return The same array allocated on the device
+ * \note The source array might also be a managed array
+ */
+template <typename T, typename Allocator>
+T*
+copyCreateHost2DeviceArray(Allocator& device_allocator,
+                           const T* host_array,
                            const stdgpu::index64_t count,
                            const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
 
@@ -192,6 +327,26 @@ copyCreateHost2HostArray(const T* host_array,
 
 /**
  * \ingroup memory
+ * \brief Creates and copies the given host array to the host
+ * \tparam T The type of the array
+ * \tparam Allocator An allocator for host memory
+ * \param[in] host_allocator The host allocator to use
+ * \param[in] host_array The host array
+ * \param[in] count The number of elements of host_array
+ * \param[in] check_safety True if this function should check whether copying is safe, false otherwise
+ * \return The same array allocated on the host
+ * \note The source array might also be a managed array
+ */
+template <typename T, typename Allocator>
+T*
+copyCreateHost2HostArray(Allocator& host_allocator,
+                         const T* host_array,
+                         const stdgpu::index64_t count,
+                         const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
+
+
+/**
+ * \ingroup memory
  * \brief Creates and copies the given device array to the device
  * \tparam T The type of the array
  * \param[in] device_array The device array
@@ -203,6 +358,26 @@ copyCreateHost2HostArray(const T* host_array,
 template <typename T>
 T*
 copyCreateDevice2DeviceArray(const T* device_array,
+                             const stdgpu::index64_t count,
+                             const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
+
+
+/**
+ * \ingroup memory
+ * \brief Creates and copies the given device array to the device
+ * \tparam T The type of the array
+ * \tparam Allocator An allocator for device memory
+ * \param[in] device_allocator The host allocator to use
+ * \param[in] device_array The device array
+ * \param[in] count The number of elements of device_array
+ * \param[in] check_safety True if this function should check whether copying is safe, false otherwise
+ * \return The same array allocated on the device
+ * \note The source array might also be a managed array
+ */
+template <typename T, typename Allocator>
+T*
+copyCreateDevice2DeviceArray(Allocator& device_allocator,
+                             const T* device_array,
                              const stdgpu::index64_t count,
                              const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
 
@@ -323,6 +498,24 @@ struct safe_device_allocator
     constexpr static dynamic_memory_type memory_type = dynamic_memory_type::device;
 
     /**
+     * \brief Default constructor
+     */
+    safe_device_allocator() = default;
+
+    /**
+     * \brief Copy constructor
+     */
+    safe_device_allocator(const safe_device_allocator&) = default;
+
+    /**
+     * \brief Copy constructor
+     * \tparam U Another type
+     * \param[in] other The allocator to be copied from
+     */
+    template <typename U>
+    explicit safe_device_allocator(const safe_device_allocator<U>& other);
+
+    /**
      * \brief Allocates a memory block of the given size
      * \param[in] n The size of the memory block in bytes
      * \return A pointer to the allocated memory block
@@ -357,6 +550,24 @@ struct safe_host_allocator
     constexpr static dynamic_memory_type memory_type = dynamic_memory_type::host;
 
     /**
+     * \brief Default constructor
+     */
+    safe_host_allocator() = default;
+
+    /**
+     * \brief Copy constructor
+     */
+    safe_host_allocator(const safe_host_allocator&) = default;
+
+    /**
+     * \brief Copy constructor
+     * \tparam U Another type
+     * \param[in] other The allocator to be copied from
+     */
+    template <typename U>
+    explicit safe_host_allocator(const safe_host_allocator<U>& other);
+
+    /**
      * \brief Allocates a memory block of the given size
      * \param[in] n The size of the memory block in bytes
      * \return A pointer to the allocated memory block
@@ -389,6 +600,24 @@ struct safe_managed_allocator
      * \brief Dynamic memory type of allocations
      */
     constexpr static dynamic_memory_type memory_type = dynamic_memory_type::managed;
+
+    /**
+     * \brief Default constructor
+     */
+    safe_managed_allocator() = default;
+
+    /**
+     * \brief Copy constructor
+     */
+    safe_managed_allocator(const safe_managed_allocator&) = default;
+
+    /**
+     * \brief Copy constructor
+     * \tparam U Another type
+     * \param[in] other The allocator to be copied from
+     */
+    template <typename U>
+    explicit safe_managed_allocator(const safe_managed_allocator<U>& other);
 
     /**
      * \brief Allocates a memory block of the given size
@@ -441,6 +670,10 @@ struct allocator_traits : public detail::allocator_traits_base<Allocator>
     using propagate_on_container_move_assignment    = std::false_type;                                                          /**< std::false_type */
     using propagate_on_container_swap               = std::false_type;                                                          /**< std::false_type */
     using is_always_equal                           = std::is_empty<Allocator>;                                                 /**< std::is_empty<Allocator> */
+    template <typename T>
+    using rebind_alloc                              = typename std::allocator_traits<Allocator>::template rebind_alloc<T>;      /**< std::allocator_traits<Allocator>::rebind_alloc<T> */
+    template <typename T>
+    using rebind_traits                             = allocator_traits<rebind_alloc<T>>;                                        /**< allocator_traits<rebind_alloc<T>> */
 
 
     /**

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -447,6 +447,20 @@ namespace
             destroyDeviceArray<int>(array_device);
 
             EXPECT_EQ(array_device, nullptr);
+
+            #if STDGPU_DETAIL_IS_DEVICE_COMPILED
+                using Allocator = stdgpu::safe_device_allocator<int>;
+                Allocator a;
+
+                int* array_device_2 = createDeviceArray<int, Allocator>(a, size, default_value);
+
+                EXPECT_TRUE( thrust::all_of(stdgpu::device_cbegin(array_device_2), stdgpu::device_cend(array_device_2),
+                                            equal_to_number(default_value)) );
+
+                destroyDeviceArray<int, Allocator>(a, array_device_2);
+
+                EXPECT_EQ(array_device_2, nullptr);
+            #endif
         }
     }
 
@@ -457,15 +471,22 @@ namespace
             const stdgpu::index64_t size = 42;
             const int default_value = 10;
 
+            using Allocator = stdgpu::safe_host_allocator<int>;
+            Allocator a;
+
             int* array_host = createHostArray<int>(size, default_value);
+            int* array_host_2 = createHostArray<int, Allocator>(a, size, default_value);
 
             EXPECT_TRUE( thrust::all_of(stdgpu::host_cbegin(array_host), stdgpu::host_cend(array_host),
                                         equal_to_number(default_value)) );
-
+            EXPECT_TRUE( thrust::all_of(stdgpu::host_cbegin(array_host_2), stdgpu::host_cend(array_host_2),
+                                        equal_to_number(default_value)) );
 
             destroyHostArray<int>(array_host);
+            destroyHostArray<int, Allocator>(a, array_host_2);
 
             EXPECT_EQ(array_host, nullptr);
+            EXPECT_EQ(array_host_2, nullptr);
         }
     }
 
@@ -476,22 +497,29 @@ namespace
             const stdgpu::index64_t size = 42;
             const int default_value = 10;
 
+            using Allocator = stdgpu::safe_managed_allocator<int>;
+            Allocator a;
+
             int* array_managed_device = createManagedArray<int>(size, default_value, Initialization::DEVICE);
             int* array_managed_host = createManagedArray<int>(size, default_value, Initialization::HOST);
+            int* array_managed_host_2 = createManagedArray<int, Allocator>(a, size, default_value, Initialization::HOST);
 
             #if STDGPU_DETAIL_IS_DEVICE_COMPILED
                 EXPECT_TRUE( thrust::all_of(stdgpu::device_cbegin(array_managed_device), stdgpu::device_cend(array_managed_device),
                                             equal_to_number(default_value)) );
             #endif
-
             EXPECT_TRUE( thrust::all_of(stdgpu::host_cbegin(array_managed_host), stdgpu::host_cend(array_managed_host),
+                                        equal_to_number(default_value)) );
+            EXPECT_TRUE( thrust::all_of(stdgpu::host_cbegin(array_managed_host_2), stdgpu::host_cend(array_managed_host_2),
                                         equal_to_number(default_value)) );
 
             destroyManagedArray<int>(array_managed_device);
             destroyManagedArray<int>(array_managed_host);
+            destroyManagedArray<int, Allocator>(a, array_managed_host_2);
 
             EXPECT_EQ(array_managed_device, nullptr);
             EXPECT_EQ(array_managed_host, nullptr);
+            EXPECT_EQ(array_managed_host_2, nullptr);
         }
     }
 }
@@ -652,8 +680,26 @@ namespace
                                            thrust::equal_to<int>()) );
             #endif
 
+            #if STDGPU_DETAIL_IS_DEVICE_COMPILED
+                using Allocator = stdgpu::safe_device_allocator<int>;
+                Allocator a;
+
+                int* array_copy_2 = copyCreateDevice2DeviceArray<int, Allocator>(a, array, size);
+
+                EXPECT_TRUE( thrust::equal(stdgpu::device_begin(array), stdgpu::device_end(array),
+                                           stdgpu::device_begin(array_copy_2),
+                                           thrust::equal_to<int>()) );
+
+                destroyDeviceArray<int, Allocator>(a, array_copy_2);
+
+                EXPECT_EQ(array_copy_2, nullptr);
+            #endif
+
             destroyDeviceArray<int>(array);
             destroyDeviceArray<int>(array_copy);
+
+            EXPECT_EQ(array, nullptr);
+            EXPECT_EQ(array_copy, nullptr);
         }
     }
 }
@@ -693,9 +739,28 @@ namespace
                                            thrust::equal_to<int>()) );
             #endif
 
+            #if STDGPU_DETAIL_IS_DEVICE_COMPILED
+                using Allocator = stdgpu::safe_device_allocator<int>;
+                Allocator a;
+
+                int* array_copy_2 = copyCreateHost2DeviceArray<int, Allocator>(a, array_host, size);
+
+                EXPECT_TRUE( thrust::equal(stdgpu::device_begin(array), stdgpu::device_end(array),
+                                           stdgpu::device_begin(array_copy_2),
+                                           thrust::equal_to<int>()) );
+
+                destroyDeviceArray<int, Allocator>(a, array_copy_2);
+
+                EXPECT_EQ(array_copy_2, nullptr);
+            #endif
+
             destroyDeviceArray<int>(array);
             destroyHostArray<int>(array_host);
             destroyDeviceArray<int>(array_copy);
+
+            EXPECT_EQ(array, nullptr);
+            EXPECT_EQ(array_host, nullptr);
+            EXPECT_EQ(array_copy, nullptr);
         }
     }
 }
@@ -750,17 +815,30 @@ namespace
             const stdgpu::index64_t size = 42;
             const int default_value = 10;
 
+            using Allocator = stdgpu::safe_host_allocator<int>;
+            Allocator a;
+
             int* array = createDeviceArray<int>(size, default_value);
             int* array_host = createHostArray<int>(size, default_value);
             int* array_copy = copyCreateDevice2HostArray<int>(array, size);
+            int* array_copy_2 = copyCreateDevice2HostArray<int, Allocator>(a, array, size);
 
             EXPECT_TRUE( thrust::equal(stdgpu::host_cbegin(array_host), stdgpu::host_cend(array_host),
                                        stdgpu::host_cbegin(array_copy),
+                                       thrust::equal_to<int>()) );
+            EXPECT_TRUE( thrust::equal(stdgpu::host_cbegin(array_host), stdgpu::host_cend(array_host),
+                                       stdgpu::host_cbegin(array_copy_2),
                                        thrust::equal_to<int>()) );
 
             destroyDeviceArray<int>(array);
             destroyHostArray<int>(array_host);
             destroyHostArray<int>(array_copy);
+            destroyHostArray<int>(array_copy_2);
+
+            EXPECT_EQ(array, nullptr);
+            EXPECT_EQ(array_host, nullptr);
+            EXPECT_EQ(array_copy, nullptr);
+            EXPECT_EQ(array_copy_2, nullptr);
         }
     }
 }
@@ -790,15 +868,27 @@ namespace
             const stdgpu::index64_t size = 42;
             const int default_value = 10;
 
+            using Allocator = stdgpu::safe_host_allocator<int>;
+            Allocator a;
+
             int* array_host = createHostArray<int>(size, default_value);
             int* array_copy = copyCreateHost2HostArray<int>(array_host, size);
+            int* array_copy_2 = copyCreateHost2HostArray<int, Allocator>(a, array_host, size);
 
             EXPECT_TRUE( thrust::equal(stdgpu::host_cbegin(array_host), stdgpu::host_cend(array_host),
                                        stdgpu::host_cbegin(array_copy),
                                        thrust::equal_to<int>()) );
+            EXPECT_TRUE( thrust::equal(stdgpu::host_cbegin(array_host), stdgpu::host_cend(array_host),
+                                       stdgpu::host_cbegin(array_copy_2),
+                                       thrust::equal_to<int>()) );
 
             destroyHostArray<int>(array_host);
             destroyHostArray<int>(array_copy);
+            destroyHostArray<int>(array_copy_2);
+
+            EXPECT_EQ(array_host, nullptr);
+            EXPECT_EQ(array_copy, nullptr);
+            EXPECT_EQ(array_copy_2, nullptr);
         }
     }
 }
@@ -1372,6 +1462,77 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_hint_deallocate)
 
     stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
     stdgpu::allocator_traits<Allocator>::deallocate(a, array_hint, size);
+}
+
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_device)
+{
+    using Allocator_original = stdgpu::safe_device_allocator<float>;
+    Allocator_original ao;
+
+    using Allocator = typename stdgpu::allocator_traits<Allocator_original>::rebind_alloc<int>;
+    Allocator a(ao);
+
+    const stdgpu::index64_t size = 42;
+
+    int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
+
+    #if STDGPU_DETAIL_IS_DEVICE_COMPILED
+        const int default_value = 10;
+        thrust::fill(stdgpu::device_begin(array), stdgpu::device_end(array),
+                     default_value);
+
+        EXPECT_TRUE( thrust::all_of(stdgpu::device_cbegin(array), stdgpu::device_cend(array),
+                                    equal_to_number(default_value)) );
+    #endif
+
+    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
+}
+
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_host)
+{
+    using Allocator_original = stdgpu::safe_host_allocator<float>;
+    Allocator_original ao;
+
+    using Allocator = typename stdgpu::allocator_traits<Allocator_original>::rebind_alloc<int>;
+    Allocator a(ao);
+
+    const stdgpu::index64_t size = 42;
+
+    int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
+
+    const int default_value = 10;
+    thrust::fill(stdgpu::host_begin(array), stdgpu::host_end(array),
+                 default_value);
+
+    EXPECT_TRUE( thrust::all_of(stdgpu::host_cbegin(array), stdgpu::host_cend(array),
+                                equal_to_number(default_value)) );
+
+    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
+}
+
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_managed)
+{
+    using Allocator_original = stdgpu::safe_managed_allocator<float>;
+    Allocator_original ao;
+
+    using Allocator = typename stdgpu::allocator_traits<Allocator_original>::rebind_alloc<int>;
+    Allocator a(ao);
+
+    const stdgpu::index64_t size = 42;
+
+    int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
+
+    const int default_value = 10;
+    thrust::fill(stdgpu::host_begin(array), stdgpu::host_end(array),
+                 default_value);
+
+    EXPECT_TRUE( thrust::all_of(stdgpu::host_cbegin(array), stdgpu::host_cend(array),
+                                equal_to_number(default_value)) );
+
+    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
 }
 
 


### PR DESCRIPTION
Up to now, the create/destroy API is limited to the internal `safe_{device,host,managed}_allocator` classes. In order to open up the API for custom allocators, provide new overloads. This also allows to simplify the implementation of the fixed variants and share code between all overloads.