### PR TITLE
vector: Add support for custom allocators

### DIFF
--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -1082,7 +1082,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual>::clear()
 
     _occupied_count.store(0);
 
-    auto reset_excess_list_positions = detail::vector_clear_fill<index_t>(_excess_list_positions);
+    auto reset_excess_list_positions = detail::vector_clear_fill<index_t, typename vector<index_t>::allocator_type>(_excess_list_positions);
     reset_excess_list_positions(thrust::counting_iterator<index_t>(bucket_count()), thrust::counting_iterator<index_t>(total_count()));
 }
 

--- a/src/stdgpu/vector_fwd
+++ b/src/stdgpu/vector_fwd
@@ -32,6 +32,9 @@ namespace stdgpu
 {
 
 template <typename T>
+struct safe_device_allocator;
+
+template <typename T, typename Allocator = safe_device_allocator<T>>
 class vector;
 
 } // namespace stdgpu

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -20,6 +20,7 @@
 #include <thrust/reduce.h>
 #include <thrust/sort.h>
 
+#include <test_memory_utils.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/vector.cuh>
@@ -1704,6 +1705,37 @@ TEST_F(stdgpu_vector, get_allocator)
     a.deallocate(array, N);
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
+}
+
+
+TEST_F(stdgpu_vector, custom_allocator)
+{
+    test_utils::get_allocator_statistics().reset();
+
+    {
+        const stdgpu::index_t N = 10000;
+
+        using Allocator = test_utils::test_device_allocator<int>;
+        Allocator a_orig;
+
+        stdgpu::vector<int, Allocator> pool = stdgpu::vector<int, Allocator>::createDeviceObject(N, a_orig);
+
+        stdgpu::vector<int, Allocator>::allocator_type a = pool.get_allocator();
+
+        int* array = a.allocate(N);
+        a.deallocate(array, N);
+
+        stdgpu::vector<int, Allocator>::destroyDeviceObject(pool);
+    }
+
+    // Account for potential but not guaranteed copy-ellision
+    EXPECT_EQ(test_utils::get_allocator_statistics().default_constructions, 1);
+    EXPECT_GE(test_utils::get_allocator_statistics().copy_constructions, 14);
+    EXPECT_LE(test_utils::get_allocator_statistics().copy_constructions, 24);
+    EXPECT_GE(test_utils::get_allocator_statistics().destructions, 15);
+    EXPECT_LE(test_utils::get_allocator_statistics().destructions, 25);
+
+    test_utils::get_allocator_statistics().reset();
 }
 
 

--- a/test/test_memory_utils.h
+++ b/test/test_memory_utils.h
@@ -18,6 +18,7 @@
 
 #include <stdgpu/cstddef.h>
 #include <stdgpu/memory.h>
+#include <stdgpu/platform.h>
 
 
 
@@ -60,17 +61,20 @@ namespace test_utils
             /**
              * \brief Default constructor
              */
+            STDGPU_HOST_DEVICE
             test_device_allocator();
 
             /**
              * \brief Destructor
              */
+            STDGPU_HOST_DEVICE
             ~test_device_allocator();
 
             /**
              * \brief Copy constructor
              * \param[in] other The allocator to be copied from
              */
+            STDGPU_HOST_DEVICE
             test_device_allocator(const test_device_allocator& other);
 
             /**
@@ -85,7 +89,8 @@ namespace test_utils
              * \param[in] other The allocator to be copied from
              */
             template <typename U>
-            explicit test_device_allocator(const test_device_allocator<U>& other);
+            explicit STDGPU_HOST_DEVICE
+            test_device_allocator(const test_device_allocator<U>& other);
 
             /**
              * \brief Allocates a memory block of the given size
@@ -103,9 +108,6 @@ namespace test_utils
             void
             deallocate(T* p,
                        stdgpu::index64_t n);
-
-       private:
-            base_type _base_allocator;
     };
 }
 

--- a/test/test_memory_utils_detail.h
+++ b/test/test_memory_utils_detail.h
@@ -16,38 +16,50 @@
 #ifndef TEST_MEMORY_UTILS_DETAIL_H
 #define TEST_MEMORY_UTILS_DETAIL_H
 
+#include <stdgpu/attribute.h>
+
 
 namespace test_utils
 {
 
 template <typename T>
+STDGPU_HOST_DEVICE
 test_device_allocator<T>::test_device_allocator()
 {
-    get_allocator_statistics().default_constructions++;
+    #if STDGPU_CODE == STDGPU_CODE_HOST || STDGPU_BACKEND == STDGPU_BACKEND_OPENMP
+        get_allocator_statistics().default_constructions++;
+    #endif
 }
 
 
 template <typename T>
+STDGPU_HOST_DEVICE
 test_device_allocator<T>::~test_device_allocator()
 {
-    get_allocator_statistics().destructions++;
+    #if STDGPU_CODE == STDGPU_CODE_HOST || STDGPU_BACKEND == STDGPU_BACKEND_OPENMP
+        get_allocator_statistics().destructions++;
+    #endif
 }
 
 
 template <typename T>
-test_device_allocator<T>::test_device_allocator(const test_device_allocator& other)
-    : _base_allocator(other._base_allocator)
+STDGPU_HOST_DEVICE
+test_device_allocator<T>::test_device_allocator(STDGPU_MAYBE_UNUSED const test_device_allocator& other)
 {
-    get_allocator_statistics().copy_constructions++;
+    #if STDGPU_CODE == STDGPU_CODE_HOST || STDGPU_BACKEND == STDGPU_BACKEND_OPENMP
+        get_allocator_statistics().copy_constructions++;
+    #endif
 }
 
 
 template <typename T>
 template <typename U>
-test_device_allocator<T>::test_device_allocator(const test_device_allocator<U>& other)
-    : _base_allocator(other._base_allocator)
+STDGPU_HOST_DEVICE
+test_device_allocator<T>::test_device_allocator(STDGPU_MAYBE_UNUSED const test_device_allocator<U>& other)
 {
-    get_allocator_statistics().copy_constructions++;
+    #if STDGPU_CODE == STDGPU_CODE_HOST || STDGPU_BACKEND == STDGPU_BACKEND_OPENMP
+        get_allocator_statistics().copy_constructions++;
+    #endif
 }
 
 
@@ -55,7 +67,7 @@ template <typename T>
 STDGPU_NODISCARD T*
 test_device_allocator<T>::allocate(stdgpu::index64_t n)
 {
-    return _base_allocator.allocate(n);
+    return base_type().allocate(n);
 }
 
 
@@ -64,7 +76,7 @@ void
 test_device_allocator<T>::deallocate(T* p,
                                      stdgpu::index64_t n)
 {
-    _base_allocator.deallocate(p, n);
+    base_type().deallocate(p, n);
 }
 
 }


### PR DESCRIPTION
Although the interface of `vector` is close to the one in the C++ standard, it still has some limitations. Add support for custom allocators to narrow the gap. Custom allocators are required to be contructible and copyable on both the host and the device.