### PR TITLE
test: Fix missing include in bitset

### DIFF
--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -15,6 +15,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <limits>
 #include <random>
 #include <unordered_set>


### PR DESCRIPTION
During the refactoring of the `bitset` unit test, the includes were also updated and cleaned up. However, this introduced a regression with `std::shuffle` which is defined in `<algorithm>`, but not directly included anymore. Fix this possible compilation error by adding the missing include. 