### PR TITLE
cmake: Add further hint for thrust system path

### DIFF
--- a/cmake/Findthrust.cmake
+++ b/cmake/Findthrust.cmake
@@ -4,6 +4,7 @@ find_path(THRUST_INCLUDE_DIR
           "/usr/include"
           "/usr/local/include"
           "/usr/local/cuda/include"
+          "/opt/cuda/include"
           NAMES
           "thrust/version.h")
 


### PR DESCRIPTION
The `Findthrust.cmake` module contains common paths for system installations on Debian/Ubuntu. However, Arch-based distributions prefer to install CUDA to `/opt/cuda`. Add this path to the list of hints to allow for correctly finding thrust on these systems.