### PR TITLE
algorithm: Add for_each_index

### DIFF
--- a/src/stdgpu/algorithm.h
+++ b/src/stdgpu/algorithm.h
@@ -26,6 +26,9 @@
  * \file stdgpu/algorithm.h
  */
 
+// For convenient calls of for_each_index() until there are abstractions for these
+#include <thrust/execution_policy.h>
+
 #include <stdgpu/platform.h>
 
 namespace stdgpu
@@ -68,6 +71,20 @@ max(const T& a, const T& b);
 template <class T>
 /*constexpr*/ STDGPU_HOST_DEVICE const T&
 clamp(const T& v, const T& lower, const T& upper);
+
+/**
+ * \ingroup algorithm
+ * \brief Calls the given unary function with an index from the range [0, size)
+ * \tparam IndexType The type of the index values
+ * \tparam ExecutionPolicy The type of the execution policy
+ * \tparam UnaryFunction The type of the unary function
+ * \param[in] policy The execution policy, e.g. host or device
+ * \param[in] size The number of indices, i.e. the upper bound of [0, size)
+ * \param[in] f The unary function to call with an index i
+ */
+template <typename IndexType, typename ExecutionPolicy, typename UnaryFunction>
+void
+for_each_index(ExecutionPolicy&& policy, IndexType size, UnaryFunction f);
 
 } // namespace stdgpu
 

--- a/src/stdgpu/impl/algorithm_detail.h
+++ b/src/stdgpu/impl/algorithm_detail.h
@@ -16,6 +16,9 @@
 #ifndef STDGPU_ALGORTIMH_DETAIL_H
 #define STDGPU_ALGORTIMH_DETAIL_H
 
+#include <thrust/for_each.h>
+#include <thrust/iterator/counting_iterator.h>
+
 #include <stdgpu/contract.h>
 
 namespace stdgpu
@@ -42,6 +45,13 @@ clamp(const T& v, const T& lower, const T& upper)
     STDGPU_EXPECTS(!(upper < lower));
 
     return v < lower ? lower : upper < v ? upper : v;
+}
+
+template <typename IndexType, typename ExecutionPolicy, typename UnaryFunction>
+void
+for_each_index(ExecutionPolicy&& policy, IndexType size, UnaryFunction f)
+{
+    thrust::for_each(policy, thrust::counting_iterator<IndexType>(0), thrust::counting_iterator<IndexType>(size), f);
 }
 
 } // namespace stdgpu

--- a/test/stdgpu/algorithm.cpp
+++ b/test/stdgpu/algorithm.cpp
@@ -20,6 +20,7 @@
 #include <limits>
 #include <random>
 #include <type_traits>
+#include <vector>
 
 #include <stdgpu/algorithm.h>
 #include <test_utils.h>
@@ -308,4 +309,36 @@ TEST_F(stdgpu_algorithm, clamp_float)
 TEST_F(stdgpu_algorithm, clamp_double)
 {
     check_clamp_random_float<double>();
+}
+
+class store_indices
+{
+public:
+    explicit store_indices(stdgpu::index_t* indices)
+      : _indices(indices)
+    {
+    }
+
+    STDGPU_HOST_DEVICE void
+    operator()(const stdgpu::index_t i) const
+    {
+        _indices[i] = i;
+    }
+
+private:
+    stdgpu::index_t* _indices;
+};
+
+TEST_F(stdgpu_algorithm, for_each_index)
+{
+    const stdgpu::index_t N = 100000000;
+    std::vector<stdgpu::index_t> indices_vector(N);
+    stdgpu::index_t* indices = indices_vector.data();
+
+    stdgpu::for_each_index(thrust::host, N, store_indices(indices));
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(indices[i], i);
+    }
 }

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -18,11 +18,11 @@
 #include <limits>
 #include <thrust/for_each.h>
 #include <thrust/generate.h>
-#include <thrust/iterator/counting_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 
+#include <stdgpu/algorithm.h>
 #include <stdgpu/atomic.cuh>
 #include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
