### PR TITLE
src,test: Port away from transform

### DIFF
--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -15,13 +15,8 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <limits>
 #include <random>
-#include <thrust/functional.h>
-#include <thrust/iterator/counting_iterator.h>
-#include <thrust/logical.h>
-#include <thrust/transform.h>
 #include <unordered_set>
 
 #include <stdgpu/algorithm.h>
@@ -75,54 +70,59 @@ TEST_F(stdgpu_bitset, default_values)
 class set_all_bits
 {
 public:
-    explicit set_all_bits(const stdgpu::bitset<>& bitset)
+    set_all_bits(const stdgpu::bitset<>& bitset, std::uint8_t* set)
       : _bitset(bitset)
+      , _set(set)
     {
     }
 
-    STDGPU_DEVICE_ONLY bool
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
         _bitset.set(i);
 
         // Test both access operators at the same time
-        return _bitset[i] && _bitset.test(i);
+        _set[i] = static_cast<std::uint8_t>(_bitset[i] && _bitset.test(i));
     }
 
 private:
     stdgpu::bitset<> _bitset;
+    std::uint8_t* _set;
 };
 
 class reset_all_bits
 {
 public:
-    explicit reset_all_bits(const stdgpu::bitset<>& bitset)
+    reset_all_bits(const stdgpu::bitset<>& bitset, std::uint8_t* set)
       : _bitset(bitset)
+      , _set(set)
     {
     }
 
-    STDGPU_DEVICE_ONLY bool
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
         _bitset.reset(i);
 
         // Test both access operators at the same time
-        return _bitset[i] && _bitset.test(i);
+        _set[i] = static_cast<std::uint8_t>(_bitset[i] && _bitset.test(i));
     }
 
 private:
     stdgpu::bitset<> _bitset;
+    std::uint8_t* _set;
 };
 
 class set_and_reset_all_bits
 {
 public:
-    explicit set_and_reset_all_bits(const stdgpu::bitset<>& bitset)
+    set_and_reset_all_bits(const stdgpu::bitset<>& bitset, std::uint8_t* set)
       : _bitset(bitset)
+      , _set(set)
     {
     }
 
-    STDGPU_DEVICE_ONLY bool
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
         _bitset.set(i);
@@ -133,42 +133,42 @@ public:
         }
 
         // Test both access operators at the same time
-        return _bitset[i] && _bitset.test(i);
+        _set[i] = static_cast<std::uint8_t>(_bitset[i] && _bitset.test(i));
     }
 
 private:
     stdgpu::bitset<> _bitset;
+    std::uint8_t* _set;
 };
 
 class flip_all_bits
 {
 public:
-    explicit flip_all_bits(const stdgpu::bitset<>& bitset)
+    flip_all_bits(const stdgpu::bitset<>& bitset, std::uint8_t* set)
       : _bitset(bitset)
+      , _set(set)
     {
     }
 
-    STDGPU_DEVICE_ONLY bool
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
         _bitset.flip(i);
 
         // Test both access operators at the same time
-        return _bitset[i] && _bitset.test(i);
+        _set[i] = static_cast<std::uint8_t>(_bitset[i] && _bitset.test(i));
     }
 
 private:
     stdgpu::bitset<> _bitset;
+    std::uint8_t* _set;
 };
 
 TEST_F(stdgpu_bitset, set_all_bits_componentwise)
 {
     std::uint8_t* set = createDeviceArray<std::uint8_t>(bitset.size());
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(0),
-                      thrust::counting_iterator<stdgpu::index_t>(bitset.size()),
-                      stdgpu::device_begin(set),
-                      set_all_bits(bitset));
+    stdgpu::for_each_index(thrust::device, bitset.size(), set_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), bitset.size());
 
@@ -187,17 +187,11 @@ TEST_F(stdgpu_bitset, reset_all_bits_componentwise)
 {
     std::uint8_t* set = createDeviceArray<std::uint8_t>(bitset.size());
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(0),
-                      thrust::counting_iterator<stdgpu::index_t>(bitset.size()),
-                      stdgpu::device_begin(set),
-                      set_all_bits(bitset));
+    stdgpu::for_each_index(thrust::device, bitset.size(), set_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), bitset.size());
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(0),
-                      thrust::counting_iterator<stdgpu::index_t>(bitset.size()),
-                      stdgpu::device_begin(set),
-                      reset_all_bits(bitset));
+    stdgpu::for_each_index(thrust::device, bitset.size(), reset_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), 0);
 
