### PR TITLE
atomic: Add support for custom allocators

### DIFF
--- a/test/stdgpu/CMakeLists.txt
+++ b/test/stdgpu/CMakeLists.txt
@@ -11,6 +11,8 @@ target_sources(teststdgpu PRIVATE algorithm.cpp
                                   memory.cpp
                                   ranges.cpp)
 
+target_sources(teststdgpu PRIVATE ../test_memory_utils.cpp)
+
 add_subdirectory(${STDGPU_BACKEND_DIRECTORY})
 
 target_include_directories(teststdgpu PRIVATE

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -25,6 +25,7 @@
 #include <thrust/sort.h>
 
 #include <test_utils.h>
+#include <test_memory_utils.h>
 #include <stdgpu/atomic.cuh>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
@@ -2429,6 +2430,52 @@ TEST_F(stdgpu_atomic, fence_unsigned_int)
 TEST_F(stdgpu_atomic, fence_unsigned_long_long_int)
 {
     sequence_fence<unsigned long long int>();
+}
+
+
+TEST_F(stdgpu_atomic, get_allocator)
+{
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::atomic<int> value = stdgpu::atomic<int>::createDeviceObject();
+
+    stdgpu::atomic<int>::allocator_type a = value.get_allocator();
+
+    int* array = a.allocate(N);
+    a.deallocate(array, N);
+
+    stdgpu::atomic<int>::destroyDeviceObject(value);
+}
+
+
+TEST_F(stdgpu_atomic, custom_allocator)
+{
+    test_utils::get_allocator_statistics().reset();
+
+    {
+        const stdgpu::index_t N = 10000;
+
+        using Allocator = test_utils::test_device_allocator<int>;
+        Allocator a_orig;
+
+        stdgpu::atomic<int, Allocator> value = stdgpu::atomic<int, Allocator>::createDeviceObject(a_orig);
+
+        stdgpu::atomic<int, Allocator>::allocator_type a = value.get_allocator();
+
+        int* array = a.allocate(N);
+        a.deallocate(array, N);
+
+        stdgpu::atomic<int, Allocator>::destroyDeviceObject(value);
+    }
+
+    // Account for potential but not guaranteed copy-ellision
+    EXPECT_EQ(test_utils::get_allocator_statistics().default_constructions, 1);
+    EXPECT_GE(test_utils::get_allocator_statistics().copy_constructions, 2);
+    EXPECT_LE(test_utils::get_allocator_statistics().copy_constructions, 3);
+    EXPECT_GE(test_utils::get_allocator_statistics().destructions, 3);
+    EXPECT_LE(test_utils::get_allocator_statistics().destructions, 4);
+
+    test_utils::get_allocator_statistics().reset();
 }
 
 

--- a/test/test_memory_utils.cpp
+++ b/test/test_memory_utils.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019 Patrick Stotko
+ *  Copyright 2021 Patrick Stotko
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -13,41 +13,28 @@
  *  limitations under the License.
  */
 
-#ifndef STDGPU_ATOMIC_FWD
-#define STDGPU_ATOMIC_FWD
-
-/**
- * \addtogroup atomic atomic
- * \ingroup data_structures
- * @{
- */
-
-/**
- * \file stdgpu/atomic_fwd
- */
+#include <test_memory_utils.h>
 
 
 
-namespace stdgpu
+namespace test_utils
 {
 
-template <typename T>
-struct safe_device_allocator;
-
-template <typename T, typename Allocator = safe_device_allocator<T>>
-class atomic;
-
-template <typename T>
-class atomic_ref;
-
-} // namespace stdgpu
+void
+allocator_statistics::reset()
+{
+    default_constructions = 0;
+    copy_constructions = 0;
+    destructions = 0;
+}
 
 
+allocator_statistics&
+get_allocator_statistics()
+{
+    static allocator_statistics stats;
+    return stats;
+}
 
-/**
- * @}
- */
+}
 
-
-
-#endif // STDGPU_ATOMIC_FWD