@@ -1190,9 +1190,7 @@ sequence_fetch_or()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     Function<T>(value));
+    stdgpu::for_each_index(thrust::device, N, Function<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1211,9 +1209,7 @@ sequence_operator_or_equals()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     or_equals_sequence<T>(value));
+    stdgpu::for_each_index(thrust::device, N, or_equals_sequence<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1384,9 +1380,7 @@ sequence_fetch_and()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     or_sequence<T>(value));
+    stdgpu::for_each_index(thrust::device, N, or_sequence<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1396,9 +1390,7 @@ sequence_fetch_and()
 
     T one_pattern = value.load(); // We previously filled this with 1's
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     Function<T>(value, one_pattern));
+    stdgpu::for_each_index(thrust::device, N, Function<T>(value, one_pattern));
 
     value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1417,9 +1409,7 @@ sequence_operator_and_equals()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     or_equals_sequence<T>(value));
+    stdgpu::for_each_index(thrust::device, N, or_equals_sequence<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1429,9 +1419,7 @@ sequence_operator_and_equals()
 
     T one_pattern = value.load(); // We previously filled this with 1's
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     and_equals_sequence<T>(value, one_pattern));
+    stdgpu::for_each_index(thrust::device, N, and_equals_sequence<T>(value, one_pattern));
 
     value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1594,9 +1582,7 @@ sequence_fetch_xor()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     Function<T>(value));
+    stdgpu::for_each_index(thrust::device, N, Function<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1615,9 +1601,7 @@ sequence_operator_xor_equals()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     xor_equals_sequence<T>(value));
+    stdgpu::for_each_index(thrust::device, N, xor_equals_sequence<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -24,6 +24,7 @@
 #include <thrust/transform.h>
 #include <unordered_set>
 
+#include <stdgpu/algorithm.h>
 #include <stdgpu/bitset.cuh>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
@@ -532,9 +533,7 @@ TEST_F(stdgpu_bitset, set_random_bits)
     stdgpu::index_t* host_random_sequence = generate_shuffled_sequence(bitset.size());
     stdgpu::index_t* random_sequence = copyCreateHost2DeviceArray<stdgpu::index_t>(host_random_sequence, bitset.size());
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     set_bits(bitset, random_sequence, set));
+    stdgpu::for_each_index(thrust::device, N, set_bits(bitset, random_sequence, set));
 
     ASSERT_EQ(bitset.count(), N);
 
@@ -568,15 +567,11 @@ TEST_F(stdgpu_bitset, reset_random_bits)
     stdgpu::index_t* host_random_sequence = generate_shuffled_sequence(bitset.size());
     stdgpu::index_t* random_sequence = copyCreateHost2DeviceArray<stdgpu::index_t>(host_random_sequence, bitset.size());
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     set_bits(bitset, random_sequence, set));
+    stdgpu::for_each_index(thrust::device, N, set_bits(bitset, random_sequence, set));
 
     ASSERT_EQ(bitset.count(), N);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     reset_bits(bitset, random_sequence, set));
+    stdgpu::for_each_index(thrust::device, N, reset_bits(bitset, random_sequence, set));
 
     ASSERT_EQ(bitset.count(), 0);
 
@@ -602,9 +597,7 @@ TEST_F(stdgpu_bitset, set_and_reset_random_bits)
     stdgpu::index_t* host_random_sequence = generate_shuffled_sequence(bitset.size());
     stdgpu::index_t* random_sequence = copyCreateHost2DeviceArray<stdgpu::index_t>(host_random_sequence, bitset.size());
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     set_and_reset_bits(bitset, random_sequence, set));
+    stdgpu::for_each_index(thrust::device, N, set_and_reset_bits(bitset, random_sequence, set));
 
     ASSERT_EQ(bitset.count(), 0);
 
@@ -635,9 +628,7 @@ TEST_F(stdgpu_bitset, flip_random_bits_previously_reset)
     stdgpu::index_t* host_random_sequence = generate_shuffled_sequence(bitset.size());
     stdgpu::index_t* random_sequence = copyCreateHost2DeviceArray<stdgpu::index_t>(host_random_sequence, bitset.size());
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     flip_bits(bitset, random_sequence, set));
+    stdgpu::for_each_index(thrust::device, N, flip_bits(bitset, random_sequence, set));
 
     ASSERT_EQ(bitset.count(), N);
 
