### PR TITLE
functional: Remove coupling to thrust functors

### DIFF
--- a/src/stdgpu/functional.h
+++ b/src/stdgpu/functional.h
@@ -354,6 +354,63 @@ private:
 
 /**
  * \ingroup functional
+ * \brief A function to return the given value
+ */
+struct identity
+{
+    /**
+     * \tparam T The type of the value
+     * \brief Returns the given value
+     * \param[in] t A value
+     * \return The given value
+     */
+    template <typename T>
+    STDGPU_HOST_DEVICE T&&
+    operator()(T&& t) const;
+};
+
+/**
+ * \ingroup functional
+ * \brief A function to add two values
+ * \tparam T The type of the values
+ */
+template <typename T = void>
+struct plus
+{
+    /**
+     * \brief Adds the two values
+     * \param[in] lhs The first value
+     * \param[in] rhs The second value
+     * \return The sum of the given values
+     */
+    STDGPU_HOST_DEVICE T
+    operator()(const T& lhs, const T& rhs) const;
+};
+
+/**
+ * \ingroup functional
+ * \brief A transparent specialization of plus
+ */
+template <>
+struct plus<void>
+{
+    using is_transparent = void; /**< unspecified */
+
+    /**
+     * \brief Adds two values
+     * \tparam T The class of the first value
+     * \tparam U The class of the second value
+     * \param[in] lhs The first value
+     * \param[in] rhs The second value
+     * \return The sum of the given values
+     */
+    template <typename T, typename U>
+    STDGPU_HOST_DEVICE auto
+    operator()(T&& lhs, U&& rhs) const -> decltype(forward<T>(lhs) + forward<U>(rhs));
+};
+
+/**
+ * \ingroup functional
  * \brief A function to check equality between two values
  * \tparam T The type of the values
  */

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -317,14 +317,14 @@ bitset<Block, Allocator>::count() const
                                                          device_end(_bit_blocks) - 1,
                                                          detail::count_block_bits<block_type>(),
                                                          0,
-                                                         thrust::plus<index_t>());
+                                                         plus<index_t>());
 
     index_t last_block_count = thrust::transform_reduce(
             thrust::counting_iterator<index_t>((number_bit_blocks(size()) - 1) * _bits_per_block),
             thrust::counting_iterator<index_t>(size()),
             detail::count_bits<Block, Allocator>(*this),
             0,
-            thrust::plus<index_t>());
+            plus<index_t>());
 
     return full_blocks_count + last_block_count;
 }

--- a/src/stdgpu/impl/functional_detail.h
+++ b/src/stdgpu/impl/functional_detail.h
@@ -20,6 +20,7 @@
 
 #include <stdgpu/bit.h>
 #include <stdgpu/cstddef.h>
+#include <stdgpu/utility.h>
 
 namespace stdgpu
 {
@@ -71,6 +72,27 @@ inline STDGPU_HOST_DEVICE std::size_t
 hash<E>::operator()(const E& key) const
 {
     return hash<std::underlying_type_t<E>>()(static_cast<std::underlying_type_t<E>>(key));
+}
+
+template <typename T>
+inline STDGPU_HOST_DEVICE T&&
+identity::operator()(T&& t) const
+{
+    return forward<T>(t);
+}
+
+template <typename T>
+inline STDGPU_HOST_DEVICE T
+plus<T>::operator()(const T& lhs, const T& rhs) const
+{
+    return lhs + rhs;
+}
+
+template <typename T, typename U>
+inline STDGPU_HOST_DEVICE auto
+plus<void>::operator()(T&& lhs, U&& rhs) const -> decltype(forward<T>(lhs) + forward<U>(rhs))
+{
+    return forward<T>(lhs) + forward<U>(rhs);
 }
 
 template <typename T>

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -28,8 +28,6 @@
  * \file stdgpu/unordered_set.cuh
  */
 
-#include <thrust/functional.h>
-
 #include <stdgpu/attribute.h>
 #include <stdgpu/functional.h>
 #include <stdgpu/impl/type_traits.h>
@@ -375,8 +373,7 @@ public:
     key_eq() const;
 
 private:
-    using base_type =
-            detail::unordered_base<key_type, value_type, thrust::identity<key_type>, hasher, key_equal, Allocator>;
+    using base_type = detail::unordered_base<key_type, value_type, identity, hasher, key_equal, Allocator>;
 
     explicit unordered_set(const base_type& base);
 

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -17,7 +17,6 @@
 
 #include <limits>
 #include <thrust/for_each.h>
-#include <thrust/functional.h>
 #include <thrust/generate.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/reduce.h>
@@ -25,6 +24,7 @@
 #include <thrust/sort.h>
 
 #include <stdgpu/atomic.cuh>
+#include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
 #include <test_memory_utils.h>
@@ -498,7 +498,7 @@ sequence_exchange()
     thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), Function<T>(value));
 
     T sum = value.load() +
