### PR TITLE
test: Fix more clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,6 @@ modernize-*,\
 -modernize-avoid-c-arrays,\
 -modernize-use-auto,\
 -modernize-pass-by-value,\
--modernize-return-braced-init-list,\
 -modernize-use-trailing-return-type,\
 performance-*,\
 readability-*,\

--- a/test/stdgpu/main.cpp
+++ b/test/stdgpu/main.cpp
@@ -19,12 +19,9 @@
 #include <cstdio>
 #include <string>
 
-#include <stdgpu/config.h>
+#include <stdgpu/platform.h>
 
-#define STDGPU_BACKEND_DEVICE_INFO_HEADER <stdgpu/STDGPU_BACKEND_DIRECTORY/device_info.h> // NOLINT(bugprone-macro-parentheses,misc-macro-parentheses)
-// cppcheck-suppress preprocessorErrorDirective
-#include STDGPU_BACKEND_DEVICE_INFO_HEADER
-#undef STDGPU_BACKEND_DEVICE_INFO_HEADER
+#include STDGPU_DETAIL_BACKEND_HEADER(device_info.h)
 
 #include <stdgpu/memory.h>
 

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -136,7 +136,7 @@ namespace
                 thrust::uniform_real_distribution<std::int16_t> dist(stdgpu::numeric_limits<std::int16_t>::min(), stdgpu::numeric_limits<std::int16_t>::max());
                 rng.discard(static_cast<unsigned long long int>(3) * static_cast<unsigned long long int>(n));
 
-                return test_unordered_datastructure::key_type(dist(rng), dist(rng), dist(rng));
+                return {dist(rng), dist(rng), dist(rng)};
             }
 
         private:

--- a/test/stdgpu/unordered_map.inc
+++ b/test/stdgpu/unordered_map.inc
@@ -216,14 +216,14 @@ struct vec_hash
 inline STDGPU_HOST_DEVICE stdgpu::unordered_map<vec3int16, dummy, vec_hash>::value_type
 key_to_value(const vec3int16& key)
 {
-    return stdgpu::unordered_map<vec3int16, dummy, vec_hash>::value_type(key, dummy());
+    return {key, dummy()};
 }
 
 
 inline STDGPU_HOST_DEVICE stdgpu::unordered_map<vec3int32, dummy, vec_hash>::value_type
 key_to_value(const vec3int32& key)
 {
-    return stdgpu::unordered_map<vec3int32, dummy, vec_hash>::value_type(key, dummy());
+    return {key, dummy()};
 }
 
 
@@ -237,7 +237,7 @@ value_to_key(const stdgpu::unordered_map<vec3int16, dummy, vec_hash>::value_type
 inline STDGPU_HOST_DEVICE vec3int32
 key_to_keylike(const vec3int16& key)
 {
-    return vec3int32(key.x, key.y, key.z);
+    return {key.x, key.y, key.z};
 }
 
 

--- a/test/stdgpu/unordered_set.inc
+++ b/test/stdgpu/unordered_set.inc
@@ -233,7 +233,7 @@ value_to_key(const vec3int16& key)
 inline STDGPU_HOST_DEVICE vec3int32
 key_to_keylike(const vec3int16& key)
 {
-    return vec3int32(key.x, key.y, key.z);
+    return {key.x, key.y, key.z};
 }
 
 


### PR DESCRIPTION
After revisiting Clang 13 support in #264, the number of  suppressed `clang-tidy` warnings increased. Revisit the list of ignored warnings and fix some of these. Since balancing the number of `NOLINT` statements over the number of completely disabled warnings is not trivial, keep the remaining setting as is.