### PR TITLE
src: Simplify backend header includes

### DIFF
--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -16,23 +16,15 @@
 #ifndef STDGPU_ATOMIC_DETAIL_H
 #define STDGPU_ATOMIC_DETAIL_H
 
-#include <stdgpu/config.h>
-
-#if STDGPU_BACKEND == STDGPU_BACKEND_CUDA
-    #define STDGPU_BACKEND_ATOMIC_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/atomic.cuh> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
-    // cppcheck-suppress preprocessorErrorDirective
-    #include STDGPU_BACKEND_ATOMIC_HEADER
-    #undef STDGPU_BACKEND_ATOMIC_HEADER
-#else
-    #define STDGPU_BACKEND_ATOMIC_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/atomic.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
-    // cppcheck-suppress preprocessorErrorDirective
-    #include STDGPU_BACKEND_ATOMIC_HEADER
-    #undef STDGPU_BACKEND_ATOMIC_HEADER
-#endif
-
 #include <stdgpu/attribute.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
+
+#if STDGPU_BACKEND == STDGPU_BACKEND_CUDA
+    #include STDGPU_DETAIL_BACKEND_HEADER(atomic.cuh)
+#else
+    #include STDGPU_DETAIL_BACKEND_HEADER(atomic.h)
+#endif
 
 
 

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -19,14 +19,11 @@
 #include <map>
 #include <mutex>
 
-#include <stdgpu/config.h>
-
-#define STDGPU_BACKEND_MEMORY_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/memory.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
-// cppcheck-suppress preprocessorErrorDirective
-#include STDGPU_BACKEND_MEMORY_HEADER
-#undef STDGPU_BACKEND_MEMORY_HEADER
-
 #include <stdgpu/contract.h>
+#include <stdgpu/platform.h>
+
+#include STDGPU_DETAIL_BACKEND_HEADER(memory.h)
+
 
 
 namespace stdgpu

--- a/src/stdgpu/impl/platform_check.h
+++ b/src/stdgpu/impl/platform_check.h
@@ -17,14 +17,9 @@
 #define STDGPU_PLATFORM_CHECK_H
 
 
-#include <stdgpu/config.h>
+#include <stdgpu/platform.h>
 
-//! @cond Doxygen_Suppress
-#define STDGPU_BACKEND_PLATFORM_CHECK_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/platform_check.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
-// cppcheck-suppress preprocessorErrorDirective
-#include STDGPU_BACKEND_PLATFORM_CHECK_HEADER
-#undef STDGPU_BACKEND_PLATFORM_CHECK_HEADER
-//! @endcond
+#include STDGPU_DETAIL_BACKEND_HEADER(platform_check.h)
 
 
 

--- a/src/stdgpu/platform.h
+++ b/src/stdgpu/platform.h
@@ -29,11 +29,10 @@
 #include <stdgpu/config.h>
 
 //! @cond Doxygen_Suppress
-#define STDGPU_BACKEND_PLATFORM_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/platform.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
-// cppcheck-suppress preprocessorErrorDirective
-#include STDGPU_BACKEND_PLATFORM_HEADER
-#undef STDGPU_BACKEND_PLATFORM_HEADER
+#define STDGPU_DETAIL_BACKEND_HEADER(header_file) <stdgpu/STDGPU_BACKEND_DIRECTORY/header_file> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
 //! @endcond
+
+#include STDGPU_DETAIL_BACKEND_HEADER(platform.h)
 
 // NOTE: For backwards compatibility only
 #include <stdgpu/compiler.h>


### PR DESCRIPTION
The `#include` statements of the backend headers are quite complicated and required defining temporary macro names to build the path. Simplify this logic by moving it to the new internal macro function `STDGPU_DETAIL_BACKEND_HEADER()`.