-            thrust::reduce(stdgpu::device_cbegin(sequence), stdgpu::device_cend(sequence), T(0), thrust::plus<T>());
+            thrust::reduce(stdgpu::device_cbegin(sequence), stdgpu::device_cend(sequence), T(0), stdgpu::plus<T>());
 
     EXPECT_EQ(sum, T(N * (N + 1) / 2));
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -20,6 +20,7 @@
 #include <thrust/sort.h>
 
 #include <stdgpu/deque.cuh>
+#include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
 #include <test_memory_utils.h>
@@ -2304,7 +2305,7 @@ TEST_F(stdgpu_deque, non_const_device_range)
     ASSERT_TRUE(pool.valid());
 
     auto range = pool.device_range();
-    int sum = thrust::reduce(range.begin(), range.end(), 0, thrust::plus<int>());
+    int sum = thrust::reduce(range.begin(), range.end(), 0, stdgpu::plus<int>());
 
     EXPECT_EQ(sum, N * (N + 1) / 2);
 
@@ -2324,7 +2325,7 @@ TEST_F(stdgpu_deque, non_const_device_range_full)
     ASSERT_TRUE(pool.valid());
 
     auto range = pool.device_range();
-    int sum = thrust::reduce(range.begin(), range.end(), 0, thrust::plus<int>());
+    int sum = thrust::reduce(range.begin(), range.end(), 0, stdgpu::plus<int>());
 
     EXPECT_EQ(sum, N * (N + 1) / 2);
 
@@ -2355,7 +2356,7 @@ TEST_F(stdgpu_deque, non_const_device_range_circular)
     ASSERT_TRUE(pool.valid());
 
     auto range = pool.device_range();
-    int sum = thrust::reduce(range.begin(), range.end(), 0, thrust::plus<int>());
+    int sum = thrust::reduce(range.begin(), range.end(), 0, stdgpu::plus<int>());
 
     EXPECT_EQ(sum, N * (N + 1) / 2);
 
@@ -2375,7 +2376,7 @@ TEST_F(stdgpu_deque, const_device_range)
     ASSERT_TRUE(pool.valid());
 
     auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range();
-    int sum = thrust::reduce(range.begin(), range.end(), 0, thrust::plus<int>());
+    int sum = thrust::reduce(range.begin(), range.end(), 0, stdgpu::plus<int>());
 
     EXPECT_EQ(sum, N * (N + 1) / 2);
 
@@ -2395,7 +2396,7 @@ TEST_F(stdgpu_deque, const_device_range_full)
     ASSERT_TRUE(pool.valid());
 
     auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range();
-    int sum = thrust::reduce(range.begin(), range.end(), 0, thrust::plus<int>());
+    int sum = thrust::reduce(range.begin(), range.end(), 0, stdgpu::plus<int>());
 
     EXPECT_EQ(sum, N * (N + 1) / 2);
 
@@ -2426,7 +2427,7 @@ TEST_F(stdgpu_deque, const_device_range_circular)
     ASSERT_TRUE(pool.valid());
 
     auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range();
-    int sum = thrust::reduce(range.begin(), range.end(), 0, thrust::plus<int>());
+    int sum = thrust::reduce(range.begin(), range.end(), 0, stdgpu::plus<int>());
 
     EXPECT_EQ(sum, N * (N + 1) / 2);
 

--- a/test/stdgpu/functional.cpp
+++ b/test/stdgpu/functional.cpp
@@ -99,6 +99,8 @@ template
 struct hash<long double>;
 */
 
+template struct plus<int>;
+
 template struct equal_to<int>;
 
 template struct bit_not<unsigned int>;
@@ -286,6 +288,83 @@ TEST_F(stdgpu_functional, hash_enum_class)
     hashes.insert(hasher(scoped_enum::three));
 
     EXPECT_GT(static_cast<stdgpu::index_t>(hashes.size()), 4 * 90 / 100);