@@ -216,10 +210,7 @@ TEST_F(stdgpu_bitset, set_and_reset_all_bits_componentwise)
 {
     std::uint8_t* set = createDeviceArray<std::uint8_t>(bitset.size());
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(0),
-                      thrust::counting_iterator<stdgpu::index_t>(bitset.size()),
-                      stdgpu::device_begin(set),
-                      set_and_reset_all_bits(bitset));
+    stdgpu::for_each_index(thrust::device, bitset.size(), set_and_reset_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), 0);
 
@@ -241,10 +232,7 @@ TEST_F(stdgpu_bitset, flip_all_bits_previously_reset_componentwise)
     // Previously reset
     bitset.reset();
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(0),
-                      thrust::counting_iterator<stdgpu::index_t>(bitset.size()),
-                      stdgpu::device_begin(set),
-                      flip_all_bits(bitset));
+    stdgpu::for_each_index(thrust::device, bitset.size(), flip_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), bitset.size());
 
@@ -266,10 +254,7 @@ TEST_F(stdgpu_bitset, flip_all_bits_previously_set_componentwise)
     // Previously set
     bitset.set();
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(0),
-                      thrust::counting_iterator<stdgpu::index_t>(bitset.size()),
-                      stdgpu::device_begin(set),
-                      flip_all_bits(bitset));
+    stdgpu::for_each_index(thrust::device, bitset.size(), flip_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), 0);
 
@@ -287,20 +272,22 @@ TEST_F(stdgpu_bitset, flip_all_bits_previously_set_componentwise)
 class read_all_bits
 {
 public:
-    explicit read_all_bits(const stdgpu::bitset<>& bitset)
+    read_all_bits(const stdgpu::bitset<>& bitset, std::uint8_t* set)
       : _bitset(bitset)
+      , _set(set)
     {
     }
 
-    STDGPU_DEVICE_ONLY bool
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
         // Test both access operators at the same time
-        return _bitset[i] && _bitset.test(i);
+        _set[i] = static_cast<std::uint8_t>(_bitset[i] && _bitset.test(i));
     }
 
 private:
     stdgpu::bitset<> _bitset;
+    std::uint8_t* _set;
 };
 
 TEST_F(stdgpu_bitset, set_all_bits)
@@ -309,10 +296,7 @@ TEST_F(stdgpu_bitset, set_all_bits)
 
     bitset.set();
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(0),
-                      thrust::counting_iterator<stdgpu::index_t>(bitset.size()),
-                      stdgpu::device_begin(set),
-                      read_all_bits(bitset));
+    stdgpu::for_each_index(thrust::device, bitset.size(), read_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), bitset.size());
 
@@ -337,10 +321,7 @@ TEST_F(stdgpu_bitset, reset_all_bits)
 
     bitset.reset();
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(0),
-                      thrust::counting_iterator<stdgpu::index_t>(bitset.size()),
-                      stdgpu::device_begin(set),
-                      read_all_bits(bitset));
+    stdgpu::for_each_index(thrust::device, bitset.size(), read_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), 0);
 
@@ -364,10 +345,7 @@ TEST_F(stdgpu_bitset, flip_all_bits_previously_reset)
 
     bitset.flip();
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(0),
-                      thrust::counting_iterator<stdgpu::index_t>(bitset.size()),
-                      stdgpu::device_begin(set),
-                      read_all_bits(bitset));
+    stdgpu::for_each_index(thrust::device, bitset.size(), read_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), bitset.size());
 

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -15,9 +15,7 @@
 
 #include <gtest/gtest.h>
 
-#include <thrust/iterator/counting_iterator.h>
 #include <thrust/logical.h>
-#include <thrust/transform.h>
 
 #include <stdgpu/algorithm.h>
 #include <stdgpu/attribute.h>
@@ -112,21 +110,23 @@ TEST_F(stdgpu_mutex, parallel_lock_and_unlock)
 class same_state
 {
 public:
-    same_state(const stdgpu::mutex_array<>& locks_1, const stdgpu::mutex_array<>& locks_2)
+    same_state(const stdgpu::mutex_array<>& locks_1, const stdgpu::mutex_array<>& locks_2, std::uint8_t* equality_flags)
       : _locks_1(locks_1)
       , _locks_2(locks_2)
+      , _equality_flags(equality_flags)
     {
     }
 
-    STDGPU_DEVICE_ONLY bool
+    STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
-        return _locks_1[i].locked() == _locks_2[i].locked();
+        _equality_flags[i] = static_cast<std::uint8_t>(_locks_1[i].locked() == _locks_2[i].locked());
     }
 
 private:
     stdgpu::mutex_array<> _locks_1;
     stdgpu::mutex_array<> _locks_2;