@@ -676,9 +667,7 @@ TEST_F(stdgpu_bitset, flip_random_bits_previously_set)
     stdgpu::index_t* host_random_sequence = generate_shuffled_sequence(bitset.size());
     stdgpu::index_t* random_sequence = copyCreateHost2DeviceArray<stdgpu::index_t>(host_random_sequence, bitset.size());
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     flip_bits(bitset, random_sequence, set));
+    stdgpu::for_each_index(thrust::device, N, flip_bits(bitset, random_sequence, set));
 
     ASSERT_EQ(bitset.count(), bitset.size() - N);
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -19,6 +19,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/sort.h>
 
+#include <stdgpu/algorithm.h>
 #include <stdgpu/deque.cuh>
 #include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
@@ -2021,20 +2022,22 @@ template <typename T>
 class non_const_operator_access_functor
 {
 public:
-    non_const_operator_access_functor(const stdgpu::deque<T>& pool, T* result)
+    non_const_operator_access_functor(const stdgpu::deque<T>& pool, const stdgpu::index_t index, T* result)
       : _pool(pool)
+      , _index(index)
       , _result(result)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
+    operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
     {
-        *_result = _pool[i];
+        *_result = _pool[_index];
     }
 
 private:
     stdgpu::deque<T> _pool;
+    stdgpu::index_t _index;
     T* _result;
 };
 
@@ -2042,20 +2045,22 @@ template <typename T>
 class const_operator_access_functor
 {
 public:
-    const_operator_access_functor(const stdgpu::deque<T>& pool, T* result)
+    const_operator_access_functor(const stdgpu::deque<T>& pool, const stdgpu::index_t index, T* result)
       : _pool(pool)
+      , _index(index)
       , _result(result)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
+    operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
     {
-        *_result = _pool[i];
+        *_result = _pool[_index];
     }
 
 private:
     const stdgpu::deque<T> _pool;
+    stdgpu::index_t _index;
     T* _result;
 };
 
@@ -2065,9 +2070,7 @@ non_const_operator_access(const stdgpu::deque<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i),
-                     thrust::counting_iterator<stdgpu::index_t>(i + 1),
-                     non_const_operator_access_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, non_const_operator_access_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -2083,9 +2086,7 @@ const_operator_access(const stdgpu::deque<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i),
-                     thrust::counting_iterator<stdgpu::index_t>(i + 1),
-                     const_operator_access_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, const_operator_access_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -2111,20 +2112,22 @@ template <typename T>
 class non_const_at_functor
 {
 public:
-    non_const_at_functor(const stdgpu::deque<T>& pool, T* result)
+    non_const_at_functor(const stdgpu::deque<T>& pool, const stdgpu::index_t index, T* result)
       : _pool(pool)
+      , _index(index)
       , _result(result)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
+    operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
     {
-        *_result = _pool.at(i);
+        *_result = _pool.at(_index);
     }
 
 private:
     stdgpu::deque<T> _pool;
+    stdgpu::index_t _index;
     T* _result;
 };
 
@@ -2132,20 +2135,22 @@ template <typename T>
 class const_at_functor
 {
 public:
-    const_at_functor(const stdgpu::deque<T>& pool, T* result)
+    const_at_functor(const stdgpu::deque<T>& pool, const stdgpu::index_t index, T* result)
       : _pool(pool)
+      , _index(index)
       , _result(result)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
+    operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
     {
-        *_result = _pool.at(i);
+        *_result = _pool.at(_index);
     }
 
 private:
     const stdgpu::deque<T> _pool;
+    stdgpu::index_t _index;
     T* _result;
 };
 
@@ -2155,9 +2160,7 @@ non_const_at(const stdgpu::deque<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i),
-                     thrust::counting_iterator<stdgpu::index_t>(i + 1),
-                     non_const_at_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, non_const_at_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -2173,9 +2176,7 @@ const_at(const stdgpu::deque<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i),
-                     thrust::counting_iterator<stdgpu::index_t>(i + 1),
-                     const_at_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, const_at_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -21,6 +21,7 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/logical.h>
 
