### PR TITLE
General: Fix new compiler warnings by Clang 13

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: "-*,\
 bugprone-*,\
+-bugprone-easily-swappable-parameters,\
 hicpp-*,\
 -hicpp-avoid-c-arrays,\
 -hicpp-vararg,\
@@ -17,6 +18,7 @@ performance-*,\
 readability-*,\
 -readability-avoid-const-params-in-decls,\
 -readability-const-return-type,\
+-readability-function-cognitive-complexity,\
 -readability-magic-numbers,\
 "
 HeaderFilterRegex: 'src|test/stdgpu'

--- a/examples/createAndDestroyDeviceObject.cpp
+++ b/examples/createAndDestroyDeviceObject.cpp
@@ -30,7 +30,7 @@ class Image
         {
             Image result;
 
-            result._values = createDeviceArray<std::uint8_t>(width * height);
+            result._values = createDeviceArray<std::uint8_t>(static_cast<stdgpu::index64_t>(width) * static_cast<stdgpu::index64_t>(height));
             result._width = width;
             result._height = height;
 
@@ -51,7 +51,7 @@ class Image
         {
             Image result;
 
-            result._values = createHostArray<std::uint8_t>(width * height);
+            result._values = createHostArray<std::uint8_t>(static_cast<stdgpu::index64_t>(width) * static_cast<stdgpu::index64_t>(height));
             result._width = width;
             result._height = height;
 

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -516,6 +516,13 @@ struct safe_device_allocator
     explicit safe_device_allocator(const safe_device_allocator<U>& other);
 
     /**
+     * \brief Copy assignment operator
+     * \return *this
+     */
+    safe_device_allocator&
+    operator=(const safe_device_allocator&) = default;
+
+    /**
      * \brief Allocates a memory block of the given size
      * \param[in] n The size of the memory block in bytes
      * \return A pointer to the allocated memory block
@@ -568,6 +575,13 @@ struct safe_host_allocator
     explicit safe_host_allocator(const safe_host_allocator<U>& other);
 
     /**
+     * \brief Copy assignment operator
+     * \return *this
+     */
+    safe_host_allocator&
+    operator=(const safe_host_allocator&) = default;
+
+    /**
      * \brief Allocates a memory block of the given size
      * \param[in] n The size of the memory block in bytes
      * \return A pointer to the allocated memory block
@@ -618,6 +632,13 @@ struct safe_managed_allocator
      */
     template <typename U>
     explicit safe_managed_allocator(const safe_managed_allocator<U>& other);
+
+    /**
+     * \brief Copy assignment operator
+     * \return *this
+     */
+    safe_managed_allocator&
+    operator=(const safe_managed_allocator&) = default;
 
     /**
      * \brief Allocates a memory block of the given size

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -92,6 +92,7 @@ class lock_and_unlock
                     {
                         j += k;
                     }
+                    dummy_j += j;
 
                     //  END  --- critical section ---  END
                     leave_loop = true;
@@ -103,6 +104,7 @@ class lock_and_unlock
 
     private:
         stdgpu::mutex_array<> _locks;
+        long dummy_j = 0;
 };
 
 


### PR DESCRIPTION
Clang 13 introduced more warnings that could reveal potential bugs in the source code. Fix or suppress the new warnings to make the code compile cleanly again.