+    std::uint8_t* _equality_flags;
 };
 
 struct check_flag
@@ -148,10 +148,7 @@ equal(const stdgpu::mutex_array<>& locks_1, const stdgpu::mutex_array<>& locks_2
 
     std::uint8_t* equality_flags = createDeviceArray<std::uint8_t>(locks_1.size());
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(0),
-                      thrust::counting_iterator<stdgpu::index_t>(locks_1.size()),
-                      stdgpu::device_begin(equality_flags),
-                      same_state(locks_1, locks_2));
+    stdgpu::for_each_index(thrust::device, locks_1.size(), same_state(locks_1, locks_2, equality_flags));
 
     bool result =
             thrust::all_of(stdgpu::device_cbegin(equality_flags), stdgpu::device_cend(equality_flags), check_flag());
@@ -164,19 +161,23 @@ equal(const stdgpu::mutex_array<>& locks_1, const stdgpu::mutex_array<>& locks_2
 class lock_single_functor
 {
 public:
-    explicit lock_single_functor(const stdgpu::mutex_array<>& locks)
+    lock_single_functor(const stdgpu::mutex_array<>& locks, const stdgpu::index_t n, std::uint8_t* result)
       : _locks(locks)
+      , _n(n)
+      , _result(result)
     {
     }
 
-    STDGPU_DEVICE_ONLY bool
-    operator()(const stdgpu::index_t i)
+    STDGPU_DEVICE_ONLY void
+    operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
     {
-        return _locks[i].try_lock();
+        *_result = static_cast<std::uint8_t>(_locks[_n].try_lock());
     }
 
 private:
     stdgpu::mutex_array<> _locks;
+    stdgpu::index_t _n;
+    std::uint8_t* _result;
 };
 
 bool
@@ -184,10 +185,7 @@ lock_single(const stdgpu::mutex_array<>& locks, const stdgpu::index_t n)
 {
     std::uint8_t* result = createDeviceArray<std::uint8_t>(1);
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(n),
-                      thrust::counting_iterator<stdgpu::index_t>(n + 1),
-                      stdgpu::device_begin(result),
-                      lock_single_functor(locks));
+    stdgpu::for_each_index(thrust::device, 1, lock_single_functor(locks, n, result));
 
     std::uint8_t host_result;
     copyDevice2HostArray<std::uint8_t>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -219,7 +217,10 @@ TEST_F(stdgpu_mutex, single_try_lock_while_locked)
 class lock_multiple_functor
 {
 public:
-    lock_multiple_functor(const stdgpu::mutex_array<>& locks, stdgpu::index_t n_0, stdgpu::index_t n_1, int* result)
+    lock_multiple_functor(const stdgpu::mutex_array<>& locks,
+                          const stdgpu::index_t n_0,
+                          const stdgpu::index_t n_1,
+                          int* result)
       : _locks(locks)
       , _n_0(n_0)
       , _n_1(n_1)
@@ -340,8 +341,8 @@ class lock_multiple_functor_new_reference
 {
 public:
     lock_multiple_functor_new_reference(const stdgpu::mutex_array<>& locks,
-                                        stdgpu::index_t n_0,
-                                        stdgpu::index_t n_1,
+                                        const stdgpu::index_t n_0,
+                                        const stdgpu::index_t n_1,
                                         int* result)
       : _locks(locks)
       , _n_0(n_0)
@@ -383,20 +384,24 @@ lock_multiple_new_reference(const stdgpu::mutex_array<>& locks, const stdgpu::in
 class lock_single_functor_new_reference
 {
 public:
-    explicit lock_single_functor_new_reference(const stdgpu::mutex_array<>& locks)
+    lock_single_functor_new_reference(const stdgpu::mutex_array<>& locks, const stdgpu::index_t n, std::uint8_t* result)
       : _locks(locks)
+      , _n(n)
+      , _result(result)
     {
     }
 
-    STDGPU_DEVICE_ONLY bool
-    operator()(const stdgpu::index_t i)
+    STDGPU_DEVICE_ONLY void
+    operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
     {
-        stdgpu::mutex_array<>::reference ref = static_cast<stdgpu::mutex_array<>::reference>(_locks[i]);
-        return ref.try_lock();
+        stdgpu::mutex_array<>::reference ref = static_cast<stdgpu::mutex_array<>::reference>(_locks[_n]);
+        *_result = static_cast<std::uint8_t>(ref.try_lock());
     }
 
 private:
     stdgpu::mutex_array<> _locks;
+    stdgpu::index_t _n;
+    std::uint8_t* _result;
 };
 
 bool
@@ -404,10 +409,7 @@ lock_single_new_reference(const stdgpu::mutex_array<>& locks, const stdgpu::inde
 {
     std::uint8_t* result = createDeviceArray<std::uint8_t>(1);
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(n),
-                      thrust::counting_iterator<stdgpu::index_t>(n + 1),
-                      stdgpu::device_begin(result),
-                      lock_single_functor_new_reference(locks));
+    stdgpu::for_each_index(thrust::device, 1, lock_single_functor_new_reference(locks, n, result));
 
     std::uint8_t host_result;
     copyDevice2HostArray<std::uint8_t>(result, 1, &host_result, MemoryCopy::NO_CHECK);

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -113,25 +113,26 @@ namespace
 class random_key
 {
 public:
-    STDGPU_HOST_DEVICE
-    explicit random_key(const std::size_t seed)
+    random_key(const std::size_t seed, test_unordered_datastructure::key_type* keys)
       : _seed(seed)
+      , _keys(keys)
     {
     }
 
-    STDGPU_HOST_DEVICE test_unordered_datastructure::key_type
-    operator()(const stdgpu::index_t n) const
+    STDGPU_HOST_DEVICE void
+    operator()(const stdgpu::index_t i)
     {
         thrust::default_random_engine rng(static_cast<thrust::default_random_engine::result_type>(_seed));
         thrust::uniform_real_distribution<std::int16_t> dist(stdgpu::numeric_limits<std::int16_t>::min(),
                                                              stdgpu::numeric_limits<std::int16_t>::max());
-        rng.discard(static_cast<unsigned long long int>(3) * static_cast<unsigned long long int>(n));
+        rng.discard(static_cast<unsigned long long int>(3) * static_cast<unsigned long long int>(i));
 
-        return { dist(rng), dist(rng), dist(rng) };
+        _keys[i] = { dist(rng), dist(rng), dist(rng) };
     }
 
 private:
     std::size_t _seed;
+    test_unordered_datastructure::key_type* _keys;
 };
 
 class count_buckets_hits
@@ -176,10 +177,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_hits)
     const stdgpu::index_t N = 2 * hash_datastructure.bucket_count();
     test_unordered_datastructure::key_type* keys = createDeviceArray<test_unordered_datastructure::key_type>(N);
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(0),
-                      thrust::counting_iterator<stdgpu::index_t>(N),
-                      stdgpu::device_begin(keys),
-                      random_key(test_utils::random_seed()));
+    stdgpu::for_each_index(thrust::device, N, random_key(test_utils::random_seed(), keys));
 
     thrust::for_each(stdgpu::device_begin(keys),
                      stdgpu::device_end(keys),
@@ -214,10 +212,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_collisions)
     const stdgpu::index_t N = hash_datastructure.bucket_count();
     test_unordered_datastructure::key_type* keys = createDeviceArray<test_unordered_datastructure::key_type>(N);
 
-    thrust::transform(thrust::counting_iterator<stdgpu::index_t>(0),
-                      thrust::counting_iterator<stdgpu::index_t>(N),
-                      stdgpu::device_begin(keys),
-                      random_key(test_utils::random_seed()));
+    stdgpu::for_each_index(thrust::device, N, random_key(test_utils::random_seed(), keys));
 
     thrust::for_each(stdgpu::device_begin(keys),
                      stdgpu::device_end(keys),
@@ -253,7 +248,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, hash_objects)
     test_unordered_datastructure::key_equal key_equals = hash_datastructure.key_eq();
     test_unordered_datastructure::hasher hash = hash_datastructure.hash_function();
 
-    test_unordered_datastructure::key_type key = random_key(test_utils::random_seed())(0);
+    test_unordered_datastructure::key_type key;
 
     std::size_t key_hash_1 = hash(key);
     std::size_t key_hash_2 = hash(key);


### PR DESCRIPTION
Another function that is primarily used in the unit test is `transform` to generate flags based on a successful operation which are then tested. Port these use cases to `for_each_index` to remove the dependency and to make the code look more uniform.

Partially addresses #279