+}
+
+template <typename T>
+void
+identity_check_integer_random()
+{
+    const stdgpu::index_t N = 1000000;
+
+    // Generate true random numbers
+    std::size_t seed = test_utils::random_seed();
+
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
+    std::uniform_int_distribution<T> dist(std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
+
+    stdgpu::identity identity_function;
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        T value = dist(rng);
+        EXPECT_EQ(identity_function(value), value);
+    }
+}
+
+TEST_F(stdgpu_functional, identity)
+{
+    identity_check_integer_random<int>();
+}
+
+template <typename T>
+void
+plus_check_integer_random()
+{
+    const stdgpu::index_t N = 1000000;
+
+    // Generate true random numbers
+    std::size_t seed = test_utils::random_seed();
+
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
+    std::uniform_int_distribution<T> dist(std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
+
+    stdgpu::plus<T> plus_function;
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        T value_1 = dist(rng);
+        T value_2 = dist(rng);
+        EXPECT_EQ(plus_function(value_1, value_2), value_1 + value_2);
+    }
+}
+
+TEST_F(stdgpu_functional, plus_int)
+{
+    plus_check_integer_random<int>();
+}
+
+template <typename T, typename U>
+void
+plus_transparent_check_integer_random()
+{
+    const stdgpu::index_t N = 1000000;
+
+    // Generate true random numbers
+    std::size_t seed = test_utils::random_seed();
+
+    std::default_random_engine rng(static_cast<std::default_random_engine::result_type>(seed));
+    std::uniform_int_distribution<T> dist(std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
+
+    stdgpu::plus<> plus_function;
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        T value_1 = dist(rng);
+        U value_2 = static_cast<U>(dist(rng));
+        EXPECT_EQ(plus_function(value_1, value_2), value_1 + value_2);
+    }
+}
+
+TEST_F(stdgpu_functional, plus_transparent)
+{
+    plus_transparent_check_integer_random<int, long>();
 }
 
 template <typename T>

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -25,6 +25,7 @@
 #include <thrust/fill.h>
 #include <thrust/logical.h>
 
+#include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
@@ -586,7 +587,7 @@ copyCreateDevice2DeviceFunction(const stdgpu::index_t iterations)
         EXPECT_TRUE(thrust::equal(stdgpu::device_begin(array),
                                   stdgpu::device_end(array),
                                   stdgpu::device_begin(array_copy),
-                                  thrust::equal_to<int>()));
+                                  stdgpu::equal_to<int>()));
 #endif
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
@@ -598,7 +599,7 @@ copyCreateDevice2DeviceFunction(const stdgpu::index_t iterations)
         EXPECT_TRUE(thrust::equal(stdgpu::device_begin(array),
                                   stdgpu::device_end(array),
                                   stdgpu::device_begin(array_copy_2),
-                                  thrust::equal_to<int>()));
+                                  stdgpu::equal_to<int>()));
 
         destroyDeviceArray<int, Allocator>(a, array_copy_2);
 
@@ -644,7 +645,7 @@ copyCreateHost2DeviceFunction(const stdgpu::index_t iterations)
         EXPECT_TRUE(thrust::equal(stdgpu::device_cbegin(array),
                                   stdgpu::device_cend(array),
                                   stdgpu::device_cbegin(array_copy),
-                                  thrust::equal_to<int>()));
+                                  stdgpu::equal_to<int>()));
 #endif
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
@@ -656,7 +657,7 @@ copyCreateHost2DeviceFunction(const stdgpu::index_t iterations)
         EXPECT_TRUE(thrust::equal(stdgpu::device_begin(array),
                                   stdgpu::device_end(array),
                                   stdgpu::device_begin(array_copy_2),
-                                  thrust::equal_to<int>()));
+                                  stdgpu::equal_to<int>()));
 
         destroyDeviceArray<int, Allocator>(a, array_copy_2);
 
@@ -703,7 +704,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2DeviceArray_no_check)
     EXPECT_TRUE(thrust::equal(stdgpu::device_cbegin(array),
                               stdgpu::device_cend(array),
                               stdgpu::device_cbegin(array_copy),
-                              thrust::equal_to<int>()));
+                              stdgpu::equal_to<int>()));
 #endif
 
     destroyDeviceArray<int>(array);
