### PR TITLE
test: Port away from sort and count_if

### DIFF
--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -19,7 +19,6 @@
 #include <thrust/copy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/sort.h>
 
 #include <stdgpu/algorithm.h>
 #include <stdgpu/deque.cuh>
@@ -202,12 +201,16 @@ fill_deque(stdgpu::deque<int>& pool, const stdgpu::index_t N)
                      thrust::counting_iterator<int>(static_cast<int>(N + init)),
                      push_back_deque<int>(pool));
 
-    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data()) + N);
+    int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+    copyHost2DeviceArray<int>(host_numbers, N, pool.data());
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_TRUE(pool.valid());
     ASSERT_TRUE((N == 0) ? pool.empty() : !pool.empty());
     ASSERT_TRUE((N == pool.capacity()) ? pool.full() : !pool.full());
+
+    destroyHostArray<int>(host_numbers);
 }
 
 void
@@ -405,14 +408,14 @@ TEST_F(stdgpu_deque, push_back_some)
                      thrust::counting_iterator<int>(N_push + init),
                      push_back_deque<int>(pool));
 
-    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -441,14 +444,14 @@ TEST_F(stdgpu_deque, push_back_all)
                      thrust::counting_iterator<int>(N_push + init),
                      push_back_deque<int>(pool));
 
-    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -553,14 +556,14 @@ TEST_F(stdgpu_deque, emplace_back_some)
                      thrust::counting_iterator<int>(N_push + init),
                      emplace_back_deque<int>(pool));
 
-    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -589,14 +592,14 @@ TEST_F(stdgpu_deque, emplace_back_all)
                      thrust::counting_iterator<int>(N_push + init),
                      emplace_back_deque<int>(pool));
 
-    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -946,14 +949,14 @@ TEST_F(stdgpu_deque, push_front_some)
                      thrust::counting_iterator<int>(N_push + init),
                      push_front_deque<int>(pool));
 
-    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -982,14 +985,14 @@ TEST_F(stdgpu_deque, push_front_all)
                      thrust::counting_iterator<int>(N_push + init),
                      push_front_deque<int>(pool));
 
-    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -1093,14 +1096,14 @@ TEST_F(stdgpu_deque, emplace_front_some)
                      thrust::counting_iterator<int>(N_push + init),
                      emplace_front_deque<int>(pool));
 
-    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -1129,14 +1132,14 @@ TEST_F(stdgpu_deque, emplace_front_all)
                      thrust::counting_iterator<int>(N_push + init),
                      emplace_front_deque<int>(pool));
 
-    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -1244,14 +1247,14 @@ TEST_F(stdgpu_deque, push_back_circular)
                      thrust::counting_iterator<int>(N_push + init),
                      push_back_deque<int>(pool));
 
-    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1 + N_pop);
@@ -1284,14 +1287,14 @@ TEST_F(stdgpu_deque, push_front_circular)
                      thrust::counting_iterator<int>(N_push + init),
                      push_front_deque<int>(pool));
 
-    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data() + pool.size()));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1 + N_pop);
@@ -1482,15 +1485,14 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_back)
     ASSERT_FALSE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    thrust::sort(stdgpu::make_device(pool_validation.data()),
-                 stdgpu::make_device(pool_validation.data() + pool_validation.size()));
-
     ASSERT_EQ(pool_validation.size(), N);
     ASSERT_FALSE(pool_validation.empty());
     ASSERT_TRUE(pool_validation.full());
     ASSERT_TRUE(pool_validation.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool_validation.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -1546,15 +1548,14 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_front)
     ASSERT_FALSE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    thrust::sort(stdgpu::make_device(pool_validation.data()),
-                 stdgpu::make_device(pool_validation.data() + pool_validation.size()));
-
     ASSERT_EQ(pool_validation.size(), N);
     ASSERT_FALSE(pool_validation.empty());
     ASSERT_TRUE(pool_validation.full());
     ASSERT_TRUE(pool_validation.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool_validation.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -1610,15 +1611,14 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_back)
     ASSERT_FALSE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    thrust::sort(stdgpu::make_device(pool_validation.data()),
-                 stdgpu::make_device(pool_validation.data() + pool_validation.size()));
-
     ASSERT_EQ(pool_validation.size(), N);
     ASSERT_FALSE(pool_validation.empty());
     ASSERT_TRUE(pool_validation.full());
     ASSERT_TRUE(pool_validation.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool_validation.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -1674,15 +1674,14 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_front)
     ASSERT_FALSE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    thrust::sort(stdgpu::make_device(pool_validation.data()),
-                 stdgpu::make_device(pool_validation.data() + pool_validation.size()));
-
     ASSERT_EQ(pool_validation.size(), N);
     ASSERT_FALSE(pool_validation.empty());
     ASSERT_TRUE(pool_validation.full());
     ASSERT_TRUE(pool_validation.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool_validation.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -31,12 +31,11 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <numeric>
 #include <random>
 #include <thread>
-#include <thrust/count.h>
 #include <thrust/for_each.h>
-#include <thrust/iterator/counting_iterator.h>
 #include <thrust/random.h>
 #include <unordered_set>
 
@@ -193,8 +192,9 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_hits)
     EXPECT_EQ(number_hash_values, N);
 
     // Number of hits (buckets with > 0 elements)
