### PR TITLE
cmake: Update support for CMake 3.23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.21)
+cmake_minimum_required(VERSION 3.15...3.23)
 
 
 project(stdgpu VERSION 1.3.0


### PR DESCRIPTION
CMake 3.23 has been recently released. Keep up with the pace of introduced behavioral changes by bumping the maximum supported policy version.