### PR TITLE
algorithm: Add parallel iota function

### DIFF
--- a/src/stdgpu/algorithm.h
+++ b/src/stdgpu/algorithm.h
@@ -86,6 +86,21 @@ template <typename IndexType, typename ExecutionPolicy, typename UnaryFunction>
 void
 for_each_index(ExecutionPolicy&& policy, IndexType size, UnaryFunction f);
 
+/**
+ * \ingroup algorithm
+ * \brief Writes ascending values {values + i} to the i-th position of the given range
+ * \tparam ExecutionPolicy The type of the execution policy
+ * \tparam Iterator The type of the iterators
+ * \tparam T The type of the values
+ * \param[in] policy The execution policy, e.g. host or device
+ * \param[in] begin The iterator pointing to the first element
+ * \param[in] end The iterator pointing past to the last element
+ * \param[in] value The starting value that will be incremented
+ */
+template <typename ExecutionPolicy, typename Iterator, typename T>
+void
+iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value);
+
 } // namespace stdgpu
 
 /**

--- a/src/stdgpu/impl/algorithm_detail.h
+++ b/src/stdgpu/impl/algorithm_detail.h
@@ -54,6 +54,38 @@ for_each_index(ExecutionPolicy&& policy, IndexType size, UnaryFunction f)
     thrust::for_each(policy, thrust::counting_iterator<IndexType>(0), thrust::counting_iterator<IndexType>(size), f);
 }
 
+namespace detail
+{
+template <typename Iterator, typename T>
+class iota_functor
+{
+public:
+    iota_functor(Iterator begin, T value)
+      : _begin(begin)
+      , _value(value)
+    {
+    }
+
+    STDGPU_HOST_DEVICE void
+    operator()(const index_t i)
+    {
+        _begin[i] = _value + static_cast<T>(i);
+    }
+
+private:
+    Iterator _begin;
+    T _value;
+};
+} // namespace detail
+
+template <typename ExecutionPolicy, typename Iterator, typename T>
+void
+iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value)
+{
+    index_t N = static_cast<index_t>(end - begin);
+    for_each_index(policy, N, detail::iota_functor<Iterator, T>(begin, value));
+}
+
 } // namespace stdgpu
 
 #endif // STDGPU_ALGORTIMH_DETAIL_H

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -18,6 +18,7 @@
 
 #include <thrust/sequence.h>
 
+#include <stdgpu/algorithm.h>
 #include <stdgpu/contract.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
@@ -521,22 +522,27 @@ deque<T, Allocator>::device_range()
     // Full, i.e. one large block and begin == end
     if (full())
     {
-        thrust::sequence(stdgpu::device_begin(_range_indices), stdgpu::device_end(_range_indices), 0);
+        stdgpu::iota(thrust::device, stdgpu::device_begin(_range_indices), stdgpu::device_end(_range_indices), 0);
     }
     // One large block, including empty block
     else if (begin <= end)
     {
-        thrust::sequence(stdgpu::device_begin(_range_indices),
-                         stdgpu::device_begin(_range_indices) + (end - begin),
-                         begin);
+        stdgpu::iota(thrust::device,
+                     stdgpu::device_begin(_range_indices),
+                     stdgpu::device_begin(_range_indices) + (end - begin),
+                     begin);
     }
     // Two disconnected blocks
     else
     {
-        thrust::sequence(stdgpu::device_begin(_range_indices), stdgpu::device_begin(_range_indices) + end, 0);
-        thrust::sequence(stdgpu::device_begin(_range_indices) + end,
-                         stdgpu::device_begin(_range_indices) + (end + capacity() - begin),
-                         begin);
+        stdgpu::iota(thrust::device,
+                     stdgpu::device_begin(_range_indices),
+                     stdgpu::device_begin(_range_indices) + end,
+                     0);
+        stdgpu::iota(thrust::device,
+                     stdgpu::device_begin(_range_indices) + end,
+                     stdgpu::device_begin(_range_indices) + (end + capacity() - begin),
+                     begin);
     }
 
     return device_indexed_range<value_type>(stdgpu::device_range<index_t>(_range_indices, size()), data());
@@ -552,22 +558,27 @@ deque<T, Allocator>::device_range() const
     // Full, i.e. one large block and begin == end
     if (full())
     {
-        thrust::sequence(stdgpu::device_begin(_range_indices), stdgpu::device_end(_range_indices), 0);
+        stdgpu::iota(thrust::device, stdgpu::device_begin(_range_indices), stdgpu::device_end(_range_indices), 0);
     }
     // One large block, including empty block
     else if (begin <= end)
     {
-        thrust::sequence(stdgpu::device_begin(_range_indices),
-                         stdgpu::device_begin(_range_indices) + (end - begin),
-                         begin);
+        stdgpu::iota(thrust::device,
+                     stdgpu::device_begin(_range_indices),
+                     stdgpu::device_begin(_range_indices) + (end - begin),
+                     begin);
     }
     // Two disconnected blocks
     else
     {
-        thrust::sequence(stdgpu::device_begin(_range_indices), stdgpu::device_begin(_range_indices) + end, 0);
-        thrust::sequence(stdgpu::device_begin(_range_indices) + end,
-                         stdgpu::device_begin(_range_indices) + (end + capacity() - begin),
-                         begin);
+        stdgpu::iota(thrust::device,
+                     stdgpu::device_begin(_range_indices),
+                     stdgpu::device_begin(_range_indices) + end,
+                     0);
+        stdgpu::iota(thrust::device,
+                     stdgpu::device_begin(_range_indices) + end,
+                     stdgpu::device_begin(_range_indices) + (end + capacity() - begin),
+                     begin);
     }
 
     return device_indexed_range<const value_type>(stdgpu::device_range<index_t>(_range_indices, size()), data());

--- a/test/stdgpu/algorithm.cpp
+++ b/test/stdgpu/algorithm.cpp
@@ -342,3 +342,18 @@ TEST_F(stdgpu_algorithm, for_each_index)
         EXPECT_EQ(indices[i], i);
     }
 }
+
+TEST_F(stdgpu_algorithm, iota)
+{
+    const stdgpu::index_t N = 100000000;
+    std::vector<stdgpu::index_t> indices_vector(N);
+    stdgpu::index_t* indices = indices_vector.data();
+
+    stdgpu::index_t init = 42;
+    stdgpu::iota(thrust::host, indices_vector.begin(), indices_vector.end(), init);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(indices[i], i + init);
+    }
+}

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -490,7 +490,7 @@ sequence_exchange()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N - 1);
-    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
     value.store(N);
@@ -649,7 +649,7 @@ sequence_compare_exchange_weak()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
@@ -667,7 +667,7 @@ sequence_compare_exchange_strong()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
@@ -821,7 +821,7 @@ sequence_fetch_add()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
@@ -839,7 +839,7 @@ sequence_operator_add_equals()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
@@ -993,7 +993,7 @@ sequence_fetch_sub()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
@@ -1015,7 +1015,7 @@ sequence_operator_sub_equals()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
@@ -1697,7 +1697,7 @@ sequence_fetch_min()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
     value.store(std::numeric_limits<T>::max());
@@ -1750,7 +1750,7 @@ sequence_fetch_max()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    thrust::sequence(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
     value.store(std::numeric_limits<T>::lowest());

--- a/test/stdgpu/iterator.cpp
+++ b/test/stdgpu/iterator.cpp
@@ -20,6 +20,7 @@
 #include <thrust/sort.h>
 #include <vector>
 
+#include <stdgpu/algorithm.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
 

--- a/test/stdgpu/ranges.cpp
+++ b/test/stdgpu/ranges.cpp
@@ -16,9 +16,8 @@
 #include <gtest/gtest.h>
 
 #include <thrust/copy.h>
-#include <thrust/functional.h>
-#include <thrust/tabulate.h>
 
+#include <stdgpu/algorithm.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
@@ -282,7 +281,7 @@ TEST_F(stdgpu_ranges, transform_range_with_range)
     const stdgpu::transform_range<stdgpu::host_range<int>, square<int>> square_range(array_range);
 
     // Setup array
-    thrust::tabulate(array_range.begin(), array_range.end(), thrust::identity<int>());
+    stdgpu::iota(thrust::host, array_range.begin(), array_range.end(), 0);
 
     // Execute transformation and write into array_result
     thrust::copy(square_range.begin(), square_range.end(), stdgpu::host_begin(array_result));
@@ -307,7 +306,7 @@ TEST_F(stdgpu_ranges, transform_range_with_range_and_function)
     const stdgpu::transform_range<stdgpu::host_range<int>, square<int>> square_range(array_range, square<int>());
 
     // Setup array
-    thrust::tabulate(array_range.begin(), array_range.end(), thrust::identity<int>());
+    stdgpu::iota(thrust::host, array_range.begin(), array_range.end(), 0);
 
     // Execute transformation and write into array_result
     thrust::copy(square_range.begin(), square_range.end(), stdgpu::host_begin(array_result));


### PR DESCRIPTION
Some data structures need a set of indices internally for managing their structure. While `for_each_index` provides a universal way to iterate over a range of indices, `iota` (and thrust's `sequence` version of it) allows to store such a sequence for later reuse. Port all uses of  `sequence` and `tabulate` to the newly added parallel `iota` function.

Partially addresses #279