--- a/test/test_memory_utils.h
+++ b/test/test_memory_utils.h
@@ -1,0 +1,118 @@
+/*
+ *  Copyright 2021 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef TEST_MEMORY_UTILS_H
+#define TEST_MEMORY_UTILS_H
+
+#include <stdgpu/cstddef.h>
+#include <stdgpu/memory.h>
+
+
+
+namespace test_utils
+{
+    /**
+     * \brief A statistics class for allocators
+     */
+    struct allocator_statistics
+    {
+        /**
+         * \brief Resets the statistics
+         */
+        void
+        reset();
+
+        stdgpu::index_t default_constructions = 0;      /**< The number of default constructions */     // NOLINT(misc-non-private-member-variables-in-classes)
+        stdgpu::index_t copy_constructions = 0;         /**< The number of copy constructions */        // NOLINT(misc-non-private-member-variables-in-classes)
+        stdgpu::index_t destructions = 0;               /**< The number of destructions */              // NOLINT(misc-non-private-member-variables-in-classes)
+    };
+
+    /**
+     * \brief Returns the global allocator statistics
+     */
+    allocator_statistics&
+    get_allocator_statistics();
+
+
+    /**
+     * \brief A test allocator for device memory
+     * \tparam T A type
+     */
+    template <typename T>
+    class test_device_allocator
+    {
+        public:
+            using base_type = stdgpu::safe_device_allocator<T>;         /**< stdgpu::safe_device_allocator<T> */
+            using value_type = typename base_type::value_type;          /**< base_type::value_type */
+
+            /**
+             * \brief Default constructor
+             */
+            test_device_allocator();
+
+            /**
+             * \brief Destructor
+             */
+            ~test_device_allocator();
+
+            /**
+             * \brief Copy constructor
+             * \param[in] other The allocator to be copied from
+             */
+            test_device_allocator(const test_device_allocator& other);
+
+            /**
+             * \brief Deleted copy assignment operator
+             */
+            test_device_allocator&
+            operator=(const test_device_allocator&) = delete;
+
+            /**
+             * \brief Copy constructor
+             * \tparam U Another type
+             * \param[in] other The allocator to be copied from
+             */
+            template <typename U>
+            explicit test_device_allocator(const test_device_allocator<U>& other);
+
+            /**
+             * \brief Allocates a memory block of the given size
+             * \param[in] n The size of the memory block in bytes
+             * \return A pointer to the allocated memory block
+             */
+            STDGPU_NODISCARD T*
+            allocate(stdgpu::index64_t n);
+
+            /**
+             * \brief Deallocates the given memory block
+             * \param[in] p A pointer to the memory block
+             * \param[in] n The size of the memory block in bytes (must match the size during allocation)
+             */
+            void
+            deallocate(T* p,
+                       stdgpu::index64_t n);
+
+       private:
+            base_type _base_allocator;
+    };
+}
+
+
+
+#include <test_memory_utils_detail.h>
+
+
+
+#endif // TEST_MEMORY_UTILS_H

--- a/test/test_memory_utils_detail.h
+++ b/test/test_memory_utils_detail.h
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2021 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef TEST_MEMORY_UTILS_DETAIL_H
+#define TEST_MEMORY_UTILS_DETAIL_H
+
+
+namespace test_utils
+{
+
+template <typename T>
+test_device_allocator<T>::test_device_allocator()
+{
+    get_allocator_statistics().default_constructions++;
+}
+
+
+template <typename T>
+test_device_allocator<T>::~test_device_allocator()
+{
+    get_allocator_statistics().destructions++;
+}
+
+
+template <typename T>
+test_device_allocator<T>::test_device_allocator(const test_device_allocator& other)
+    : _base_allocator(other._base_allocator)
+{
+    get_allocator_statistics().copy_constructions++;
+}
+
+
+template <typename T>
+template <typename U>
+test_device_allocator<T>::test_device_allocator(const test_device_allocator<U>& other)
+    : _base_allocator(other._base_allocator)
+{
+    get_allocator_statistics().copy_constructions++;
+}
+
+
+template <typename T>
+STDGPU_NODISCARD T*
+test_device_allocator<T>::allocate(stdgpu::index64_t n)
+{
+    return _base_allocator.allocate(n);
+}
+
+
+template <typename T>
+void
+test_device_allocator<T>::deallocate(T* p,
+                                     stdgpu::index64_t n)
+{
+    _base_allocator.deallocate(p, n);
+}
+
+}
+
+
+
+#endif // TEST_MEMORY_UTILS_DETAIL_H


### PR DESCRIPTION
Although `atomic` internally uses an allocator to construct the internal value, it did not expose any API regarding this relationship. Extend its API and add support for custom allocators. This makes `atomic` become closer to a container and makes the differences to the C++ standard library easier to understand.