### PR TITLE
src: Port away from distance

### DIFF
--- a/src/stdgpu/impl/ranges_detail.h
+++ b/src/stdgpu/impl/ranges_detail.h
@@ -16,8 +16,6 @@
 #ifndef STDGPU_RANGES_DETAIL_H
 #define STDGPU_RANGES_DETAIL_H
 
-#include <thrust/distance.h>
-
 namespace stdgpu
 {
 
@@ -69,7 +67,7 @@ template <typename T>
 STDGPU_HOST_DEVICE index64_t
 device_range<T>::size() const
 {
-    return thrust::distance(begin(), end());
+    return end() - begin();
 }
 
 template <typename T>
@@ -127,7 +125,7 @@ template <typename T>
 STDGPU_HOST_DEVICE index64_t
 host_range<T>::size() const
 {
-    return thrust::distance(begin(), end());
+    return end() - begin();
 }
 
 template <typename T>
@@ -170,7 +168,7 @@ template <typename R, typename UnaryFunction>
 STDGPU_HOST_DEVICE index64_t
 transform_range<R, UnaryFunction>::size() const
 {
-    return thrust::distance(begin(), end());
+    return end() - begin();
 }
 
 template <typename R, typename UnaryFunction>

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <cmath>
 
-#include <thrust/distance.h>
 #include <thrust/logical.h>
 
 #include <stdgpu/algorithm.h>
@@ -338,7 +337,7 @@ public:
             auto block = _base._key_from_value(_base._values[i]);
 
             auto it = _base.find(block); // NOLINT(readability-qualified-auto)
-            index_t position = static_cast<index_t>(thrust::distance(_base.begin(), it));
+            index_t position = static_cast<index_t>(it - _base.begin());
 
             if (position != i)
             {
@@ -714,7 +713,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::try_erase(
     operation_status status = operation_status::failed_collision;
 
     const_iterator it = find(key);
-    index_t position = static_cast<index_t>(thrust::distance(cbegin(), it));
+    index_t position = static_cast<index_t>(it - cbegin());
 
     bool contains_block = (it != end());
     if (contains_block)

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -53,7 +53,7 @@ namespace stdgpu
 namespace detail
 {
 
-template <typename T, typename Allocator, bool>
+template <typename T, typename Allocator, typename ValueIterator, bool>
 class vector_insert;
 
 template <typename T, typename Allocator, bool>
@@ -360,7 +360,7 @@ public:
     device_range() const;
 
 private:
-    template <typename T2, typename Allocator2, bool>
+    template <typename T2, typename Allocator2, typename ValueIterator2, bool>
     friend class detail::vector_insert;
 
     template <typename T2, typename Allocator2, bool>


### PR DESCRIPTION
Due to the parallelism of the involved algorithms, we already assume that all pointers and iterators can be accessed randomly which also implies that the computing the distance between two iterators only involves a subtraction. Replace calls to `distance` by a simple subtraction. Furthermore, clean up the internal insertion function of `vector` which also relies on `distance`.

Partially addresses #279