### PR TITLE
src: Move device info functionality from unit tests

### DIFF
--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -32,7 +32,8 @@ else()
     add_library(stdgpu STATIC)
 endif()
 
-target_sources(stdgpu PRIVATE impl/iterator.cpp
+target_sources(stdgpu PRIVATE impl/device.cpp
+                              impl/iterator.cpp
                               impl/memory.cpp
                               impl/limits.cpp)
 

--- a/src/stdgpu/cuda/CMakeLists.txt
+++ b/src/stdgpu/cuda/CMakeLists.txt
@@ -5,7 +5,8 @@ set(STDGPU_DEPENDENCIES_BACKEND_INIT "
 find_dependency(CUDAToolkit 10.0 REQUIRED MODULE)
 " PARENT_SCOPE)
 
-target_sources(stdgpu PRIVATE impl/memory.cpp)
+target_sources(stdgpu PRIVATE impl/device.cpp
+                              impl/memory.cpp)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
     target_compile_features(stdgpu PUBLIC cuda_std_14)

--- a/src/stdgpu/cuda/device.h
+++ b/src/stdgpu/cuda/device.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2019 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_CUDA_DEVICE_H
+#define STDGPU_CUDA_DEVICE_H
+
+namespace stdgpu
+{
+
+namespace cuda
+{
+
+/**
+ * \brief Prints the technical data of the currently used device
+ */
+void
+print_device_information();
+
+} // namespace cuda
+
+} // namespace stdgpu
+
+#endif // STDGPU_CUDA_DEVICE_H

--- a/src/stdgpu/cuda/impl/device.cpp
+++ b/src/stdgpu/cuda/impl/device.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2020 Patrick Stotko
+ *  Copyright 2019 Patrick Stotko
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -13,12 +13,12 @@
  *  limitations under the License.
  */
 
-#include <stdgpu/hip/device_info.h>
+#include <stdgpu/cuda/device.h>
 
 #include <algorithm>
 #include <cstddef>
 #include <cstdio>
-#include <hip/hip_runtime_api.h>
+#include <cuda_runtime_api.h>
 #include <string>
 
 namespace detail
@@ -45,17 +45,17 @@ byte_to_gibi_byte(const float byte)
 namespace stdgpu
 {
 
-namespace hip
+namespace cuda
 {
 
 void
 print_device_information()
 {
-    hipDeviceProp_t properties;
-    if (hipGetDeviceProperties(&properties, 0) != hipSuccess)
+    cudaDeviceProp properties;
+    if (cudaGetDeviceProperties(&properties, 0) != cudaSuccess)
     {
         printf("+---------------------------------------------------------+\n");
-        printf("|                   Invalid HIP Device                    |\n");
+        printf("|                   Invalid CUDA Device                   |\n");
         printf("+---------------------------------------------------------+\n");
         printf("| WARNING: Unable to fetch properties of invalid device!  |\n");
         printf("+---------------------------------------------------------+\n\n");
@@ -65,7 +65,7 @@ print_device_information()
 
     std::size_t free_memory = 0;
     std::size_t total_memory = 0;
-    hipMemGetInfo(&free_memory, &total_memory);
+    cudaMemGetInfo(&free_memory, &total_memory);
 
     std::string gpu_name = properties.name;
     const int gpu_name_total_width = 57;
@@ -76,7 +76,7 @@ print_device_information()
     printf("+---------------------------------------------------------+\n");
     printf("|%*s%*s%*s|\n", gpu_name_space_left, " ", gpu_name_size, gpu_name.c_str(), gpu_name_space_right, " ");
     printf("+---------------------------------------------------------+\n");
-    printf("| GCN Architecture          :   %4d                      |\n", properties.gcnArch);
+    printf("| Compute Capability        :   %1d.%1d                       |\n", properties.major, properties.minor);
     printf("| Clock rate                :   %-6.0f MHz                |\n",
            static_cast<double>(detail::kilo_to_mega_hertz(static_cast<float>(properties.clockRate))));
     printf("| Global Memory             :   %-6.3f GiB / %-6.3f GiB   |\n",
@@ -90,15 +90,13 @@ print_device_information()
     printf("| Total Constant Memory     :   %-6.0f KiB                |\n",
            static_cast<double>(detail::byte_to_kibi_byte(static_cast<float>(properties.totalConstMem))));
     printf("| Shared Memory per SM      :   %-6.0f KiB                |\n",
-           static_cast<double>(
-                   detail::byte_to_kibi_byte(static_cast<float>(properties.maxSharedMemoryPerMultiProcessor))));
+           static_cast<double>(detail::byte_to_kibi_byte(static_cast<float>(properties.sharedMemPerMultiprocessor))));
     printf("| Total Shared Memory       :   %-6.0f KiB                |\n",
-           static_cast<double>(detail::byte_to_kibi_byte(
-                   static_cast<float>(properties.maxSharedMemoryPerMultiProcessor *
-                                      static_cast<std::size_t>(properties.multiProcessorCount)))));
+           static_cast<double>(detail::byte_to_kibi_byte(static_cast<float>(
+                   properties.sharedMemPerMultiprocessor * static_cast<std::size_t>(properties.multiProcessorCount)))));
     printf("+---------------------------------------------------------+\n\n");
 }
 
-} // namespace hip
+} // namespace cuda
 
 } // namespace stdgpu

--- a/src/stdgpu/device.h
+++ b/src/stdgpu/device.h
@@ -13,13 +13,10 @@
  *  limitations under the License.
  */
 
-#ifndef STDGPU_CUDA_DEVICE_INFO_H
-#define STDGPU_CUDA_DEVICE_INFO_H
+#ifndef STDGPU_DEVICE_H
+#define STDGPU_DEVICE_H
 
 namespace stdgpu
-{
-
-namespace cuda
 {
 
 /**
@@ -28,8 +25,6 @@ namespace cuda
 void
 print_device_information();
 
-} // namespace cuda
-
 } // namespace stdgpu
 
-#endif // STDGPU_CUDA_DEVICE_INFO_H
+#endif // STDGPU_DEVICE_H

--- a/src/stdgpu/hip/CMakeLists.txt
+++ b/src/stdgpu/hip/CMakeLists.txt
@@ -15,7 +15,8 @@ set(STDGPU_DEPENDENCIES_BACKEND_INIT "
 find_dependency(hip 5.1 REQUIRED)
 " PARENT_SCOPE)
 
-target_sources(stdgpu PRIVATE impl/memory.cpp)
+target_sources(stdgpu PRIVATE impl/device.cpp
+                              impl/memory.cpp)
 
 target_compile_features(stdgpu PUBLIC hip_std_14)
 

--- a/src/stdgpu/hip/device.h
+++ b/src/stdgpu/hip/device.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019 Patrick Stotko
+ *  Copyright 2020 Patrick Stotko
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -13,13 +13,13 @@
  *  limitations under the License.
  */
 
-#ifndef STDGPU_OPENMP_DEVICE_INFO_H
-#define STDGPU_OPENMP_DEVICE_INFO_H
+#ifndef STDGPU_HIP_DEVICE_H
+#define STDGPU_HIP_DEVICE_H
 
 namespace stdgpu
 {
 
-namespace openmp
+namespace hip
 {
 
 /**
@@ -28,8 +28,8 @@ namespace openmp
 void
 print_device_information();
 
-} // namespace openmp
+} // namespace hip
 
 } // namespace stdgpu
 
-#endif // STDGPU_OPENMP_DEVICE_INFO_H
+#endif // STDGPU_HIP_DEVICE_H

--- a/src/stdgpu/impl/device.cpp
+++ b/src/stdgpu/impl/device.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2020 Patrick Stotko
+ *  Copyright 2019 Patrick Stotko
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -13,23 +13,19 @@
  *  limitations under the License.
  */
 
-#ifndef STDGPU_HIP_DEVICE_INFO_H
-#define STDGPU_HIP_DEVICE_INFO_H
+#include <stdgpu/device.h>
+
+#include <stdgpu/platform.h>
+
+#include STDGPU_DETAIL_BACKEND_HEADER(device.h)
 
 namespace stdgpu
 {
 
-namespace hip
-{
-
-/**
- * \brief Prints the technical data of the currently used device
- */
 void
-print_device_information();
-
-} // namespace hip
+print_device_information()
+{
+    stdgpu::STDGPU_BACKEND_NAMESPACE::print_device_information();
+}
 
 } // namespace stdgpu
-
-#endif // STDGPU_HIP_DEVICE_INFO_H

--- a/src/stdgpu/openmp/CMakeLists.txt
+++ b/src/stdgpu/openmp/CMakeLists.txt
@@ -5,7 +5,8 @@ set(STDGPU_DEPENDENCIES_BACKEND_INIT "
 find_dependency(OpenMP 2.0 REQUIRED)
 " PARENT_SCOPE)
 
-target_sources(stdgpu PRIVATE impl/memory.cpp)
+target_sources(stdgpu PRIVATE impl/device.cpp
+                              impl/memory.cpp)
 
 target_compile_definitions(stdgpu PUBLIC THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_OMP)
 

--- a/src/stdgpu/openmp/device.h
+++ b/src/stdgpu/openmp/device.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2019 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_OPENMP_DEVICE_H
+#define STDGPU_OPENMP_DEVICE_H
+
+namespace stdgpu
+{
+
+namespace openmp
+{
+
+/**
+ * \brief Prints the technical data of the currently used device
+ */
+void
+print_device_information();
+
+} // namespace openmp
+
+} // namespace stdgpu
+
+#endif // STDGPU_OPENMP_DEVICE_H

--- a/src/stdgpu/openmp/impl/device.cpp
+++ b/src/stdgpu/openmp/impl/device.cpp
@@ -13,7 +13,7 @@
  *  limitations under the License.
  */
 
-#include <stdgpu/openmp/device_info.h>
+#include <stdgpu/openmp/device.h>
 
 #include <algorithm>
 #include <cstdio>

--- a/test/stdgpu/cuda/CMakeLists.txt
+++ b/test/stdgpu/cuda/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-target_sources(teststdgpu PRIVATE device_info.cpp
-                                  atomic.cu
+target_sources(teststdgpu PRIVATE atomic.cu
                                   bitset.cu
                                   deque.cu
                                   memory.cu

--- a/test/stdgpu/hip/CMakeLists.txt
+++ b/test/stdgpu/hip/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-target_sources(teststdgpu PRIVATE device_info.cpp
-                                  atomic.hip
+target_sources(teststdgpu PRIVATE atomic.hip
                                   bitset.hip
                                   deque.hip
                                   mutex.hip

--- a/test/stdgpu/main.cpp
+++ b/test/stdgpu/main.cpp
@@ -19,10 +19,7 @@
 #include <cstdio>
 #include <string>
 
-#include <stdgpu/platform.h>
-
-#include STDGPU_DETAIL_BACKEND_HEADER(device_info.h)
-
+#include <stdgpu/device.h>
 #include <stdgpu/memory.h>
 
 GTEST_API_ int
@@ -45,7 +42,7 @@ main(int argc, char* argv[])
     printf("+---------------------------------------------------------+\n");
     printf("\n");
 
-    stdgpu::STDGPU_BACKEND_NAMESPACE::print_device_information();
+    stdgpu::print_device_information();
 
     // Initialize gtest framework
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/stdgpu/openmp/CMakeLists.txt
+++ b/test/stdgpu/openmp/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-target_sources(teststdgpu PRIVATE device_info.cpp
-                                  atomic.cpp
+target_sources(teststdgpu PRIVATE atomic.cpp
                                   bitset.cpp
                                   deque.cpp
                                   mutex.cpp


### PR DESCRIPTION
The functionality to print information for the currently used device can also be useful besides the internal unit tests. Move this functionality to the library. This does not only simplify the call in the main function of the tests and hide all backend-specific details, but also gives users more hints about their environment.