### PR TITLE
Container: Minimize size of container structures

### DIFF
--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -412,7 +412,6 @@ class atomic
     private:
         explicit atomic(const Allocator& allocator);
 
-        T* _value = nullptr;
         atomic_ref<T> _value_ref;
         allocator_type _allocator = {};
 };

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -309,10 +309,11 @@ class bitset
     private:
         explicit bitset(const Allocator& allocator);
 
+        static index_t number_bit_blocks(const index_t size);
+
         static constexpr index_t _bits_per_block = std::numeric_limits<block_type>::digits;
 
         block_type* _bit_blocks = nullptr;
-        index_t _number_bit_blocks = 0;
         index_t _size = 0;
         allocator_type _allocator = {};
 };

--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -39,7 +39,6 @@
 #include <stdgpu/mutex.cuh>
 #include <stdgpu/platform.h>
 #include <stdgpu/ranges.h>
-#include <stdgpu/vector.cuh>
 
 
 
@@ -337,19 +336,17 @@ class deque
               const atomic<int, atomic_int_allocator_type>& size,
               const atomic<unsigned int, atomic_uint_allocator_type>& begin,
               const atomic<unsigned int, atomic_uint_allocator_type>& end,
-              const Allocator& allocator,
-              const vector<index_t, index_allocator_type>& range_indices);
+              const Allocator& allocator);
 
         T* _data = nullptr;
+        mutable index_t* _range_indices = nullptr;
         mutex_array<mutex_default_type, mutex_array_allocator_type> _locks = {};
         bitset<bitset_default_type, bitset_allocator_type> _occupied = {};
         atomic<int, atomic_int_allocator_type> _size = {};
         atomic<unsigned int, atomic_uint_allocator_type> _begin = {};
         atomic<unsigned int, atomic_uint_allocator_type> _end = {};
-        index_t _capacity = 0;
         allocator_type _allocator = {};
-
-        mutable vector<index_t, index_allocator_type> _range_indices = {};
+        index_allocator_type _index_allocator = {};
 };
 
 } // namespace stdgpu

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -148,8 +148,7 @@ inline atomic<T, Allocator>
 atomic<T, Allocator>::createDeviceObject(const Allocator& allocator)
 {
     atomic<T, Allocator> result(allocator);
-    result._value = createDeviceArray<T, allocator_type>(result._allocator, 1, 0);
-    result._value_ref = atomic_ref<T>(result._value);
+    result._value_ref._value = createDeviceArray<T, allocator_type>(result._allocator, 1, 0);
 
     return result;
 }
@@ -159,8 +158,7 @@ template <typename T, typename Allocator>
 inline void
 atomic<T, Allocator>::destroyDeviceObject(atomic<T, Allocator>& device_object)
 {
-    destroyDeviceArray<T, allocator_type>(device_object._allocator, device_object._value);
-    device_object._value_ref = atomic_ref<T>(nullptr);
+    destroyDeviceArray<T, allocator_type>(device_object._allocator, device_object._value_ref._value);
 }
 
 

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -186,8 +186,7 @@ bitset<Block, Allocator>::createDeviceObject(const index_t& size,
                                              const Allocator& allocator)
 {
     bitset<Block, Allocator> result(allocator);
-    result._number_bit_blocks   = detail::div_up(size, _bits_per_block);
-    result._bit_blocks          = createDeviceArray<block_type, Allocator>(result._allocator, result._number_bit_blocks, static_cast<block_type>(0));
+    result._bit_blocks          = createDeviceArray<block_type, Allocator>(result._allocator, number_bit_blocks(size), static_cast<block_type>(0));
     result._size                = size;
 
     return result;
@@ -210,6 +209,14 @@ bitset<Block, Allocator>::bitset(const Allocator& allocator)
     : _allocator(allocator)
 {
 
+}
+
+
+template <typename Block, typename Allocator>
+inline index_t
+bitset<Block, Allocator>::number_bit_blocks(const index_t size)
+{
+    return detail::div_up(size, _bits_per_block);
 }
 
 
@@ -353,7 +360,7 @@ bitset<Block, Allocator>::count() const
                                                          0,
                                                          thrust::plus<index_t>());
 