+#include <stdgpu/algorithm.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/mutex.cuh>
@@ -104,9 +105,7 @@ private:
 
 TEST_F(stdgpu_mutex, parallel_lock_and_unlock)
 {
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(locks.size()),
-                     lock_and_unlock(locks));
+    stdgpu::for_each_index(thrust::device, locks.size(), lock_and_unlock(locks));
 
     EXPECT_TRUE(locks.valid());
 }

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -39,6 +39,7 @@
 #include <thrust/random.h>
 #include <unordered_set>
 
+#include <stdgpu/algorithm.h>
 #include <stdgpu/functional.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/vector.cuh>
@@ -297,9 +298,7 @@ insert_key(HashDataStructure& hash_datastructure, const typename HashDataStructu
 {
     stdgpu::index_t* inserted = createDeviceArray<stdgpu::index_t>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     insert_single<HashDataStructure>(hash_datastructure, key, inserted));
+    stdgpu::for_each_index(thrust::device, 1, insert_single<HashDataStructure>(hash_datastructure, key, inserted));
 
     stdgpu::index_t host_inserted;
     copyDevice2HostArray<stdgpu::index_t>(inserted, 1, &host_inserted, MemoryCopy::NO_CHECK);
@@ -338,9 +337,7 @@ erase_key(test_unordered_datastructure& hash_datastructure, const test_unordered
 {
     stdgpu::index_t* erased = createDeviceArray<stdgpu::index_t>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     erase_single(hash_datastructure, key, erased));
+    stdgpu::for_each_index(thrust::device, 1, erase_single(hash_datastructure, key, erased));
 
     stdgpu::index_t host_erased;
     copyDevice2HostArray<stdgpu::index_t>(erased, 1, &host_erased, MemoryCopy::NO_CHECK);
@@ -404,9 +401,7 @@ regular_contains_key(const test_unordered_datastructure& hash_datastructure,
 {
     stdgpu::index_t* contained = createDeviceArray<stdgpu::index_t>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     contains_key_functor(hash_datastructure, key, contained));
+    stdgpu::for_each_index(thrust::device, 1, contains_key_functor(hash_datastructure, key, contained));
 
     stdgpu::index_t host_contained;
     copyDevice2HostArray<stdgpu::index_t>(contained, 1, &host_contained, MemoryCopy::NO_CHECK);
@@ -422,9 +417,7 @@ transparent_contains_key(const test_unordered_datastructure& hash_datastructure,
 {
     stdgpu::index_t* contained = createDeviceArray<stdgpu::index_t>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     transparent_contains_key_functor(hash_datastructure, key, contained));
+    stdgpu::for_each_index(thrust::device, 1, transparent_contains_key_functor(hash_datastructure, key, contained));
 
     stdgpu::index_t host_contained;
     copyDevice2HostArray<stdgpu::index_t>(contained, 1, &host_contained, MemoryCopy::NO_CHECK);
@@ -547,9 +540,7 @@ non_const_find_key(const test_unordered_datastructure& hash_datastructure,
 {
     test_unordered_datastructure::iterator* result = createDeviceArray<test_unordered_datastructure::iterator>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     non_const_find_key_functor(hash_datastructure, key, result));
+    stdgpu::for_each_index(thrust::device, 1, non_const_find_key_functor(hash_datastructure, key, result));
 
     test_unordered_datastructure::iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -566,9 +557,7 @@ const_find_key(const test_unordered_datastructure& hash_datastructure,
     test_unordered_datastructure::const_iterator* result =
             createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     const_find_key_functor(hash_datastructure, key, result));
+    stdgpu::for_each_index(thrust::device, 1, const_find_key_functor(hash_datastructure, key, result));
 
     test_unordered_datastructure::const_iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -584,9 +573,7 @@ transparent_non_const_find_key(const test_unordered_datastructure& hash_datastru
 {
     test_unordered_datastructure::iterator* result = createDeviceArray<test_unordered_datastructure::iterator>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     transparent_non_const_find_key_functor(hash_datastructure, key, result));
+    stdgpu::for_each_index(thrust::device, 1, transparent_non_const_find_key_functor(hash_datastructure, key, result));
 
     test_unordered_datastructure::iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -603,9 +590,7 @@ transparent_const_find_key(const test_unordered_datastructure& hash_datastructur
     test_unordered_datastructure::const_iterator* result =
             createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     transparent_const_find_key_functor(hash_datastructure, key, result));
+    stdgpu::for_each_index(thrust::device, 1, transparent_const_find_key_functor(hash_datastructure, key, result));
 
     test_unordered_datastructure::const_iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -701,9 +686,7 @@ non_const_begin_iterator(const test_unordered_datastructure& hash_datastructure)
 {
     test_unordered_datastructure::iterator* result = createDeviceArray<test_unordered_datastructure::iterator>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     non_const_begin_iterator_functor(hash_datastructure, result));
+    stdgpu::for_each_index(thrust::device, 1, non_const_begin_iterator_functor(hash_datastructure, result));
 
     test_unordered_datastructure::iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -719,9 +702,7 @@ const_begin_iterator(const test_unordered_datastructure& hash_datastructure)
     test_unordered_datastructure::const_iterator* result =
             createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     const_begin_iterator_functor(hash_datastructure, result));
+    stdgpu::for_each_index(thrust::device, 1, const_begin_iterator_functor(hash_datastructure, result));
 
     test_unordered_datastructure::const_iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -737,9 +718,7 @@ cbegin_iterator(const test_unordered_datastructure& hash_datastructure)
     test_unordered_datastructure::const_iterator* result =
             createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     cbegin_iterator_functor(hash_datastructure, result));
+    stdgpu::for_each_index(thrust::device, 1, cbegin_iterator_functor(hash_datastructure, result));
 
     test_unordered_datastructure::const_iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -830,9 +809,7 @@ non_const_end_iterator(const test_unordered_datastructure& hash_datastructure)
 {
     test_unordered_datastructure::iterator* result = createDeviceArray<test_unordered_datastructure::iterator>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     non_const_end_iterator_functor(hash_datastructure, result));
+    stdgpu::for_each_index(thrust::device, 1, non_const_end_iterator_functor(hash_datastructure, result));
 
     test_unordered_datastructure::iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -848,9 +825,7 @@ const_end_iterator(const test_unordered_datastructure& hash_datastructure)
     test_unordered_datastructure::const_iterator* result =
             createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     const_end_iterator_functor(hash_datastructure, result));
+    stdgpu::for_each_index(thrust::device, 1, const_end_iterator_functor(hash_datastructure, result));
 
     test_unordered_datastructure::const_iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -866,9 +841,7 @@ cend_iterator(const test_unordered_datastructure& hash_datastructure)
     test_unordered_datastructure::const_iterator* result =
             createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     cend_iterator_functor(hash_datastructure, result));
+    stdgpu::for_each_index(thrust::device, 1, cend_iterator_functor(hash_datastructure, result));
 
     test_unordered_datastructure::const_iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1230,9 +1203,7 @@ insert_key_multiple(test_unordered_datastructure& hash_datastructure, const test
     const stdgpu::index_t N = 100000;
     stdgpu::index_t* inserted = createDeviceArray<stdgpu::index_t>(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     insert_multiple(hash_datastructure, key, inserted));
+    stdgpu::for_each_index(thrust::device, N, insert_multiple(hash_datastructure, key, inserted));
 
     stdgpu::index_t number_inserted = thrust::reduce(stdgpu::device_cbegin(inserted), stdgpu::device_cend(inserted));
 
@@ -1251,9 +1222,7 @@ erase_key_multiple(test_unordered_datastructure& hash_datastructure, const test_
     const stdgpu::index_t N = 100000;
     stdgpu::index_t* erased = createDeviceArray<stdgpu::index_t>(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     erase_multiple(hash_datastructure, key, erased));
+    stdgpu::for_each_index(thrust::device, N, erase_multiple(hash_datastructure, key, erased));
 
     stdgpu::index_t number_erased = thrust::reduce(stdgpu::device_cbegin(erased), stdgpu::device_cend(erased));
 
@@ -1417,9 +1386,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_multiple_while_full)
     const stdgpu::index_t N = 100000;
     stdgpu::index_t* inserted = createDeviceArray<stdgpu::index_t>(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     insert_multiple(tiny_hash_datastructure, position_3, inserted));
+    stdgpu::for_each_index(thrust::device, N, insert_multiple(tiny_hash_datastructure, position_3, inserted));
 
     stdgpu::index_t number_inserted = thrust::reduce(stdgpu::device_cbegin(inserted), stdgpu::device_cend(inserted));
 
@@ -1575,9 +1542,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_one_free
     test_unordered_datastructure::key_type* positions =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     insert_keys(tiny_hash_datastructure, positions, inserted));
+    stdgpu::for_each_index(thrust::device, N, insert_keys(tiny_hash_datastructure, positions, inserted));
 
     stdgpu::index_t number_inserted = thrust::reduce(stdgpu::device_cbegin(inserted), stdgpu::device_cend(inserted));
 
@@ -1615,9 +1580,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_excess_e
     test_unordered_datastructure::key_type* positions =
             createDeviceArray<test_unordered_datastructure::key_type>(N, position_3);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     insert_keys(tiny_hash_datastructure, positions, inserted));
+    stdgpu::for_each_index(thrust::device, N, insert_keys(tiny_hash_datastructure, positions, inserted));
 
     stdgpu::index_t number_inserted = thrust::reduce(stdgpu::device_cbegin(inserted), stdgpu::device_cend(inserted));
 
@@ -1667,9 +1630,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, emplace_parallel_while_one_fre
     test_unordered_datastructure::key_type* positions =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     emplace_keys(tiny_hash_datastructure, positions, inserted));