@@ -732,11 +733,11 @@ copyCreateDevice2HostFunction(const stdgpu::index_t iterations)
         EXPECT_TRUE(thrust::equal(stdgpu::host_cbegin(array_host),
                                   stdgpu::host_cend(array_host),
                                   stdgpu::host_cbegin(array_copy),
-                                  thrust::equal_to<int>()));
+                                  stdgpu::equal_to<int>()));
         EXPECT_TRUE(thrust::equal(stdgpu::host_cbegin(array_host),
                                   stdgpu::host_cend(array_host),
                                   stdgpu::host_cbegin(array_copy_2),
-                                  thrust::equal_to<int>()));
+                                  stdgpu::equal_to<int>()));
 
         destroyDeviceArray<int>(array);
         destroyHostArray<int>(array_host);
@@ -783,11 +784,11 @@ copyCreateHost2HostFunction(const stdgpu::index_t iterations)
         EXPECT_TRUE(thrust::equal(stdgpu::host_cbegin(array_host),
                                   stdgpu::host_cend(array_host),
                                   stdgpu::host_cbegin(array_copy),
-                                  thrust::equal_to<int>()));
+                                  stdgpu::equal_to<int>()));
         EXPECT_TRUE(thrust::equal(stdgpu::host_cbegin(array_host),
                                   stdgpu::host_cend(array_host),
                                   stdgpu::host_cbegin(array_copy_2),
-                                  thrust::equal_to<int>()));
+                                  stdgpu::equal_to<int>()));
 
         destroyHostArray<int>(array_host);
         destroyHostArray<int>(array_copy);
@@ -828,7 +829,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2HostArray_no_check)
                               array_host,
                               array_host + size,
                               stdgpu::host_cbegin(array_copy),
-                              thrust::equal_to<int>()));
+                              stdgpu::equal_to<int>()));
 
     delete[] array_host;
     destroyHostArray<int>(array_copy);
@@ -899,7 +900,7 @@ copyDevice2DeviceFunction(const stdgpu::index_t iterations)
         EXPECT_TRUE(thrust::equal(stdgpu::device_cbegin(array),
                                   stdgpu::device_cend(array),
                                   stdgpu::device_cbegin(array_copy),
-                                  thrust::equal_to<int>()));
+                                  stdgpu::equal_to<int>()));
 #endif
 
         destroyDeviceArray<int>(array);
@@ -933,7 +934,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2DeviceArray_self)
     EXPECT_TRUE(thrust::equal(stdgpu::device_cbegin(array),
                               stdgpu::device_cend(array),
                               stdgpu::device_cbegin(array_copy),
-                              thrust::equal_to<int>()));
+                              stdgpu::equal_to<int>()));
 #endif
 
     destroyDeviceArray<int>(array);
@@ -958,7 +959,7 @@ copyHost2DeviceFunction(const stdgpu::index_t iterations)
         EXPECT_TRUE(thrust::equal(stdgpu::device_cbegin(array),
                                   stdgpu::device_cend(array),
                                   stdgpu::device_cbegin(array_copy),
-                                  thrust::equal_to<int>()));
+                                  stdgpu::equal_to<int>()));
 #endif
 
         destroyDeviceArray<int>(array);
@@ -998,7 +999,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2DeviceArray_no_check)
     EXPECT_TRUE(thrust::equal(stdgpu::device_cbegin(array),
                               stdgpu::device_cend(array),
                               stdgpu::device_cbegin(array_copy),
-                              thrust::equal_to<int>()));
+                              stdgpu::equal_to<int>()));
 #endif
 
     destroyDeviceArray<int>(array);
@@ -1024,7 +1025,7 @@ copyDevice2HostFunction(const stdgpu::index_t iterations)
         EXPECT_TRUE(thrust::equal(stdgpu::host_cbegin(array_host),
                                   stdgpu::host_cend(array_host),
                                   stdgpu::host_cbegin(array_copy),
-                                  thrust::equal_to<int>()));
+                                  stdgpu::equal_to<int>()));
 
         destroyDeviceArray<int>(array);
         destroyHostArray<int>(array_host);
@@ -1059,7 +1060,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2HostArray_no_check)
                               stdgpu::host_cbegin(array_host),
                               stdgpu::host_cend(array_host),
                               array_copy,