-    index_t last_block_count = thrust::transform_reduce(thrust::counting_iterator<index_t>((_number_bit_blocks - 1) * _bits_per_block), thrust::counting_iterator<index_t>(size()),
+    index_t last_block_count = thrust::transform_reduce(thrust::counting_iterator<index_t>((number_bit_blocks(size()) - 1) * _bits_per_block), thrust::counting_iterator<index_t>(size()),
                                                         detail::count_bits<Block, Allocator>(*this),
                                                         0,
                                                         thrust::plus<index_t>());

--- a/src/stdgpu/impl/mutex_detail.cuh
+++ b/src/stdgpu/impl/mutex_detail.cuh
@@ -68,9 +68,7 @@ inline mutex_array<Block, Allocator>
 mutex_array<Block, Allocator>::createDeviceObject(const index_t& size,
                                                   const Allocator& allocator)
 {
-    mutex_array<Block, Allocator> result(bitset<Block, Allocator>::createDeviceObject(size, allocator),
-                                         allocator);
-    result._size  = size;
+    mutex_array<Block, Allocator> result(bitset<Block, Allocator>::createDeviceObject(size, allocator));
 
     return result;
 }
@@ -81,16 +79,13 @@ inline void
 mutex_array<Block, Allocator>::destroyDeviceObject(mutex_array<Block, Allocator>& device_object)
 {
     bitset<Block, Allocator>::destroyDeviceObject(device_object._lock_bits);
-    device_object._size = 0;
 }
 
 
 template <typename Block, typename Allocator>
 inline
-mutex_array<Block, Allocator>::mutex_array(const bitset<Block, Allocator>& lock_bits,
-                                           const Allocator& allocator)
-    : _lock_bits(lock_bits),
-      _allocator(allocator)
+mutex_array<Block, Allocator>::mutex_array(const bitset<Block, Allocator>& lock_bits)
+    : _lock_bits(lock_bits)
 {
 
 }
@@ -100,7 +95,7 @@ template <typename Block, typename Allocator>
 inline STDGPU_HOST_DEVICE typename mutex_array<Block, Allocator>::allocator_type
 mutex_array<Block, Allocator>::get_allocator() const
 {
-    return _allocator;
+    return _lock_bits.get_allocator();
 }
 
 
@@ -135,7 +130,7 @@ template <typename Block, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
 mutex_array<Block, Allocator>::size() const
 {
-    return _size;
+    return _lock_bits.size();
 }
 
 

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -16,7 +16,6 @@
 #ifndef STDGPU_UNORDERED_BASE_H
 #define STDGPU_UNORDERED_BASE_H
 
-#include <thrust/iterator/transform_iterator.h>
 #include <thrust/pair.h>
 
 #include <stdgpu/atomic.cuh>
@@ -418,24 +417,23 @@ class unordered_base
                        const atomic<int, atomic_allocator_type>& occupied_count,
                        const vector<index_t, index_allocator_type>& excess_list_positions,
                        const mutex_array<mutex_default_type, mutex_array_allocator_type>& locks,
-                       const Allocator& allocator,
-                       const vector<index_t, index_allocator_type>& range_indices);
+                       const atomic<int, atomic_allocator_type>& range_indices_end,
+                       const Allocator& allocator);
 
-        index_t _bucket_count = 0;                                                  /**< The number of buckets */                       // NOLINT(misc-non-private-member-variables-in-classes)
-        index_t _excess_count = 0;                                                  /**< The number of excess entries */                // NOLINT(misc-non-private-member-variables-in-classes)
         value_type* _values = nullptr;                                              /**< The values */                                  // NOLINT(misc-non-private-member-variables-in-classes)
         index_t* _offsets = nullptr;                                                /**< The offset to model linked list */             // NOLINT(misc-non-private-member-variables-in-classes)
         bitset<bitset_default_type, bitset_allocator_type> _occupied = {};          /**< The indicator array for occupied entries */    // NOLINT(misc-non-private-member-variables-in-classes)
         atomic<int, atomic_allocator_type> _occupied_count = {};                    /**< The number of occupied entries */              // NOLINT(misc-non-private-member-variables-in-classes)
         vector<index_t, index_allocator_type> _excess_list_positions = {};          /**< The excess list positions */                   // NOLINT(misc-non-private-member-variables-in-classes)
         mutex_array<mutex_default_type, mutex_array_allocator_type> _locks = {};    /**< The locks used to insert and erase entries */  // NOLINT(misc-non-private-member-variables-in-classes)
+        mutable index_t* _range_indices = nullptr;                                  /**< The offset to model linked list */             // NOLINT(misc-non-private-member-variables-in-classes)
+        mutable atomic<int, atomic_allocator_type> _range_indices_end = {};         /**< The number of occupied entries */              // NOLINT(misc-non-private-member-variables-in-classes)
+        index_t _bucket_count = 0;                                                  /**< The number of buckets */                       // NOLINT(misc-non-private-member-variables-in-classes)
         key_from_value _key_from_value = {};                                        /**< The value to key functor */                    // NOLINT(misc-non-private-member-variables-in-classes)
         key_equal _key_equal = {};                                                  /**< The key comparison functor */                  // NOLINT(misc-non-private-member-variables-in-classes)
         hasher _hash = {};                                                          /**< The hashing function */                        // NOLINT(misc-non-private-member-variables-in-classes)
         allocator_type _allocator = {};                                             /**< The allocator */                               // NOLINT(misc-non-private-member-variables-in-classes)
         index_allocator_type _index_allocator = {};                                 /**< The index allocator */                         // NOLINT(misc-non-private-member-variables-in-classes)
-
-        mutable vector<index_t, index_allocator_type> _range_indices = {};          /**< The buffer of range indices */                 // NOLINT(misc-non-private-member-variables-in-classes)
 
         STDGPU_HOST_DEVICE index_t
         total_count() const;

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -186,12 +186,9 @@ class mutex_array
         valid() const;
 
     private:
-        mutex_array(const bitset<Block, Allocator>& lock_bits,
-                    const Allocator& allocator);
+        explicit mutex_array(const bitset<Block, Allocator>& lock_bits);
 
         bitset<Block, Allocator> _lock_bits = {};
-        index_t _size = 0;
-        allocator_type _allocator = {};
 };
 
 

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -405,7 +405,6 @@ class vector
         mutex_array<mutex_default_type, mutex_array_allocator_type> _locks = {};
         bitset<bitset_default_type, bitset_allocator_type> _occupied = {};
         atomic<int, atomic_allocator_type> _size = {};
-        index_t _capacity = 0;
         allocator_type _allocator = {};
 };
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -2567,10 +2567,10 @@ TEST_F(stdgpu_deque, custom_allocator)
 
     // Account for potential but not guaranteed copy-ellision
     EXPECT_EQ(test_utils::get_allocator_statistics().default_constructions, 1);
-    EXPECT_GE(test_utils::get_allocator_statistics().copy_constructions, 39);
-    EXPECT_LE(test_utils::get_allocator_statistics().copy_constructions, 68);
-    EXPECT_GE(test_utils::get_allocator_statistics().destructions, 40);
-    EXPECT_LE(test_utils::get_allocator_statistics().destructions, 69);
+    EXPECT_GE(test_utils::get_allocator_statistics().copy_constructions, 19);
+    EXPECT_LE(test_utils::get_allocator_statistics().copy_constructions, 32);
+    EXPECT_GE(test_utils::get_allocator_statistics().destructions, 20);
+    EXPECT_LE(test_utils::get_allocator_statistics().destructions, 33);
 
     test_utils::get_allocator_statistics().reset();
 }

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -577,10 +577,10 @@ TEST_F(stdgpu_mutex, custom_allocator)
 
     // Account for potential but not guaranteed copy-ellision
     EXPECT_EQ(test_utils::get_allocator_statistics().default_constructions, 1);
-    EXPECT_GE(test_utils::get_allocator_statistics().copy_constructions, 4);
-    EXPECT_LE(test_utils::get_allocator_statistics().copy_constructions, 7);
-    EXPECT_GE(test_utils::get_allocator_statistics().destructions, 5);
-    EXPECT_LE(test_utils::get_allocator_statistics().destructions, 8);
+    EXPECT_GE(test_utils::get_allocator_statistics().copy_constructions, 3);
+    EXPECT_LE(test_utils::get_allocator_statistics().copy_constructions, 5);
+    EXPECT_GE(test_utils::get_allocator_statistics().destructions, 4);
+    EXPECT_LE(test_utils::get_allocator_statistics().destructions, 6);
 
     test_utils::get_allocator_statistics().reset();
 }

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -2555,10 +2555,10 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, custom_allocator)
 
     // Account for potential but not guaranteed copy-ellision
     EXPECT_EQ(test_utils::get_allocator_statistics().default_constructions, 1);
-    EXPECT_GE(test_utils::get_allocator_statistics().copy_constructions, 94);
-    EXPECT_LE(test_utils::get_allocator_statistics().copy_constructions, 151);
-    EXPECT_GE(test_utils::get_allocator_statistics().destructions, 95);
-    EXPECT_LE(test_utils::get_allocator_statistics().destructions, 152);
+    EXPECT_GE(test_utils::get_allocator_statistics().copy_constructions, 62);
+    EXPECT_LE(test_utils::get_allocator_statistics().copy_constructions, 95);
+    EXPECT_GE(test_utils::get_allocator_statistics().destructions, 63);
+    EXPECT_LE(test_utils::get_allocator_statistics().destructions, 96);
 
     test_utils::get_allocator_statistics().reset();
 }

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -1730,10 +1730,10 @@ TEST_F(stdgpu_vector, custom_allocator)
 
     // Account for potential but not guaranteed copy-ellision
     EXPECT_EQ(test_utils::get_allocator_statistics().default_constructions, 1);
-    EXPECT_GE(test_utils::get_allocator_statistics().copy_constructions, 14);
-    EXPECT_LE(test_utils::get_allocator_statistics().copy_constructions, 24);
-    EXPECT_GE(test_utils::get_allocator_statistics().destructions, 15);
-    EXPECT_LE(test_utils::get_allocator_statistics().destructions, 25);
+    EXPECT_GE(test_utils::get_allocator_statistics().copy_constructions, 12);
+    EXPECT_LE(test_utils::get_allocator_statistics().copy_constructions, 20);
+    EXPECT_GE(test_utils::get_allocator_statistics().destructions, 13);
+    EXPECT_LE(test_utils::get_allocator_statistics().destructions, 21);
 
     test_utils::get_allocator_statistics().reset();
 }


### PR DESCRIPTION
Adding support for custom allocators for the containers increased their structure size by a considerable amount. This may negatively impact the performance and block parts of the cache unnecessarily. Minimize the size of the container structures by removing redundant member variables or replace complex members with simpler variables. As a result, the sizes should no be on par or even lower than before adding custom allocator support.