### PR TITLE
test: Fix printing of properties for invalid devices

### DIFF
--- a/test/stdgpu/cuda/device_info.cpp
+++ b/test/stdgpu/cuda/device_info.cpp
@@ -55,7 +55,16 @@ void
 print_device_information()
 {
     cudaDeviceProp properties;
-    cudaGetDeviceProperties(&properties, 0);
+    if (cudaGetDeviceProperties(&properties, 0) != cudaSuccess)
+    {
+        printf( "+---------------------------------------------------------+\n" );
+        printf( "|                   Invalid CUDA Device                   |\n" );
+        printf( "+---------------------------------------------------------+\n" );
+        printf( "| WARNING: Unable to fetch properties of invalid device!  |\n" );
+        printf( "+---------------------------------------------------------+\n\n" );
+
+        return;
+    }
 
     std::size_t free_memory  = 0;
     std::size_t total_memory = 0;

--- a/test/stdgpu/hip/device_info.cpp
+++ b/test/stdgpu/hip/device_info.cpp
@@ -55,7 +55,16 @@ void
 print_device_information()
 {
     hipDeviceProp_t properties;
-    hipGetDeviceProperties(&properties, 0);
+    if (hipGetDeviceProperties(&properties, 0) != hipSuccess)
+    {
+        printf( "+---------------------------------------------------------+\n" );
+        printf( "|                   Invalid HIP Device                    |\n" );
+        printf( "+---------------------------------------------------------+\n" );
+        printf( "| WARNING: Unable to fetch properties of invalid device!  |\n" );
+        printf( "+---------------------------------------------------------+\n\n" );
+
+        return;
+    }
 
     std::size_t free_memory  = 0;
     std::size_t total_memory = 0;


### PR DESCRIPTION
When executing the unit tests, a summary of the properties of the used device is printed. However, if no valid device is available, bogus values are printed when executing the tests. Catch this corner case and output a clearer message stating that no device has been detected at runtime.