+    stdgpu::for_each_index(thrust::device, N, emplace_keys(tiny_hash_datastructure, positions, inserted));
 
     stdgpu::index_t number_inserted = thrust::reduce(stdgpu::device_cbegin(inserted), stdgpu::device_cend(inserted));
 
@@ -1707,9 +1668,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, emplace_parallel_while_excess_
     test_unordered_datastructure::key_type* positions =
             createDeviceArray<test_unordered_datastructure::key_type>(N, position_3);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     emplace_keys(tiny_hash_datastructure, positions, inserted));
+    stdgpu::for_each_index(thrust::device, N, emplace_keys(tiny_hash_datastructure, positions, inserted));
 
     stdgpu::index_t number_inserted = thrust::reduce(stdgpu::device_cbegin(inserted), stdgpu::device_cend(inserted));
 
@@ -1761,9 +1720,7 @@ insert_unique_parallel(test_unordered_datastructure& hash_datastructure, const s
     test_unordered_datastructure::key_type* positions =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     insert_keys(hash_datastructure, positions, inserted));
+    stdgpu::for_each_index(thrust::device, N, insert_keys(hash_datastructure, positions, inserted));
 
     stdgpu::index_t number_inserted = thrust::reduce(stdgpu::device_cbegin(inserted), stdgpu::device_cend(inserted));
 