-    stdgpu::index_t number_hits = static_cast<stdgpu::index_t>(
-            thrust::count_if(stdgpu::device_cbegin(bucket_hits), stdgpu::device_cend(bucket_hits), greater_value<0>()));
+    stdgpu::index_t number_hits = static_cast<stdgpu::index_t>(std::count_if(stdgpu::host_cbegin(host_bucket_hits),
+                                                                             stdgpu::host_cend(host_bucket_hits),
+                                                                             greater_value<0>()));
 
     const float percent_hits = 80.0F;
     EXPECT_GT(number_hits,
@@ -229,8 +229,10 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_collisions)
     EXPECT_EQ(number_hash_values, N);
 
     // Number of collisions (buckets with > 1 elements)
-    stdgpu::index_t number_collisions = static_cast<stdgpu::index_t>(
-            thrust::count_if(stdgpu::device_cbegin(bucket_hits), stdgpu::device_cend(bucket_hits), greater_value<1>()));
+    stdgpu::index_t number_collisions =
+            static_cast<stdgpu::index_t>(std::count_if(stdgpu::host_cbegin(host_bucket_hits),
+                                                       stdgpu::host_cend(host_bucket_hits),
+                                                       greater_value<1>()));
 
     const float percent_collisions = 40.0F;
     EXPECT_LT(number_collisions, static_cast<stdgpu::index_t>(static_cast<float>(N) * percent_collisions / 100.0F));
@@ -2285,8 +2287,8 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_keys_same)
     test_unordered_datastructure::key_type* host_positions_inserted =
             copyCreateDevice2HostArray<test_unordered_datastructure::key_type>(keys.data(), keys.size());
 
-    thrust::sort(host_positions, host_positions + N, less());
-    thrust::sort(host_positions_inserted, host_positions_inserted + N, less());
+    std::sort(host_positions, host_positions + N, less());
+    std::sort(host_positions_inserted, host_positions_inserted + N, less());
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -19,7 +19,6 @@
 #include <thrust/copy.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
-#include <thrust/sort.h>
 
 #include <stdgpu/algorithm.h>
 #include <stdgpu/functional.h>
@@ -200,12 +199,16 @@ fill_vector(stdgpu::vector<int>& pool, const stdgpu::index_t N)
                      thrust::counting_iterator<int>(static_cast<int>(N + init)),
                      push_back_vector<int>(pool));
 
-    thrust::sort(stdgpu::make_device(pool.data()), stdgpu::make_device(pool.data()) + N);
+    int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+    copyHost2DeviceArray<int>(host_numbers, N, pool.data());
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_TRUE(pool.valid());
     ASSERT_TRUE((N == 0) ? pool.empty() : !pool.empty());
     ASSERT_TRUE((N == pool.capacity()) ? pool.full() : !pool.full());
+
+    destroyHostArray<int>(host_numbers);
 }
 
 void
@@ -403,14 +406,14 @@ TEST_F(stdgpu_vector, push_back_some)
                      thrust::counting_iterator<int>(N_push + init),
                      push_back_vector<int>(pool));
 
-    thrust::sort(stdgpu::device_begin(pool), stdgpu::device_end(pool));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -439,14 +442,14 @@ TEST_F(stdgpu_vector, push_back_all)
                      thrust::counting_iterator<int>(N_push + init),
                      push_back_vector<int>(pool));
 
-    thrust::sort(stdgpu::device_begin(pool), stdgpu::device_end(pool));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -551,14 +554,14 @@ TEST_F(stdgpu_vector, emplace_back_some)
                      thrust::counting_iterator<int>(N_push + init),
                      push_back_vector<int>(pool));
 
-    thrust::sort(stdgpu::device_begin(pool), stdgpu::device_end(pool));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -587,14 +590,14 @@ TEST_F(stdgpu_vector, emplace_back_all)
                      thrust::counting_iterator<int>(N_push + init),
                      emplace_back_vector<int>(pool));
 
-    thrust::sort(stdgpu::device_begin(pool), stdgpu::device_end(pool));
-
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);
@@ -907,14 +910,14 @@ TEST_F(stdgpu_vector, simultaneous_push_back_and_pop_back)
     ASSERT_FALSE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    thrust::sort(stdgpu::device_begin(pool_validation), stdgpu::device_end(pool_validation));
-
     ASSERT_EQ(pool_validation.size(), N);
     ASSERT_FALSE(pool_validation.empty());
     ASSERT_TRUE(pool_validation.full());
     ASSERT_TRUE(pool_validation.valid());
 
     int* host_numbers = copyCreateDevice2HostArray(pool_validation.data(), N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
         EXPECT_EQ(host_numbers[i], i + 1);


### PR DESCRIPTION
The `sort` and `count_if` functions are only used in the unit tests and are already surrounded by code where both a device and host version of the involved data arrays are allocated. Port away from both of these functions by utilizing the host versions instead.

Partially addresses #279