### PR TITLE
bitset: Add support for custom allocators

### DIFF
--- a/examples/cuda/bitset.cu
+++ b/examples/cuda/bitset.cu
@@ -38,7 +38,7 @@ struct is_odd
 __global__ void
 set_bits(const int* d_result,
          const stdgpu::index_t d_result_size,
-         stdgpu::bitset bits,
+         stdgpu::bitset<> bits,
          stdgpu::atomic<int> counter)
 {
     stdgpu::index_t i = static_cast<stdgpu::index_t>(blockIdx.x * blockDim.x + threadIdx.x);
@@ -67,7 +67,7 @@ main()
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n / 2);
-    stdgpu::bitset bits = stdgpu::bitset::createDeviceObject(n);
+    stdgpu::bitset<> bits = stdgpu::bitset<>::createDeviceObject(n);
     stdgpu::atomic<int> counter = stdgpu::atomic<int>::createDeviceObject();
 
     thrust::sequence(stdgpu::device_begin(d_input), stdgpu::device_end(d_input),
@@ -106,7 +106,7 @@ main()
 
     destroyDeviceArray<int>(d_input);
     destroyDeviceArray<int>(d_result);
-    stdgpu::bitset::destroyDeviceObject(bits);
+    stdgpu::bitset<>::destroyDeviceObject(bits);
     stdgpu::atomic<int>::destroyDeviceObject(counter);
 }
 

--- a/examples/openmp/bitset.cpp
+++ b/examples/openmp/bitset.cpp
@@ -38,7 +38,7 @@ struct is_odd
 void
 set_bits(const int* d_result,
          const stdgpu::index_t d_result_size,
-         stdgpu::bitset& bits,
+         stdgpu::bitset<>& bits,
          stdgpu::atomic<int>& counter)
 {
     #pragma omp parallel for
@@ -67,7 +67,7 @@ main()
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n / 2);
-    stdgpu::bitset bits = stdgpu::bitset::createDeviceObject(n);
+    stdgpu::bitset<> bits = stdgpu::bitset<>::createDeviceObject(n);
     stdgpu::atomic<int> counter = stdgpu::atomic<int>::createDeviceObject();
 
     thrust::sequence(stdgpu::device_begin(d_input), stdgpu::device_end(d_input),
@@ -101,7 +101,7 @@ main()
 
     destroyDeviceArray<int>(d_input);
     destroyDeviceArray<int>(d_result);
-    stdgpu::bitset::destroyDeviceObject(bits);
+    stdgpu::bitset<>::destroyDeviceObject(bits);
     stdgpu::atomic<int>::destroyDeviceObject(counter);
 }
 

--- a/src/stdgpu/bitset_fwd
+++ b/src/stdgpu/bitset_fwd
@@ -31,6 +31,12 @@
 namespace stdgpu
 {
 
+template <typename T>
+struct safe_device_allocator;
+
+using bitset_default_type = unsigned int;   /**< The default type of the internal block data structure */
+
+template <typename Block = bitset_default_type, typename Allocator = safe_device_allocator<Block>>
 class bitset;
 
 } // namespace stdgpu

--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -325,7 +325,7 @@ class deque
 
         T* _data = nullptr;
         mutex_array _locks = {};
-        bitset _occupied = {};
+        bitset<> _occupied = {};
         atomic<int> _size = {};
         atomic<unsigned int> _begin = {};
         atomic<unsigned int> _end = {};

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -37,7 +37,7 @@ deque<T>::createDeviceObject(const index_t& capacity)
     deque<T> result;
     result._data     = allocator_traits<allocator_type>::allocate(result._allocator, capacity);
     result._locks    = mutex_array::createDeviceObject(capacity);
-    result._occupied = bitset::createDeviceObject(capacity);
+    result._occupied = bitset<>::createDeviceObject(capacity);
     result._size     = atomic<int>::createDeviceObject();
     result._begin    = atomic<unsigned int>::createDeviceObject();
     result._end      = atomic<unsigned int>::createDeviceObject();
@@ -59,7 +59,7 @@ deque<T>::destroyDeviceObject(deque<T>& device_object)
 
     allocator_traits<allocator_type>::deallocate(device_object._allocator, device_object._data, device_object._capacity);
     mutex_array::destroyDeviceObject(device_object._locks);
-    bitset::destroyDeviceObject(device_object._occupied);
+    bitset<>::destroyDeviceObject(device_object._occupied);
     atomic<int>::destroyDeviceObject(device_object._size);
     atomic<unsigned int>::destroyDeviceObject(device_object._begin);
     atomic<unsigned int>::destroyDeviceObject(device_object._end);

