### PR TITLE
General: Add installation test

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -55,3 +55,13 @@ jobs:
         shell: bash
         run: |
           bash scripts/run_tests.sh ${{ matrix.BuildType }}
+
+      - name: Install project
+        shell: bash
+        run: |
+          bash scripts/install.sh ${{ matrix.BuildType }}
+
+      - name: Check linking to installed project
+        shell: bash
+        run: |
+          bash scripts/ci/check_install_openmp.sh ${{ matrix.BuildType }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,3 +39,13 @@ jobs:
         shell: bash
         run: |
           bash scripts/run_tests.sh ${{ matrix.BuildType }}
+
+      - name: Install project
+        shell: bash
+        run: |
+          bash scripts/install.sh ${{ matrix.BuildType }}
+
+      - name: Check linking to installed project
+        shell: bash
+        run: |
+          bash scripts/ci/check_install_openmp.sh ${{ matrix.BuildType }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Build directories
 /bin/
 /build/
+/build_install_test/
+/external/
 
 # KDevelop
 *.kdev4

--- a/scripts/ci/check_install_openmp.sh
+++ b/scripts/ci/check_install_openmp.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+if [ "$#" = 0 ]; then
+    CONFIG="Release"
+else
+    CONFIG=$1
+    shift
+fi
+
+# Create build directory
+sh scripts/utils/create_empty_directory.sh build_install_test
+
+# Compile dependent project
+cmake -E cmake_echo_color --blue ">>>>> Check installation ($CONFIG)"
+cmake -B build_install_test -S test/install_test -DCMAKE_BUILD_TYPE=$CONFIG -Dstdgpu_ROOT=bin -Dthrust_ROOT=external/thrust $@
+cmake --build build_install_test --config ${CONFIG} --parallel 13

--- a/test/install_test/CMakeLists.txt
+++ b/test/install_test/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(install_test LANGUAGES CXX)
+
+
+find_package(stdgpu REQUIRED)
+
+
+add_executable(install_test)
+
+target_sources(install_test PRIVATE install_test.cpp)
+
+target_link_libraries(install_test PRIVATE stdgpu::stdgpu)
+

--- a/test/install_test/install_test.cpp
+++ b/test/install_test/install_test.cpp
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2022 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdgpu/memory.h>
+
+
+
+int
+main()
+{
+    const stdgpu::index_t n = 1000;
+    const int default_value = 42;
+
+    int* d_array = createDeviceArray<int>(n, default_value);
+    int* h_array = copyCreateDevice2HostArray<int>(d_array, n);
+
+    destroyHostArray<int>(h_array);
+    destroyDeviceArray<int>(d_array);
+}
+
+


### PR DESCRIPTION
Although we export the relevant CMake targets as well as all required information of the dependencies when installing the library, there is not formal test to verify that installed versions of `stdgpu` can actually be found out-of-the-box. Add a small test project that is based on the recommended way of finding the package (see `README.md`) and run this test for each relevant configuration in the CI. 