### PR TITLE
Container: Fix host device annotation for get_allocator function

### DIFF
--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -146,7 +146,7 @@ class atomic
          * \brief Returns the container allocator
          * \return The container allocator
          */
-        allocator_type
+        STDGPU_HOST_DEVICE allocator_type
         get_allocator() const;
 
 

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -184,7 +184,7 @@ class bitset
          * \brief Returns the container allocator
          * \return The container allocator
          */
-        allocator_type
+        STDGPU_HOST_DEVICE allocator_type
         get_allocator() const;
 
         /**

--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -116,7 +116,7 @@ class deque
          * \brief Returns the container allocator
          * \return The container allocator
          */
-        allocator_type
+        STDGPU_HOST_DEVICE allocator_type
         get_allocator() const;
 
         /**

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -184,7 +184,7 @@ atomic<T, Allocator>::atomic(const Allocator& allocator)
 
 
 template <typename T, typename Allocator>
-inline typename atomic<T, Allocator>::allocator_type
+inline STDGPU_HOST_DEVICE typename atomic<T, Allocator>::allocator_type
 atomic<T, Allocator>::get_allocator() const
 {
     return _allocator;

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -214,7 +214,7 @@ bitset<Block, Allocator>::bitset(const Allocator& allocator)
 
 
 template <typename Block, typename Allocator>
-inline typename bitset<Block, Allocator>::allocator_type
+inline STDGPU_HOST_DEVICE typename bitset<Block, Allocator>::allocator_type
 bitset<Block, Allocator>::get_allocator() const
 {
     return _allocator;

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -91,7 +91,7 @@ deque<T, Allocator>::deque(const mutex_array<mutex_default_type, mutex_array_all
 
 
 template <typename T, typename Allocator>
-inline typename deque<T, Allocator>::allocator_type
+inline STDGPU_HOST_DEVICE typename deque<T, Allocator>::allocator_type
 deque<T, Allocator>::get_allocator() const
 {
     return _allocator;

--- a/src/stdgpu/impl/mutex_detail.cuh
+++ b/src/stdgpu/impl/mutex_detail.cuh
@@ -97,7 +97,7 @@ mutex_array<Block, Allocator>::mutex_array(const bitset<Block, Allocator>& lock_
 
 
 template <typename Block, typename Allocator>
-inline typename mutex_array<Block, Allocator>::allocator_type
+inline STDGPU_HOST_DEVICE typename mutex_array<Block, Allocator>::allocator_type
 mutex_array<Block, Allocator>::get_allocator() const
 {
     return _allocator;

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -81,7 +81,7 @@ vector<T, Allocator>::vector(const mutex_array<mutex_default_type, mutex_array_a
 
 
 template <typename T, typename Allocator>
-inline typename vector<T, Allocator>::allocator_type
+inline STDGPU_HOST_DEVICE typename vector<T, Allocator>::allocator_type
 vector<T, Allocator>::get_allocator() const
 {
     return _allocator;

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -141,7 +141,7 @@ class mutex_array
          * \brief Returns the container allocator
          * \return The container allocator
          */
-        allocator_type
+        STDGPU_HOST_DEVICE allocator_type
         get_allocator() const;
 
         /**

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -133,7 +133,7 @@ class vector
          * \brief Returns the container allocator
          * \return The container allocator
          */
-        allocator_type
+        STDGPU_HOST_DEVICE allocator_type
         get_allocator() const;
 
         /**


### PR DESCRIPTION
While introducing the `Allocator` template parameter, the interface of the `get_allocator` member functions has changed to allow for less restrict definitions of custom allocators. However, the allocator might still be accessed in device code. Fix missing `STDGPU_HOST_DEVICE` annotation and consider custom allocators for be constructible and copyable on both the host and the device.