@@ -1787,9 +1744,7 @@ emplace_unique_parallel(test_unordered_datastructure& hash_datastructure, const 
     test_unordered_datastructure::key_type* positions =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     emplace_keys(hash_datastructure, positions, inserted));
+    stdgpu::for_each_index(thrust::device, N, emplace_keys(hash_datastructure, positions, inserted));
 
     stdgpu::index_t number_inserted = thrust::reduce(stdgpu::device_cbegin(inserted), stdgpu::device_cend(inserted));
 
@@ -1813,9 +1768,7 @@ erase_unique_parallel(test_unordered_datastructure& hash_datastructure,
     test_unordered_datastructure::key_type* positions =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(N),
-                     erase_keys(hash_datastructure, positions, erased));
+    stdgpu::for_each_index(thrust::device, N, erase_keys(hash_datastructure, positions, erased));
 
     stdgpu::index_t number_erased = thrust::reduce(stdgpu::device_cbegin(erased), stdgpu::device_cend(erased));
 
@@ -1894,9 +1847,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_range_unique_parallel)
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
     test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     Key2ValueFunctor(hash_datastructure, positions, values));
+    stdgpu::for_each_index(thrust::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
 
     stdgpu::device_ptr<test_unordered_datastructure::value_type> values_begin = stdgpu::device_begin(values);
     stdgpu::device_ptr<test_unordered_datastructure::value_type> values_end = stdgpu::device_end(values);
@@ -1920,9 +1871,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_const_range_unique_para
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
     test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     Key2ValueFunctor(hash_datastructure, positions, values));
