### PR TITLE
cmake: Provide more version information for depending tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.15...3.23)
+message(STATUS "Configuring with CMake ${CMAKE_VERSION}")
 
 
 project(stdgpu VERSION 1.3.0

--- a/cmake/FindClangTidy.cmake
+++ b/cmake/FindClangTidy.cmake
@@ -1,0 +1,23 @@
+
+find_program(CLANG_TIDY_EXECUTABLE
+             NAMES
+             "clang-tidy")
+
+if(CLANG_TIDY_EXECUTABLE)
+    execute_process(COMMAND "${CLANG_TIDY_EXECUTABLE}" "--version" OUTPUT_VARIABLE CLANG_TIDY_VERSION_TEXT)
+    string(REGEX MATCH "LLVM version ([^\n]*)" CLANG_TIDY_VERSION_TEXT_CUT "${CLANG_TIDY_VERSION_TEXT}")
+    set(CLANG_TIDY_VERSION "${CMAKE_MATCH_1}")
+
+    unset(CLANG_TIDY_VERSION_TEXT_CUT)
+    unset(CLANG_TIDY_VERSION_TEXT)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ClangTidy
+                                  REQUIRED_VARS CLANG_TIDY_EXECUTABLE
+                                  VERSION_VAR CLANG_TIDY_VERSION)
+
+if(ClangTidy_FOUND)
+    add_executable(ClangTidy::ClangTidy IMPORTED)
+    set_target_properties(ClangTidy::ClangTidy PROPERTIES IMPORTED_LOCATION "${CLANG_TIDY_EXECUTABLE}")
+endif()

--- a/cmake/FindCppcheck.cmake
+++ b/cmake/FindCppcheck.cmake
@@ -1,0 +1,23 @@
+
+find_program(CPPCHECK_EXECUTABLE
+             NAMES
+             "cppcheck")
+
+if(CPPCHECK_EXECUTABLE)
+    execute_process(COMMAND "${CPPCHECK_EXECUTABLE}" "--version" OUTPUT_VARIABLE CPPCHECK_VERSION_TEXT)
+    string(REGEX MATCH "^Cppcheck ([^\n]*)" CPPCHECK_VERSION_TEXT_CUT "${CPPCHECK_VERSION_TEXT}")
+    set(CPPCHECK_VERSION "${CMAKE_MATCH_1}")
+
+    unset(CPPCHECK_VERSION_TEXT_CUT)
+    unset(CPPCHECK_VERSION_TEXT)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Cppcheck
+                                  REQUIRED_VARS CPPCHECK_EXECUTABLE
+                                  VERSION_VAR CPPCHECK_VERSION)
+
+if(Cppcheck_FOUND)
+    add_executable(Cppcheck::Cppcheck IMPORTED)
+    set_target_properties(Cppcheck::Cppcheck PROPERTIES IMPORTED_LOCATION "${CPPCHECK_EXECUTABLE}")
+endif()

--- a/cmake/setup_clang_tidy.cmake
+++ b/cmake/setup_clang_tidy.cmake
@@ -1,13 +1,7 @@
 function(stdgpu_setup_clang_tidy STDGPU_OUTPUT_PROPERTY_CLANG_TIDY)
-    find_program(STDGPU_CLANG_TIDY
-                 NAMES
-                 "clang-tidy")
+    find_package(ClangTidy REQUIRED)
 
-    if(NOT STDGPU_CLANG_TIDY)
-        message(FATAL_ERROR "clang-tidy not found.")
-    endif()
-
-    set(${STDGPU_OUTPUT_PROPERTY_CLANG_TIDY} "${STDGPU_CLANG_TIDY}")
+    set(${STDGPU_OUTPUT_PROPERTY_CLANG_TIDY} "${CLANG_TIDY_EXECUTABLE}")
 
     if(NOT DEFINED STDGPU_TREAT_WARNINGS_AS_ERRORS)
         message(FATAL_ERROR "STDGPU_TREAT_WARNINGS_AS_ERRORS not defined.")

--- a/cmake/setup_cppcheck.cmake
+++ b/cmake/setup_cppcheck.cmake
@@ -1,14 +1,8 @@
 function(stdgpu_setup_cppcheck STDGPU_OUTPUT_PROPERTY_CPPCHECK)
-    find_program(STDGPU_CPPCHECK
-                 NAMES
-                 "cppcheck")
-
-    if(NOT STDGPU_CPPCHECK)
-        message(FATAL_ERROR "cppcheck not found.")
-    endif()
+    find_package(Cppcheck REQUIRED)
 
     # Do not enable noisy "style" checks
-    set(${STDGPU_OUTPUT_PROPERTY_CPPCHECK} "${STDGPU_CPPCHECK}" "--enable=warning,performance,portability" "--force" "--inline-suppr" "--quiet")
+    set(${STDGPU_OUTPUT_PROPERTY_CPPCHECK} "${CPPCHECK_EXECUTABLE}" "--enable=warning,performance,portability" "--force" "--inline-suppr" "--quiet")
 
     if(NOT DEFINED STDGPU_TREAT_WARNINGS_AS_ERRORS)
         message(FATAL_ERROR "STDGPU_TREAT_WARNINGS_AS_ERRORS not defined.")


### PR DESCRIPTION
We depend on several external commonly used tools to support certain functionalities such as documentation creation, unit tests, static analysis, etc. For some of these tools, there is proper support using `Find*` modules that provide version and path information for the found components. For others, however, this information is currently missing.

Add modules for `clang-tidy` and `cppcheck` to have a reusable and more powerful way of finding and getting version information from them. Furthermore, print the version of the currently used `CMake` executable which may help to maintain compatibility across various versions.