### PR TITLE
scripts: Fix compatibility with zsh

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -18,27 +18,27 @@ jobs:
       - name: Install OpenMP
         shell: bash
         run: |
-          sh scripts/utils/install_openmp_ubuntu2004.sh
+          bash scripts/utils/install_openmp_ubuntu2004.sh
 
       - name: Install clang-tidy
         shell: bash
         run: |
-          sh scripts/utils/install_clang_tidy_ubuntu2004.sh
+          bash scripts/utils/install_clang_tidy_ubuntu2004.sh
 
       - name: Download dependencies
         shell: bash
         run: |
-          sh scripts/utils/download_dependencies.sh
+          bash scripts/utils/download_dependencies.sh
 
       - name: Configure project
         shell: bash
         run: |
-          sh scripts/ci/configure_openmp_clang_tidy.sh
+          bash scripts/ci/configure_openmp_clang_tidy.sh
 
       - name: Build project
         shell: bash
         run: |
-          sh scripts/build.sh Debug
+          bash scripts/build.sh Debug
 
   Cppcheck:
     runs-on: ubuntu-20.04
@@ -49,24 +49,24 @@ jobs:
       - name: Install OpenMP
         shell: bash
         run: |
-          sh scripts/utils/install_openmp_ubuntu2004.sh
+          bash scripts/utils/install_openmp_ubuntu2004.sh
 
       - name: Install cppcheck
         shell: bash
         run: |
-          sh scripts/utils/install_cppcheck_ubuntu2004.sh
+          bash scripts/utils/install_cppcheck_ubuntu2004.sh
 
       - name: Download dependencies
         shell: bash
         run: |
-          sh scripts/utils/download_dependencies.sh
+          bash scripts/utils/download_dependencies.sh
 
       - name: Configure project
         shell: bash
         run: |
-          sh scripts/ci/configure_openmp_cppcheck.sh
+          bash scripts/ci/configure_openmp_cppcheck.sh
 
       - name: Build project
         shell: bash
         run: |
-          sh scripts/build.sh Debug
+          bash scripts/build.sh Debug

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,32 +18,32 @@ jobs:
       - name: Install OpenMP
         shell: bash
         run: |
-          sh scripts/utils/install_openmp_ubuntu2004.sh
+          bash scripts/utils/install_openmp_ubuntu2004.sh
 
       - name: Install lcov
         shell: bash
         run: |
-          sh scripts/utils/install_lcov_ubuntu2004.sh
+          bash scripts/utils/install_lcov_ubuntu2004.sh
 
       - name: Download dependencies
         shell: bash
         run: |
-          sh scripts/utils/download_dependencies.sh
+          bash scripts/utils/download_dependencies.sh
 
       - name: Configure project
         shell: bash
         run: |
-          sh scripts/ci/configure_openmp_lcov.sh
+          bash scripts/ci/configure_openmp_lcov.sh
 
       - name: Build project
         shell: bash
         run: |
-          sh scripts/build.sh Debug
+          bash scripts/build.sh Debug
 
       - name: Run coverage
         shell: bash
         run: |
-          sh scripts/ci/run_coverage.sh
+          bash scripts/ci/run_coverage.sh
 
       - name: Upload coverage report
         shell: bash

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,29 +18,29 @@ jobs:
       - name: Install OpenMP
         shell: bash
         run: |
-          sh scripts/utils/install_openmp_ubuntu2004.sh
+          bash scripts/utils/install_openmp_ubuntu2004.sh
 
       - name: Install doxygen dependencies
         shell: bash
         run: |
-          sh scripts/utils/install_doxygen_dependencies_ubuntu2004.sh
+          bash scripts/utils/install_doxygen_dependencies_ubuntu2004.sh
 
       - name: Download dependencies
         shell: bash
         run: |
-          sh scripts/utils/download_dependencies.sh
+          bash scripts/utils/download_dependencies.sh
 
       - name: Download doxygen
         shell: bash
         run: |