-                              thrust::equal_to<int>()));
+                              stdgpu::equal_to<int>()));
 
     destroyDeviceArray<int>(array);
     destroyHostArray<int>(array_host);
@@ -1083,7 +1084,7 @@ copyHost2HostFunction(const stdgpu::index_t iterations)
         EXPECT_TRUE(thrust::equal(stdgpu::host_cbegin(array_host),
                                   stdgpu::host_cend(array_host),
                                   stdgpu::host_cbegin(array_copy),
-                                  thrust::equal_to<int>()));
+                                  stdgpu::equal_to<int>()));
 
         destroyHostArray<int>(array_host);
         destroyHostArray<int>(array_copy);
@@ -1116,7 +1117,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_no_check)
     int* array_copy = new int[static_cast<std::size_t>(size)];
     copyHost2HostArray<int>(array_host, size, array_copy, MemoryCopy::NO_CHECK);
 
-    EXPECT_TRUE(thrust::equal(thrust::host, array_host, array_host + size, array_copy, thrust::equal_to<int>()));
+    EXPECT_TRUE(thrust::equal(thrust::host, array_host, array_host + size, array_copy, stdgpu::equal_to<int>()));
 
     delete[] array_host;
     delete[] array_copy;
@@ -1134,7 +1135,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_self)
     EXPECT_TRUE(thrust::equal(stdgpu::host_cbegin(array_host),
                               stdgpu::host_cend(array_host),
                               stdgpu::host_cbegin(array_copy),
-                              thrust::equal_to<int>()));
+                              stdgpu::equal_to<int>()));
 
     destroyHostArray<int>(array_host);
 }
@@ -1152,7 +1153,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_self_no_check)
     int* array_copy = array_host;
     copyHost2HostArray<int>(array_host, size, array_copy, MemoryCopy::NO_CHECK);
 
-    EXPECT_TRUE(thrust::equal(thrust::host, array_host, array_host + size, array_copy, thrust::equal_to<int>()));
+    EXPECT_TRUE(thrust::equal(thrust::host, array_host, array_host + size, array_copy, stdgpu::equal_to<int>()));
 
     delete[] array_host;
 }

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -39,6 +39,7 @@
 #include <thrust/random.h>
 #include <unordered_set>
 
+#include <stdgpu/functional.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/vector.cuh>
 #include <test_utils.h>
@@ -187,7 +188,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_hits)
     stdgpu::index_t number_hash_values = thrust::reduce(stdgpu::device_cbegin(bucket_hits),
                                                         stdgpu::device_cend(bucket_hits),
                                                         0,
-                                                        thrust::plus<int>());
+                                                        stdgpu::plus<int>());
 
     EXPECT_EQ(number_hash_values, N);
 
@@ -225,7 +226,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_collisions)
     stdgpu::index_t number_hash_values = thrust::reduce(stdgpu::device_cbegin(bucket_hits),
                                                         stdgpu::device_cend(bucket_hits),
                                                         0,
-                                                        thrust::plus<int>());
+                                                        stdgpu::plus<int>());
 
     EXPECT_EQ(number_hash_values, N);
 

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -20,6 +20,7 @@
 #include <thrust/reduce.h>
 #include <thrust/sort.h>
 
+#include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/vector.cuh>
@@ -1581,7 +1582,7 @@ TEST_F(stdgpu_vector, non_const_device_range)
     ASSERT_TRUE(pool.valid());
 
     auto range = pool.device_range();
-    int sum = thrust::reduce(range.begin(), range.end(), 0, thrust::plus<int>());
+    int sum = thrust::reduce(range.begin(), range.end(), 0, stdgpu::plus<int>());
 
     EXPECT_EQ(sum, N * (N + 1) / 2);
 
@@ -1601,7 +1602,7 @@ TEST_F(stdgpu_vector, const_device_range)
     ASSERT_TRUE(pool.valid());
 
     auto range = static_cast<const stdgpu::vector<int>&>(pool).device_range();
-    int sum = thrust::reduce(range.begin(), range.end(), 0, thrust::plus<int>());
+    int sum = thrust::reduce(range.begin(), range.end(), 0, stdgpu::plus<int>());
 
     EXPECT_EQ(sum, N * (N + 1) / 2);
 


### PR DESCRIPTION
In terms of functors, we currently rely on the `equal_to`, `identity`, and `plus` classes provided by thrust. Remove the coupling to those functions and fix some missing includes.

Partially addresses #279