### PR TITLE
cmake: Fix uninstall target

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -65,3 +65,8 @@ jobs:
         shell: bash
         run: |
           bash scripts/ci/check_install_openmp.sh ${{ matrix.BuildType }}
+
+      - name: Uninstall project
+        shell: bash
+        run: |
+          bash scripts/uninstall.sh ${{ matrix.BuildType }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,6 +50,11 @@ jobs:
         run: |
           bash scripts/ci/check_install_openmp.sh ${{ matrix.BuildType }}
 
+      - name: Uninstall project
+        shell: bash
+        run: |
+          bash scripts/uninstall.sh ${{ matrix.BuildType }}
+
   Windows-2022:
     runs-on: windows-2022
 
@@ -90,3 +95,8 @@ jobs:
         shell: bash
         run: |
           bash scripts/ci/check_install_openmp.sh ${{ matrix.BuildType }}
+
+      - name: Uninstall project
+        shell: bash
+        run: |
+          bash scripts/uninstall.sh ${{ matrix.BuildType }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,9 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/stdgpu-config.cmake"
         COMPONENT stdgpu)
 
 
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/add_uninstall_target.cmake")
+
+
 if(STDGPU_BUILD_EXAMPLES)
     enable_testing()
     add_subdirectory(examples)
@@ -203,12 +206,3 @@ endif()
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/config_summary.cmake")
 stdgpu_print_configuration_summary()
-# uninstall target
-if (NOT TARGET uninstall)
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
-                   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-                   IMMEDIATE @ONLY)
-
-    add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P
-                      ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
-endif ()

--- a/NOTICE
+++ b/NOTICE
@@ -17,3 +17,8 @@ Code Coverage Script (cmake/code_coverage.cmake)
 https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake
 License: BSD-3 Clause (https://opensource.org/licenses/BSD-3-Clause)
 Copyright 2012 - 2017, Lars Bilke
+
+Uninstall Target (cmake/add_uninstall_target.cmake, cmake/cmake_uninstall.cmake.in)
+https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+License: BSD-3 Clause (https://opensource.org/licenses/BSD-3-Clause)
+Copyright 2000 - 2022 Kitware, Inc. and Contributors

--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ Command | Effect
 <code>bash&nbsp;scripts/setup.sh [&lt;build_type&gt;]</code> | Performs a full clean build of the project. Removes old build, configures the project (build path: `./build`, default build type: `Release`), builds the project, and runs the unit tests.
 <code>bash&nbsp;scripts/build.sh [&lt;build_type&gt;]</code> | (Re-)Builds the project. Requires that the project is set up (default build type: `Release`).
 <code>bash&nbsp;scripts/run_tests.sh [&lt;build_type&gt;]</code> | Runs the unit tests. Requires that the project is built (default build type: `Release`).
-<code>bash&nbsp;scripts/install.sh [&lt;build_type&gt;]</code> | Installs the project at the configured install path (default install dir: `./bin`, default build type: `Release`).
+<code>bash&nbsp;scripts/install.sh [&lt;build_type&gt;]</code> | Installs the project to the configured install path (default install dir: `./bin`, default build type: `Release`).
+<code>bash&nbsp;scripts/uninstall.sh [&lt;build_type&gt;]</code> | Uninstalls the project from the configured install path (default build type: `Release`).
 
 
 ## Integration

--- a/cmake/add_uninstall_target.cmake
+++ b/cmake/add_uninstall_target.cmake
@@ -1,0 +1,12 @@
+# https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+
+# uninstall target
+if(NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_CURRENT_LIST_DIR}/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,24 +1,24 @@
-
 # https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+
 if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
-    message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
-endif(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
 
 file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
 string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
-    message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
-    if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
-        exec_program(
-        "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
-        OUTPUT_VARIABLE rm_out
-        RETURN_VALUE rm_retval)
-
-        if(NOT "${rm_retval}" STREQUAL 0)
-            message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
-        endif(NOT "${rm_retval}" STREQUAL 0)
-    else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
-        message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
-    endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
-endforeach(file)
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()
 

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -183,8 +183,8 @@ Command | Effect
 <code>bash&nbsp;scripts/setup.sh [&lt;build_type&gt;]</code> | Performs a full clean build of the project. Removes old build, configures the project (build path: `./build`, default build type: `Release`), builds the project, and runs the unit tests.
 <code>bash&nbsp;scripts/build.sh [&lt;build_type&gt;]</code> | (Re-)Builds the project. Requires that the project is set up (default build type: `Release`).
 <code>bash&nbsp;scripts/run_tests.sh [&lt;build_type&gt;]</code> | Runs the unit tests. Requires that the project is built (default build type: `Release`).
-<code>bash&nbsp;scripts/install.sh [&lt;build_type&gt;]</code> | Installs the project at the configured install path (default install dir: `./bin`, default build type: `Release`).
-
+<code>bash&nbsp;scripts/install.sh [&lt;build_type&gt;]</code> | Installs the project to the configured install path (default install dir: `./bin`, default build type: `Release`).
+<code>bash&nbsp;scripts/uninstall.sh [&lt;build_type&gt;]</code> | Uninstalls the project from the configured install path (default build type: `Release`).
 
 \section integration Integration
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -13,6 +13,6 @@ else
     CONFIG=$1
 fi
 
-# Install project
-cmake -E cmake_echo_color --blue ">>>>> Install stdgpu project ($CONFIG)"
-cmake --install build --config $CONFIG
+# Uninstall project
+cmake -E cmake_echo_color --blue ">>>>> Uninstall stdgpu project ($CONFIG)"
+cmake --build build --config $CONFIG --target uninstall


### PR DESCRIPTION
Although the implementation of the uninstall target is also used in many other projects and quite robust in general, testing it with the `install.sh` scripts resulted in an error. Fix this issue and move the target creation to a separate file. Furthermore, add the missing license information and update the related code snippets. To avoid such regressions in the future, extend the installation test in the CI to also cover the new `uninstall.sh` script.