+    stdgpu::for_each_index(thrust::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
 
     stdgpu::device_ptr<const test_unordered_datastructure::value_type> values_begin = stdgpu::device_cbegin(values);
     stdgpu::device_ptr<const test_unordered_datastructure::value_type> values_end = stdgpu::device_cend(values);
@@ -1946,9 +1895,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_range_unique_parallel)
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
     test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     Key2ValueFunctor(hash_datastructure, positions, values));
+    stdgpu::for_each_index(thrust::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
 
     stdgpu::device_ptr<test_unordered_datastructure::value_type> values_begin = stdgpu::device_begin(values);
     stdgpu::device_ptr<test_unordered_datastructure::value_type> values_end = stdgpu::device_end(values);
@@ -1980,9 +1927,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_const_range_unique_paral
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
     test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     Key2ValueFunctor(hash_datastructure, positions, values));
+    stdgpu::for_each_index(thrust::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
 
     stdgpu::device_ptr<const test_unordered_datastructure::value_type> values_begin = stdgpu::device_cbegin(values);
     stdgpu::device_ptr<const test_unordered_datastructure::value_type> values_end = stdgpu::device_cend(values);
@@ -2053,9 +1998,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_and_erase_unique_parall
     test_unordered_datastructure::key_type* positions =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     insert_and_erase_keys(hash_datastructure, positions, inserted, erased));
+    stdgpu::for_each_index(thrust::device, N, insert_and_erase_keys(hash_datastructure, positions, inserted, erased));
 
     stdgpu::index_t number_inserted = thrust::reduce(stdgpu::device_cbegin(inserted), stdgpu::device_cend(inserted));
     stdgpu::index_t number_erased = thrust::reduce(stdgpu::device_cbegin(erased), stdgpu::device_cend(erased));
@@ -2154,9 +2097,9 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_size_sum)
 
     stdgpu::index_t* bucket_sizes = createDeviceArray<stdgpu::index_t>(hash_datastructure.bucket_count());
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(hash_datastructure.bucket_count()),
-                     store_bucket_sizes(hash_datastructure, bucket_sizes));
+    stdgpu::for_each_index(thrust::device,
+                           hash_datastructure.bucket_count(),
+                           store_bucket_sizes(hash_datastructure, bucket_sizes));
 
     stdgpu::index_t bucket_size_sum =
             thrust::reduce(stdgpu::device_cbegin(bucket_sizes), stdgpu::device_cend(bucket_sizes));
@@ -2182,13 +2125,11 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, count_sum)
     stdgpu::index_t* counts = createDeviceArray<stdgpu::index_t>(N);
     stdgpu::index_t* transparent_counts = createDeviceArray<stdgpu::index_t>(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     store_counts(hash_datastructure, positions, counts));
+    stdgpu::for_each_index(thrust::device, N, store_counts(hash_datastructure, positions, counts));
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     transparent_store_counts(hash_datastructure, positions, transparent_counts));
+    stdgpu::for_each_index(thrust::device,
+                           N,
+                           transparent_store_counts(hash_datastructure, positions, transparent_counts));
 
     stdgpu::index_t counts_sum = thrust::reduce(stdgpu::device_cbegin(counts), stdgpu::device_cend(counts));
     stdgpu::index_t transparent_counts_sum =

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -20,6 +20,7 @@
 #include <thrust/reduce.h>
 #include <thrust/sort.h>
 