-          sh scripts/utils/download_doxygen.sh
+          bash scripts/utils/download_doxygen.sh
 
       - name: Configure project
         shell: bash
         run: |
-          sh scripts/ci/configure_openmp_documentation.sh
+          bash scripts/ci/configure_openmp_documentation.sh
 
       - name: Build documentation
         shell: bash
         run: |
-          sh scripts/utils/build_documentation.sh
+          bash scripts/utils/build_documentation.sh

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -28,29 +28,29 @@ jobs:
       - name: Install OpenMP
         shell: bash
         run: |
-          sh scripts/utils/install_openmp_ubuntu2004.sh
+          bash scripts/utils/install_openmp_ubuntu2004.sh
 
       - name: Download dependencies
         shell: bash
         run: |
-          sh scripts/utils/download_dependencies.sh
+          bash scripts/utils/download_dependencies.sh
 
       - name: Set C/C++ compiler
         shell: bash
         run: |
-          sh scripts/utils/set_cxx_compiler_ubuntu.sh ${{ matrix.CC }} ${{ matrix.CXX }}
+          bash scripts/utils/set_cxx_compiler_ubuntu.sh ${{ matrix.CC }} ${{ matrix.CXX }}
 
       - name: Configure project
         shell: bash
         run: |
-          sh scripts/ci/configure_openmp.sh ${{ matrix.BuildType }}
+          bash scripts/ci/configure_openmp.sh ${{ matrix.BuildType }}
 
       - name: Build project
         shell: bash
         run: |
-          sh scripts/build.sh ${{ matrix.BuildType }}
+          bash scripts/build.sh ${{ matrix.BuildType }}
 
       - name: Run tests
         shell: bash
         run: |