--- a/src/stdgpu/impl/mutex_detail.cuh
+++ b/src/stdgpu/impl/mutex_detail.cuh
@@ -27,7 +27,7 @@ namespace stdgpu
 {
 
 inline STDGPU_HOST_DEVICE
-mutex_array::reference::reference(const bitset::reference& bit_ref)
+mutex_array::reference::reference(const bitset<>::reference& bit_ref)
     : _bit_ref(bit_ref)
 {
 
@@ -63,7 +63,7 @@ inline mutex_array
 mutex_array::createDeviceObject(const index_t& size)
 {
     mutex_array result;
-    result._lock_bits = bitset::createDeviceObject(size);
+    result._lock_bits = bitset<>::createDeviceObject(size);
     result._size  = size;
 
     return result;
@@ -73,7 +73,7 @@ mutex_array::createDeviceObject(const index_t& size)
 inline void
 mutex_array::destroyDeviceObject(mutex_array& device_object)
 {
-    bitset::destroyDeviceObject(device_object._lock_bits);
+    bitset<>::destroyDeviceObject(device_object._lock_bits);
     device_object._size = 0;
 }
 

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -409,7 +409,7 @@ class unordered_base
         index_t _excess_count = 0;                      /**< The number of excess entries */                // NOLINT(misc-non-private-member-variables-in-classes)
         value_type* _values = nullptr;                  /**< The values */                                  // NOLINT(misc-non-private-member-variables-in-classes)
         index_t* _offsets = nullptr;                    /**< The offset to model linked list */             // NOLINT(misc-non-private-member-variables-in-classes)
-        bitset _occupied = {};                          /**< The indicator array for occupied entries */    // NOLINT(misc-non-private-member-variables-in-classes)
+        bitset<> _occupied = {};                        /**< The indicator array for occupied entries */    // NOLINT(misc-non-private-member-variables-in-classes)
         atomic<int> _occupied_count = {};               /**< The number of occupied entries */              // NOLINT(misc-non-private-member-variables-in-classes)
         vector<index_t> _excess_list_positions = {};    /**< The excess list positions */                   // NOLINT(misc-non-private-member-variables-in-classes)
         mutex_array _locks = {};                        /**< The locks used to insert and erase entries */  // NOLINT(misc-non-private-member-variables-in-classes)

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -1106,7 +1106,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::createDeviceObject(con
     result._excess_count            = excess_count;
     result._values                  = allocator_traits<allocator_type>::allocate(result._allocator, total_count);
     result._offsets                 = createDeviceArray<index_t>(total_count, 0);
-    result._occupied                = bitset::createDeviceObject(total_count);
+    result._occupied                = bitset<>::createDeviceObject(total_count);
     result._occupied_count          = atomic<int>::createDeviceObject();
     result._locks                   = mutex_array::createDeviceObject(total_count);
     result._excess_list_positions   = vector<index_t>::createDeviceObject(excess_count);
@@ -1140,7 +1140,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::destroyDeviceObject(un
     device_object._bucket_count = 0;
     device_object._excess_count = 0;
     destroyDeviceArray<index_t>(device_object._offsets);
-    bitset::destroyDeviceObject(device_object._occupied);
+    bitset<>::destroyDeviceObject(device_object._occupied);
     atomic<int>::destroyDeviceObject(device_object._occupied_count);
     mutex_array::destroyDeviceObject(device_object._locks);
     vector<index_t>::destroyDeviceObject(device_object._excess_list_positions);

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -40,7 +40,7 @@ vector<T>::createDeviceObject(const index_t& capacity)
     vector<T> result;
     result._data     = allocator_traits<allocator_type>::allocate(result._allocator, capacity);
     result._locks    = mutex_array::createDeviceObject(capacity);
-    result._occupied = bitset::createDeviceObject(capacity);
+    result._occupied = bitset<>::createDeviceObject(capacity);
     result._size     = atomic<int>::createDeviceObject();
     result._capacity = capacity;
 
@@ -58,7 +58,7 @@ vector<T>::destroyDeviceObject(vector<T>& device_object)
 
     allocator_traits<allocator_type>::deallocate(device_object._allocator, device_object._data, device_object._capacity);
     mutex_array::destroyDeviceObject(device_object._locks);
-    bitset::destroyDeviceObject(device_object._occupied);
+    bitset<>::destroyDeviceObject(device_object._occupied);
     atomic<int>::destroyDeviceObject(device_object._size);
     device_object._capacity = 0;
 }

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -102,9 +102,9 @@ class mutex_array
                 friend mutex_array;
 
                 STDGPU_HOST_DEVICE
-                explicit reference(const bitset::reference& bit_ref);
+                explicit reference(const bitset<>::reference& bit_ref);
 
-                bitset::reference _bit_ref;
+                bitset<>::reference _bit_ref;
         };
 
         /**
@@ -170,7 +170,7 @@ class mutex_array
         valid() const;
 
     private:
-        bitset _lock_bits = {};
+        bitset<> _lock_bits = {};
         index_t _size = 0;
 };
 

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -391,7 +391,7 @@ class vector
 
         T* _data = nullptr;
         mutex_array _locks = {};
-        bitset _occupied = {};
+        bitset<> _occupied = {};
         atomic<int> _size = {};
         index_t _capacity = 0;
         allocator_type _allocator = {};

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -25,6 +25,7 @@
 #include <thrust/transform.h>
 
 #include <test_utils.h>
+#include <test_memory_utils.h>
 #include <stdgpu/bitset.cuh>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
@@ -37,24 +38,24 @@ class stdgpu_bitset : public ::testing::Test
         // Called before each test
         void SetUp() override
         {
-            bitset = stdgpu::bitset::createDeviceObject(bitset_size);
+            bitset = stdgpu::bitset<>::createDeviceObject(bitset_size);
         }
 
         // Called after each test
         void TearDown() override
         {
-            stdgpu::bitset::destroyDeviceObject(bitset);
+            stdgpu::bitset<>::destroyDeviceObject(bitset);
         }
 
         const stdgpu::index_t bitset_size = 1048576; // NOLINT(misc-non-private-member-variables-in-classes)
-        stdgpu::bitset bitset = {}; // NOLINT(misc-non-private-member-variables-in-classes)
+        stdgpu::bitset<> bitset = {}; // NOLINT(misc-non-private-member-variables-in-classes)
 };
 
 
 
 TEST_F(stdgpu_bitset, empty_container)
 {
-    stdgpu::bitset empty_container;
+    stdgpu::bitset<> empty_container;
 
     EXPECT_TRUE(empty_container.empty());
     EXPECT_EQ(empty_container.size(), 0);
@@ -77,7 +78,7 @@ TEST_F(stdgpu_bitset, default_values)
 class set_all_bits
 {
     public:
-        explicit set_all_bits(const stdgpu::bitset& bitset)
+        explicit set_all_bits(const stdgpu::bitset<>& bitset)
             : _bitset(bitset)
         {
 
@@ -93,14 +94,14 @@ class set_all_bits
         }
 
     private:
-        stdgpu::bitset _bitset;
+        stdgpu::bitset<> _bitset;
 };
 
 
 class reset_all_bits
 {
     public:
-        explicit reset_all_bits(const stdgpu::bitset& bitset)
+        explicit reset_all_bits(const stdgpu::bitset<>& bitset)
             : _bitset(bitset)
         {
 
@@ -116,14 +117,14 @@ class reset_all_bits
         }
 
     private:
-        stdgpu::bitset _bitset;
+        stdgpu::bitset<> _bitset;
 };
 
 
 class set_and_reset_all_bits
 {
     public:
-        explicit set_and_reset_all_bits(const stdgpu::bitset& bitset)
+        explicit set_and_reset_all_bits(const stdgpu::bitset<>& bitset)
             : _bitset(bitset)
         {
 
@@ -144,14 +145,14 @@ class set_and_reset_all_bits
         }
 
     private:
-        stdgpu::bitset _bitset;
+        stdgpu::bitset<> _bitset;
 };
 
 
 class flip_all_bits
 {
     public:
-        explicit flip_all_bits(const stdgpu::bitset& bitset)
+        explicit flip_all_bits(const stdgpu::bitset<>& bitset)
             : _bitset(bitset)
         {
 
@@ -167,7 +168,7 @@ class flip_all_bits
         }
 
     private:
-        stdgpu::bitset _bitset;
+        stdgpu::bitset<> _bitset;
 };
 
 
@@ -299,7 +300,7 @@ TEST_F(stdgpu_bitset, flip_all_bits_previously_set_componentwise)
 class read_all_bits
 {
     public:
-        explicit read_all_bits(const stdgpu::bitset& bitset)
+        explicit read_all_bits(const stdgpu::bitset<>& bitset)
             : _bitset(bitset)
         {
 
@@ -313,7 +314,7 @@ class read_all_bits
         }
 
     private:
-        stdgpu::bitset _bitset;
+        stdgpu::bitset<> _bitset;
 };
 
 
@@ -446,7 +447,7 @@ generate_shuffled_sequence(const stdgpu::index_t size)
 class set_bits
 {
     public:
-        set_bits(const stdgpu::bitset& bitset,
+        set_bits(const stdgpu::bitset<>& bitset,
                  stdgpu::index_t* positions,
                  std::uint8_t* set)
             : _bitset(bitset),
@@ -465,7 +466,7 @@ class set_bits
         }
 
     private:
-        stdgpu::bitset _bitset;
+        stdgpu::bitset<> _bitset;
         stdgpu::index_t* _positions;
         std::uint8_t* _set;
 };
@@ -474,7 +475,7 @@ class set_bits
 class reset_bits
 {
     public:
-        reset_bits(const stdgpu::bitset& bitset,
+        reset_bits(const stdgpu::bitset<>& bitset,
                    stdgpu::index_t* positions,
                    std::uint8_t* set)
             : _bitset(bitset),
@@ -493,7 +494,7 @@ class reset_bits
         }
 
     private:
-        stdgpu::bitset _bitset;
+        stdgpu::bitset<> _bitset;
         stdgpu::index_t* _positions;
         std::uint8_t* _set;
 };
@@ -502,7 +503,7 @@ class reset_bits
 class set_and_reset_bits
 {
     public:
-        set_and_reset_bits(const stdgpu::bitset& bitset,
+        set_and_reset_bits(const stdgpu::bitset<>& bitset,
                            stdgpu::index_t* positions,
                            std::uint8_t* set)
             : _bitset(bitset),
@@ -526,7 +527,7 @@ class set_and_reset_bits
         }
 
     private:
-        stdgpu::bitset _bitset;
+        stdgpu::bitset<> _bitset;
         stdgpu::index_t* _positions;
         std::uint8_t* _set;
 };
@@ -535,7 +536,7 @@ class set_and_reset_bits
 class flip_bits
 {
     public:
-        flip_bits(const stdgpu::bitset& bitset,
+        flip_bits(const stdgpu::bitset<>& bitset,
                   stdgpu::index_t* positions,
                   std::uint8_t* set)
             : _bitset(bitset),
@@ -554,7 +555,7 @@ class flip_bits
         }
 
     private:
-        stdgpu::bitset _bitset;
+        stdgpu::bitset<> _bitset;
         stdgpu::index_t* _positions;
         std::uint8_t* _set;
 };
@@ -732,6 +733,52 @@ TEST_F(stdgpu_bitset, flip_random_bits_previously_set)
 
     destroyDeviceArray<stdgpu::index_t>(random_sequence);
     destroyHostArray<stdgpu::index_t>(host_random_sequence);
+}
+
+
+TEST_F(stdgpu_bitset, get_allocator)
+{
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::bitset<> bits = stdgpu::bitset<>::createDeviceObject(N);
+
+    stdgpu::bitset<>::allocator_type a = bits.get_allocator();
+
+    stdgpu::bitset_default_type* array = a.allocate(N);
+    a.deallocate(array, N);
+
+    stdgpu::bitset<>::destroyDeviceObject(bits);
+}
+
+
+TEST_F(stdgpu_bitset, custom_allocator)
+{
+    test_utils::get_allocator_statistics().reset();
+
+    {
+        const stdgpu::index_t N = 10000;
+
+        using Allocator = test_utils::test_device_allocator<stdgpu::bitset_default_type>;
+        Allocator a_orig;
+
+        stdgpu::bitset<stdgpu::bitset_default_type, Allocator> bits = stdgpu::bitset<stdgpu::bitset_default_type, Allocator>::createDeviceObject(N, a_orig);
+
+        stdgpu::bitset<stdgpu::bitset_default_type, Allocator>::allocator_type a = bits.get_allocator();
+
+        stdgpu::bitset_default_type* array = a.allocate(N);
+        a.deallocate(array, N);
+
+        stdgpu::bitset<stdgpu::bitset_default_type, Allocator>::destroyDeviceObject(bits);
+    }
+
+    // Account for potential but not guaranteed copy-ellision
+    EXPECT_EQ(test_utils::get_allocator_statistics().default_constructions, 1);
+    EXPECT_GE(test_utils::get_allocator_statistics().copy_constructions, 2);
+    EXPECT_LE(test_utils::get_allocator_statistics().copy_constructions, 3);
+    EXPECT_GE(test_utils::get_allocator_statistics().destructions, 3);
+    EXPECT_LE(test_utils::get_allocator_statistics().destructions, 4);
+
+    test_utils::get_allocator_statistics().reset();
 }
 
 


### PR DESCRIPTION
Although `bitset` internally uses an allocator to construct the internal value, it did not expose any API regarding this relationship. Extend its API and add support for custom allocators. This makes `bitset` become closer to a container (and boost's `dynamic_bitset`, see #54 for a discussion) and makes the differences to the C++ standard library easier to understand.