+#include <stdgpu/algorithm.h>
 #include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
@@ -1208,9 +1209,7 @@ non_const_back(const stdgpu::vector<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(1),
-                     non_const_back_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, non_const_back_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1226,9 +1225,7 @@ const_back(const stdgpu::vector<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(0),
-                     thrust::counting_iterator<stdgpu::index_t>(1),
-                     const_back_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, const_back_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1254,20 +1251,22 @@ template <typename T>
 class non_const_operator_access_functor
 {
 public:
-    non_const_operator_access_functor(const stdgpu::vector<T>& pool, T* result)
+    non_const_operator_access_functor(const stdgpu::vector<T>& pool, const stdgpu::index_t index, T* result)
       : _pool(pool)
+      , _index(index)
       , _result(result)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
+    operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
     {
-        *_result = _pool[i];
+        *_result = _pool[_index];
     }
 
 private:
     stdgpu::vector<T> _pool;
+    stdgpu::index_t _index;
     T* _result;
 };
 
@@ -1275,20 +1274,22 @@ template <typename T>
 class const_operator_access_functor
 {
 public:
-    const_operator_access_functor(const stdgpu::vector<T>& pool, T* result)
+    const_operator_access_functor(const stdgpu::vector<T>& pool, const stdgpu::index_t index, T* result)
       : _pool(pool)
+      , _index(index)
       , _result(result)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
+    operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
     {
-        *_result = _pool[i];
+        *_result = _pool[_index];
     }
 
 private:
     const stdgpu::vector<T> _pool;
+    stdgpu::index_t _index;
     T* _result;
 };
 
@@ -1298,9 +1299,7 @@ non_const_operator_access(const stdgpu::vector<T>& pool, const stdgpu::index_t i
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i),
-                     thrust::counting_iterator<stdgpu::index_t>(i + 1),
-                     non_const_operator_access_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, non_const_operator_access_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1316,9 +1315,7 @@ const_operator_access(const stdgpu::vector<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i),
-                     thrust::counting_iterator<stdgpu::index_t>(i + 1),
-                     const_operator_access_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, const_operator_access_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1344,20 +1341,22 @@ template <typename T>
 class non_const_at_functor
 {
 public:
-    non_const_at_functor(const stdgpu::vector<T>& pool, T* result)
+    non_const_at_functor(const stdgpu::vector<T>& pool, const stdgpu::index_t index, T* result)
       : _pool(pool)
+      , _index(index)
       , _result(result)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
+    operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
     {
-        *_result = _pool.at(i);
+        *_result = _pool.at(_index);
     }
 
 private:
     stdgpu::vector<T> _pool;
+    stdgpu::index_t _index;
     T* _result;
 };
 
@@ -1365,20 +1364,22 @@ template <typename T>
 class const_at_functor
 {
 public:
-    const_at_functor(const stdgpu::vector<T>& pool, T* result)
+    const_at_functor(const stdgpu::vector<T>& pool, const stdgpu::index_t index, T* result)
       : _pool(pool)
+      , _index(index)
       , _result(result)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
+    operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
     {
-        *_result = _pool.at(i);
+        *_result = _pool.at(_index);
     }
 
 private:
     const stdgpu::vector<T> _pool;
+    stdgpu::index_t _index;
     T* _result;
 };
 
@@ -1388,9 +1389,7 @@ non_const_at(const stdgpu::vector<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i),
-                     thrust::counting_iterator<stdgpu::index_t>(i + 1),
-                     non_const_at_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, non_const_at_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1406,9 +1405,7 @@ const_at(const stdgpu::vector<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<stdgpu::index_t>(i),
-                     thrust::counting_iterator<stdgpu::index_t>(i + 1),
-                     const_at_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, const_at_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);


### PR DESCRIPTION
A common pattern of the used algorithms is a simple parallel for loop over a range of indices `[0, N)`. Since many other algorithms could be implemented in terms such a for loop as well, this will be a good starting point to consolidate the calls to thrust to a single place. Add a `for_each_index` function and port all direct functions following this pattern to the new syntax.

Partially addresses #279