-          sh scripts/run_tests.sh ${{ matrix.BuildType }}
+          bash scripts/run_tests.sh ${{ matrix.BuildType }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,19 +22,19 @@ jobs:
       - name: Download dependencies
         shell: bash
         run: |
-          sh scripts/utils/download_dependencies.sh
+          bash scripts/utils/download_dependencies.sh
 
       - name: Configure project
         shell: bash
         run: |
-          sh scripts/ci/configure_openmp.sh ${{ matrix.BuildType }}
+          bash scripts/ci/configure_openmp.sh ${{ matrix.BuildType }}
 
       - name: Build project
         shell: bash
         run: |
-          sh scripts/build.sh ${{ matrix.BuildType }}
+          bash scripts/build.sh ${{ matrix.BuildType }}
 
       - name: Run tests
         shell: bash
         run: |
-          sh scripts/run_tests.sh ${{ matrix.BuildType }}
+          bash scripts/run_tests.sh ${{ matrix.BuildType }}

--- a/README.md
+++ b/README.md
@@ -232,10 +232,10 @@ In addition, we also provide cross-platform scripts to make the build process mo
 
 Command | Effect
 --- | ---
-<code>sh&nbsp;scripts/setup.sh [&lt;build_type&gt;]</code> | Performs a full clean build of the project. Removes old build, configures the project (build path: `./build`, default build type: `Release`), builds the project, and runs the unit tests.
-<code>sh&nbsp;scripts/build.sh [&lt;build_type&gt;]</code> | (Re-)Builds the project. Requires that the project is set up (default build type: `Release`).
-<code>sh&nbsp;scripts/run_tests.sh [&lt;build_type&gt;]</code> | Runs the unit tests. Requires that the project is built (default build type: `Release`).
-<code>sh&nbsp;scripts/install.sh [&lt;build_type&gt;]</code> | Installs the project at the configured install path (default install dir: `./bin`, default build type: `Release`).
+<code>bash&nbsp;scripts/setup.sh [&lt;build_type&gt;]</code> | Performs a full clean build of the project. Removes old build, configures the project (build path: `./build`, default build type: `Release`), builds the project, and runs the unit tests.
+<code>bash&nbsp;scripts/build.sh [&lt;build_type&gt;]</code> | (Re-)Builds the project. Requires that the project is set up (default build type: `Release`).
+<code>bash&nbsp;scripts/run_tests.sh [&lt;build_type&gt;]</code> | Runs the unit tests. Requires that the project is built (default build type: `Release`).
+<code>bash&nbsp;scripts/install.sh [&lt;build_type&gt;]</code> | Installs the project at the configured install path (default install dir: `./bin`, default build type: `Release`).
 
 
 ## Integration

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -181,10 +181,10 @@ In addition, we also provide cross-platform scripts to make the build process mo
 
 Command | Effect
 --- | ---
-<code>sh&nbsp;scripts/setup.sh [&lt;build_type&gt;]</code> | Performs a full clean build of the project. Removes old build, configures the project (build path: `./build`, default build type: `Release`), builds the project, and runs the unit tests.
-<code>sh&nbsp;scripts/build.sh [&lt;build_type&gt;]</code> | (Re-)Builds the project. Requires that the project is set up (default build type: `Release`).
-<code>sh&nbsp;scripts/run_tests.sh [&lt;build_type&gt;]</code> | Runs the unit tests. Requires that the project is built (default build type: `Release`).
-<code>sh&nbsp;scripts/install.sh [&lt;build_type&gt;]</code> | Installs the project at the configured install path (default install dir: `./bin`, default build type: `Release`).
+<code>bash&nbsp;scripts/setup.sh [&lt;build_type&gt;]</code> | Performs a full clean build of the project. Removes old build, configures the project (build path: `./build`, default build type: `Release`), builds the project, and runs the unit tests.
+<code>bash&nbsp;scripts/build.sh [&lt;build_type&gt;]</code> | (Re-)Builds the project. Requires that the project is set up (default build type: `Release`).
+<code>bash&nbsp;scripts/run_tests.sh [&lt;build_type&gt;]</code> | Runs the unit tests. Requires that the project is built (default build type: `Release`).
+<code>bash&nbsp;scripts/install.sh [&lt;build_type&gt;]</code> | Installs the project at the configured install path (default install dir: `./bin`, default build type: `Release`).
 
 
 \section integration Integration

--- a/scripts/ci/configure_cuda.sh
+++ b/scripts/ci/configure_cuda.sh
@@ -5,10 +5,8 @@ if [ "$#" = 0 ]; then
     CONFIG="Release"
 else
     CONFIG=$1
+    shift
 fi
-
-# Remove first parameter
-shift
 
 # Create build directory
 sh scripts/utils/create_empty_directory.sh build

--- a/scripts/ci/configure_hip.sh
+++ b/scripts/ci/configure_hip.sh
@@ -5,10 +5,8 @@ if [ "$#" = 0 ]; then
     CONFIG="Release"
 else
     CONFIG=$1
+    shift
 fi
-
-# Remove first parameter
-shift
 
 # Create build directory
 sh scripts/utils/create_empty_directory.sh build

--- a/scripts/ci/configure_openmp.sh
+++ b/scripts/ci/configure_openmp.sh
@@ -5,10 +5,8 @@ if [ "$#" = 0 ]; then
     CONFIG="Release"
 else
     CONFIG=$1
+    shift
 fi
-
-# Remove first parameter
-shift
 
 # Create build directory
 sh scripts/utils/create_empty_directory.sh build

--- a/scripts/utils/configure.sh
+++ b/scripts/utils/configure.sh
@@ -5,10 +5,8 @@ if [ "$#" = 0 ]; then
     CONFIG="Release"
 else
     CONFIG=$1
+    shift
 fi
-
-# Remove first parameter
-shift
 
 # Configure project
 cmake -E cmake_echo_color --blue ">>>>> Configure stdgpu project ($CONFIG)"


### PR DESCRIPTION
The recently update scripts allowed for greater flexibility, but regressed support on other shells such as `zsh`. Conditionally use the `shift` command to avoid an explicit error with `zsh` (and an implicit one with `bash`).

Furthermore, explicitly call the scripts with the `bash` command to avoid implicitly falling back to `dash`/`sh` on Ubuntu which does not support `shift`ing.