### PR TITLE
src,test: Port away from for_each

### DIFF
--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -111,7 +111,7 @@ template <typename Iterator>
 void
 unoptimized_destroy(Iterator first, Iterator last)
 {
-    thrust::for_each(first, last, detail::destroy_value<typename std::iterator_traits<Iterator>::value_type>());
+    thrust::for_each(first, last, destroy_value<typename std::iterator_traits<Iterator>::value_type>());
 }
 
 void
@@ -705,11 +705,9 @@ template <typename Iterator>
 void
 destroy(Iterator first, Iterator last)
 {
-    using T = typename std::iterator_traits<Iterator>::value_type;
-
-    if (!detail::is_destroy_optimizable<T>())
+    if (!detail::is_destroy_optimizable<typename std::iterator_traits<Iterator>::value_type>())
     {
-        thrust::for_each(first, last, detail::destroy_value<T>());
+        detail::unoptimized_destroy(first, last);
     }
 }
 

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -17,7 +17,6 @@
 
 #include <algorithm>
 #include <limits>
-#include <thrust/for_each.h>
 
 #include <stdgpu/algorithm.h>
 #include <stdgpu/atomic.cuh>
@@ -428,57 +427,63 @@ template <typename T>
 class exchange_sequence
 {
 public:
-    explicit exchange_sequence(const stdgpu::atomic<T>& value)
+    exchange_sequence(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(T& x)
+    operator()(const stdgpu::index_t i)
     {
-        x = _value.exchange(x);
+        _sequence[i] = _value.exchange(_sequence[i]);
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
 class exchange_sequence_nonmember
 {
 public:
-    explicit exchange_sequence_nonmember(const stdgpu::atomic<T>& value)
+    exchange_sequence_nonmember(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(T& x)
+    operator()(const stdgpu::index_t i)
     {
-        x = stdgpu::atomic_exchange(&_value, x);
+        _sequence[i] = stdgpu::atomic_exchange(&_value, _sequence[i]);
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
 class exchange_sequence_nonmember_explicit
 {
 public:
-    explicit exchange_sequence_nonmember_explicit(const stdgpu::atomic<T>& value)
+    exchange_sequence_nonmember_explicit(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(T& x)
+    operator()(const stdgpu::index_t i)
     {
-        x = stdgpu::atomic_exchange_explicit(&_value, x, stdgpu::memory_order_relaxed);
+        _sequence[i] = stdgpu::atomic_exchange_explicit(&_value, _sequence[i], stdgpu::memory_order_relaxed);
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T, template <typename> class Function>
@@ -492,7 +497,7 @@ sequence_exchange()
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
     value.store(N);
 
-    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), Function<T>(value));
+    stdgpu::for_each_index(thrust::device, N - 1, Function<T>(value, sequence));
 
     T* host_sequence = createHostArray<T>(N);
     copyDevice2HostArray<T>(sequence, N - 1, host_sequence);
@@ -559,16 +564,17 @@ template <typename T>
 class add_sequence_with_compare_exchange_weak
 {
 public:
-    explicit add_sequence_with_compare_exchange_weak(const stdgpu::atomic<T>& value)
+    add_sequence_with_compare_exchange_weak(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
         T old = _value.load();
-        while (!_value.compare_exchange_weak(old, old + x))
+        while (!_value.compare_exchange_weak(old, old + _sequence[i]))
         {
             // Wait until exchanged
         }
@@ -576,22 +582,24 @@ public:
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
 class add_sequence_with_compare_exchange_weak_nonmember
 {
 public:
-    explicit add_sequence_with_compare_exchange_weak_nonmember(const stdgpu::atomic<T>& value)
+    add_sequence_with_compare_exchange_weak_nonmember(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
         T old = stdgpu::atomic_load(&_value);
-        while (!stdgpu::atomic_compare_exchange_weak(&_value, &old, old + x))
+        while (!stdgpu::atomic_compare_exchange_weak(&_value, &old, old + _sequence[i]))
         {
             // Wait until exchanged
         }
@@ -599,22 +607,24 @@ public:
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
 class add_sequence_with_compare_exchange_strong
 {
 public:
-    explicit add_sequence_with_compare_exchange_strong(const stdgpu::atomic<T>& value)
+    add_sequence_with_compare_exchange_strong(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
         T old = _value.load();
-        while (!_value.compare_exchange_strong(old, old + x))
+        while (!_value.compare_exchange_strong(old, old + _sequence[i]))
         {
             // Wait until exchanged
         }
@@ -622,22 +632,24 @@ public:
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
 class add_sequence_with_compare_exchange_strong_nonmember
 {
 public:
-    explicit add_sequence_with_compare_exchange_strong_nonmember(const stdgpu::atomic<T>& value)
+    add_sequence_with_compare_exchange_strong_nonmember(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
         T old = stdgpu::atomic_load(&_value);
-        while (!stdgpu::atomic_compare_exchange_strong(&_value, &old, old + x))
+        while (!stdgpu::atomic_compare_exchange_strong(&_value, &old, old + _sequence[i]))
         {
             // Wait until exchanged
         }
@@ -645,6 +657,7 @@ public:
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T, template <typename> class Function>
@@ -657,7 +670,7 @@ sequence_compare_exchange_weak()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), Function<T>(value));
+    stdgpu::for_each_index(thrust::device, N, Function<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(N * (N + 1) / 2));
 
@@ -675,7 +688,7 @@ sequence_compare_exchange_strong()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), Function<T>(value));
+    stdgpu::for_each_index(thrust::device, N, Function<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(N * (N + 1) / 2));
 
@@ -747,76 +760,84 @@ template <typename T>
 class add_sequence
 {
 public:
-    explicit add_sequence(const stdgpu::atomic<T>& value)
+    add_sequence(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _value.fetch_add(x);
+        _value.fetch_add(_sequence[i]);
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
 class add_sequence_nonmember
 {
 public:
-    explicit add_sequence_nonmember(const stdgpu::atomic<T>& value)
+    add_sequence_nonmember(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        stdgpu::atomic_fetch_add(&_value, x);
+        stdgpu::atomic_fetch_add(&_value, _sequence[i]);
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
 class add_sequence_nonmember_explicit
 {
 public:
-    explicit add_sequence_nonmember_explicit(const stdgpu::atomic<T>& value)
+    add_sequence_nonmember_explicit(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        stdgpu::atomic_fetch_add_explicit(&_value, x, stdgpu::memory_order_relaxed);
+        stdgpu::atomic_fetch_add_explicit(&_value, _sequence[i], stdgpu::memory_order_relaxed);
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
 class add_equals_sequence
 {
 public:
-    explicit add_equals_sequence(const stdgpu::atomic<T>& value)
+    add_equals_sequence(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _value += x;
+        _value += _sequence[i];
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T, template <typename> class Function>
@@ -829,7 +850,7 @@ sequence_fetch_add()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), Function<T>(value));
+    stdgpu::for_each_index(thrust::device, N, Function<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(N * (N + 1) / 2));
 
@@ -847,7 +868,7 @@ sequence_operator_add_equals()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), add_equals_sequence<T>(value));
+    stdgpu::for_each_index(thrust::device, N, add_equals_sequence<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(N * (N + 1) / 2));
 
@@ -919,76 +940,84 @@ template <typename T>
 class sub_sequence
 {
 public:
-    explicit sub_sequence(const stdgpu::atomic<T>& value)
+    sub_sequence(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _value.fetch_sub(x);
+        _value.fetch_sub(_sequence[i]);
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
 class sub_sequence_nonmember
 {
 public:
-    explicit sub_sequence_nonmember(const stdgpu::atomic<T>& value)
+    sub_sequence_nonmember(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        stdgpu::atomic_fetch_sub(&_value, x);
+        stdgpu::atomic_fetch_sub(&_value, _sequence[i]);
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
 class sub_sequence_nonmember_explicit
 {
 public:
-    explicit sub_sequence_nonmember_explicit(const stdgpu::atomic<T>& value)
+    sub_sequence_nonmember_explicit(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        stdgpu::atomic_fetch_sub_explicit(&_value, x, stdgpu::memory_order_relaxed);
+        stdgpu::atomic_fetch_sub_explicit(&_value, _sequence[i], stdgpu::memory_order_relaxed);
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
 class sub_equals_sequence
 {
 public:
-    explicit sub_equals_sequence(const stdgpu::atomic<T>& value)
+    sub_equals_sequence(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _value -= x;
+        _value -= _sequence[i];
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T, template <typename> class Function>
@@ -1001,11 +1030,11 @@ sequence_fetch_sub()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), add_sequence<T>(value));
+    stdgpu::for_each_index(thrust::device, N, add_sequence<T>(value, sequence));
 
     ASSERT_EQ(value.load(), T(N * (N + 1) / 2));
 
-    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), Function<T>(value));
+    stdgpu::for_each_index(thrust::device, N, Function<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(0));
 
@@ -1023,11 +1052,11 @@ sequence_operator_sub_equals()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), add_equals_sequence<T>(value));
+    stdgpu::for_each_index(thrust::device, N, add_equals_sequence<T>(value, sequence));
 
     ASSERT_EQ(value.load(), T(N * (N + 1) / 2));
 
-    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), sub_equals_sequence<T>(value));
+    stdgpu::for_each_index(thrust::device, N, sub_equals_sequence<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(0));
 
@@ -1304,6 +1333,7 @@ public:
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
     T _one_pattern;
 };
 
@@ -1327,6 +1357,7 @@ public:
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
     T _one_pattern;
 };
 
@@ -1680,19 +1711,21 @@ template <typename T>
 class min_sequence
 {
 public:
-    explicit min_sequence(const stdgpu::atomic<T>& value)
+    min_sequence(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _value.fetch_min(x);
+        _value.fetch_min(_sequence[i]);
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
@@ -1706,7 +1739,7 @@ sequence_fetch_min()
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
     value.store(std::numeric_limits<T>::max());
 
-    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), min_sequence<T>(value));
+    stdgpu::for_each_index(thrust::device, N, min_sequence<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(1));
 
@@ -1733,19 +1766,21 @@ template <typename T>
 class max_sequence
 {
 public:
-    explicit max_sequence(const stdgpu::atomic<T>& value)
+    max_sequence(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _value.fetch_max(x);
+        _value.fetch_max(_sequence[i]);
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
@@ -1759,7 +1794,7 @@ sequence_fetch_max()
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
     value.store(std::numeric_limits<T>::lowest());
 
-    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), max_sequence<T>(value));
+    stdgpu::for_each_index(thrust::device, N, max_sequence<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(N));
 
@@ -1786,19 +1821,21 @@ template <typename T>
 class inc_mod_sequence
 {
 public:
-    explicit inc_mod_sequence(const stdgpu::atomic<T>& value)
+    inc_mod_sequence(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _value.fetch_inc_mod(x);
+        _value.fetch_inc_mod(_sequence[i]);
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
@@ -1813,7 +1850,7 @@ sequence_fetch_inc_mod()
     const T new_value = static_cast<T>(42);
     value.store(new_value);
 
-    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), inc_mod_sequence<T>(value));
+    stdgpu::for_each_index(thrust::device, N, inc_mod_sequence<T>(value, sequence));
 
     EXPECT_EQ(value.load(), new_value);
 
@@ -1840,19 +1877,21 @@ template <typename T>
 class dec_mod_dequence
 {
 public:
-    explicit dec_mod_dequence(const stdgpu::atomic<T>& value)
+    dec_mod_dequence(const stdgpu::atomic<T>& value, T* sequence)
       : _value(value)
+      , _sequence(sequence)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _value.fetch_dec_mod(x);
+        _value.fetch_dec_mod(_sequence[i]);
     }
 
 private:
     stdgpu::atomic<T> _value;
+    T* _sequence;
 };
 
 template <typename T>
@@ -1867,7 +1906,7 @@ sequence_fetch_dec_mod()
     const T new_value = static_cast<T>(42);
     value.store(new_value);
 
-    thrust::for_each(stdgpu::device_begin(sequence), stdgpu::device_end(sequence), dec_mod_dequence<T>(value));
+    stdgpu::for_each_index(thrust::device, N, dec_mod_dequence<T>(value, sequence));
 
     EXPECT_EQ(value.load(), new_value);
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -17,8 +17,6 @@
 
 #include <algorithm>
 #include <thrust/copy.h>
-#include <thrust/for_each.h>
-#include <thrust/iterator/counting_iterator.h>
 
 #include <stdgpu/algorithm.h>
 #include <stdgpu/deque.cuh>
@@ -82,7 +80,7 @@ public:
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(STDGPU_MAYBE_UNUSED const T x)
+    operator()(STDGPU_MAYBE_UNUSED stdgpu::index_t i)
     {
         _pool.pop_back();
     }
@@ -101,7 +99,7 @@ public:
     }
 
     inline STDGPU_HOST_DEVICE void
-    operator()(STDGPU_MAYBE_UNUSED const typename Pair::first_type& first)
+    operator()(STDGPU_MAYBE_UNUSED stdgpu::index_t i)
     {
         _pool.pop_back();
     }
@@ -110,83 +108,95 @@ private:
     stdgpu::deque<Pair> _pool;
 };
 
-template <typename T>
+template <typename T, typename Values = T>
 class push_back_deque
 {
 public:
-    explicit push_back_deque(const stdgpu::deque<T>& pool)
+    push_back_deque(const stdgpu::deque<T>& pool, Values* values)
       : _pool(pool)
+      , _values(values)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.push_back(x);
+        _pool.push_back(_values[i]);
     }
 
 private:
     stdgpu::deque<T> _pool;
+    Values* _values;
 };
 
 template <typename Pair>
 class push_back_deque_const_type
 {
 public:
-    push_back_deque_const_type(const stdgpu::deque<Pair>& pool, const typename Pair::second_type& second)
+    push_back_deque_const_type(const stdgpu::deque<Pair>& pool,
+                               typename Pair::first_type* firsts,
+                               const typename Pair::second_type& second)
       : _pool(pool)
+      , _firsts(firsts)
       , _second(second)
     {
     }
 
     inline STDGPU_HOST_DEVICE void
-    operator()(const typename Pair::first_type& first)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.push_back(thrust::make_pair(first, _second));
+        _pool.push_back(thrust::make_pair(_firsts[i], _second));
     }
 
 private:
     stdgpu::deque<Pair> _pool;
+    typename Pair::first_type* _firsts;
     typename Pair::second_type _second;
 };
 
-template <typename T>
+template <typename T, typename Values = T>
 class emplace_back_deque
 {
 public:
-    explicit emplace_back_deque(const stdgpu::deque<T>& pool)
+    emplace_back_deque(const stdgpu::deque<T>& pool, Values* values)
       : _pool(pool)
+      , _values(values)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.emplace_back(x);
+        _pool.emplace_back(_values[i]);
     }
 
 private:
     stdgpu::deque<T> _pool;
+    Values* _values;
 };
 
 template <typename Pair>
 class emplace_back_deque_const_type
 {
 public:
-    emplace_back_deque_const_type(const stdgpu::deque<Pair>& pool, const typename Pair::second_type& second)
+    emplace_back_deque_const_type(const stdgpu::deque<Pair>& pool,
+                                  typename Pair::first_type* firsts,
+                                  const typename Pair::second_type& second)
       : _pool(pool)
+      , _firsts(firsts)
       , _second(second)
     {
     }
 
     inline STDGPU_HOST_DEVICE void
-    operator()(const typename Pair::first_type& first)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.emplace_back(first, _second);
+        _pool.emplace_back(_firsts[i], _second);
     }
 
 private:
     stdgpu::deque<Pair> _pool;
+    typename Pair::first_type* _firsts;
     typename Pair::second_type _second;
 };
 
@@ -196,10 +206,10 @@ fill_deque(stdgpu::deque<int>& pool, const stdgpu::index_t N)
     ASSERT_GE(N, 0);
     ASSERT_LE(N, pool.capacity());
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(static_cast<int>(init)),
-                     thrust::counting_iterator<int>(static_cast<int>(N + init)),
-                     push_back_deque<int>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, push_back_deque<int>(pool, values));
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -211,6 +221,7 @@ fill_deque(stdgpu::deque<int>& pool, const stdgpu::index_t N)
     ASSERT_TRUE((N == pool.capacity()) ? pool.full() : !pool.full());
 
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 void
@@ -270,9 +281,7 @@ TEST_F(stdgpu_deque, pop_back_some)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), N_remaining);
     ASSERT_FALSE(pool.empty());
@@ -298,9 +307,7 @@ TEST_F(stdgpu_deque, pop_back_all)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -319,9 +326,7 @@ TEST_F(stdgpu_deque, pop_back_too_many)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -339,19 +344,18 @@ TEST_F(stdgpu_deque, pop_back_const_type)
 
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
     const float part_second = 2.0F;
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_deque_const_type<T>(pool, part_second));
+    stdgpu::for_each_index(thrust::device, N, push_back_deque_const_type<T>(pool, values, part_second));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     pop_back_deque_const_type<T>(pool));
+    stdgpu::for_each_index(thrust::device, N, pop_back_deque_const_type<T>(pool));
 
     EXPECT_EQ(pool.size(), 0);
     EXPECT_TRUE(pool.empty());
@@ -359,6 +363,7 @@ TEST_F(stdgpu_deque, pop_back_const_type)
     EXPECT_TRUE(pool.valid());
 
     stdgpu::deque<T>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, pop_back_nondefault_type)
@@ -367,18 +372,17 @@ TEST_F(stdgpu_deque, pop_back_nondefault_type)
 
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_deque<nondefault_int_deque>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     pop_back_deque<nondefault_int_deque>(pool));
+    stdgpu::for_each_index(thrust::device, N, pop_back_deque<nondefault_int_deque>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -386,6 +390,7 @@ TEST_F(stdgpu_deque, pop_back_nondefault_type)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::deque<nondefault_int_deque>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, push_back_some)
@@ -399,14 +404,12 @@ TEST_F(stdgpu_deque, push_back_some)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
 
-    const stdgpu::index_t init = 1 + N_remaining;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     push_back_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
+
+    stdgpu::for_each_index(thrust::device, N_push, push_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -423,6 +426,7 @@ TEST_F(stdgpu_deque, push_back_some)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, push_back_all)
@@ -435,14 +439,12 @@ TEST_F(stdgpu_deque, push_back_all)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     push_back_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, push_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -459,6 +461,7 @@ TEST_F(stdgpu_deque, push_back_all)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, push_back_too_many)
@@ -471,14 +474,12 @@ TEST_F(stdgpu_deque, push_back_too_many)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     push_back_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, push_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -495,6 +496,7 @@ TEST_F(stdgpu_deque, push_back_too_many)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, push_back_const_type)
@@ -505,10 +507,11 @@ TEST_F(stdgpu_deque, push_back_const_type)
 
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
     const float part_second = 2.0F;
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_deque_const_type<T>(pool, part_second));
+    stdgpu::for_each_index(thrust::device, N, push_back_deque_const_type<T>(pool, values, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -516,6 +519,7 @@ TEST_F(stdgpu_deque, push_back_const_type)
     EXPECT_TRUE(pool.valid());
 
     stdgpu::deque<T>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, push_back_nondefault_type)
@@ -524,9 +528,10 @@ TEST_F(stdgpu_deque, push_back_nondefault_type)
 
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_deque<nondefault_int_deque>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -534,6 +539,7 @@ TEST_F(stdgpu_deque, push_back_nondefault_type)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::deque<nondefault_int_deque>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, emplace_back_some)
@@ -547,14 +553,12 @@ TEST_F(stdgpu_deque, emplace_back_some)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
 
-    const stdgpu::index_t init = 1 + N_remaining;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     emplace_back_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
+
+    stdgpu::for_each_index(thrust::device, N_push, emplace_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -571,6 +575,7 @@ TEST_F(stdgpu_deque, emplace_back_some)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, emplace_back_all)
@@ -583,14 +588,12 @@ TEST_F(stdgpu_deque, emplace_back_all)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     emplace_back_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, emplace_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -607,6 +610,7 @@ TEST_F(stdgpu_deque, emplace_back_all)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, emplace_back_too_many)
@@ -619,14 +623,12 @@ TEST_F(stdgpu_deque, emplace_back_too_many)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     emplace_back_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, emplace_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -643,6 +645,7 @@ TEST_F(stdgpu_deque, emplace_back_too_many)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, emplace_back_const_type)
@@ -653,10 +656,11 @@ TEST_F(stdgpu_deque, emplace_back_const_type)
 
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
     const float part_second = 2.0F;
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     emplace_back_deque_const_type<T>(pool, part_second));
+    stdgpu::for_each_index(thrust::device, N, emplace_back_deque_const_type<T>(pool, values, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -664,6 +668,7 @@ TEST_F(stdgpu_deque, emplace_back_const_type)
     EXPECT_TRUE(pool.valid());
 
     stdgpu::deque<T>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, emplace_back_nondefault_type)
@@ -672,9 +677,10 @@ TEST_F(stdgpu_deque, emplace_back_nondefault_type)
 
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     emplace_back_deque<nondefault_int_deque>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, emplace_back_deque<nondefault_int_deque, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -682,6 +688,7 @@ TEST_F(stdgpu_deque, emplace_back_nondefault_type)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::deque<nondefault_int_deque>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 template <typename T>
@@ -694,7 +701,7 @@ public:
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(STDGPU_MAYBE_UNUSED const T x)
+    operator()(STDGPU_MAYBE_UNUSED stdgpu::index_t i)
     {
         _pool.pop_front();
     }
@@ -713,7 +720,7 @@ public:
     }
 
     inline STDGPU_HOST_DEVICE void
-    operator()(STDGPU_MAYBE_UNUSED const typename Pair::first_type& first)
+    operator()(STDGPU_MAYBE_UNUSED stdgpu::index_t i)
     {
         _pool.pop_front();
     }
@@ -722,83 +729,95 @@ private:
     stdgpu::deque<Pair> _pool;
 };
 
-template <typename T>
+template <typename T, typename Values = T>
 class push_front_deque
 {
 public:
-    explicit push_front_deque(const stdgpu::deque<T>& pool)
+    push_front_deque(const stdgpu::deque<T>& pool, Values* values)
       : _pool(pool)
+      , _values(values)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.push_front(x);
+        _pool.push_front(_values[i]);
     }
 
 private:
     stdgpu::deque<T> _pool;
+    Values* _values;
 };
 
 template <typename Pair>
 class push_front_deque_const_type
 {
 public:
-    push_front_deque_const_type(const stdgpu::deque<Pair>& pool, const typename Pair::second_type& second)
+    push_front_deque_const_type(const stdgpu::deque<Pair>& pool,
+                                typename Pair::first_type* firsts,
+                                const typename Pair::second_type& second)
       : _pool(pool)
+      , _firsts(firsts)
       , _second(second)
     {
     }
 
     inline STDGPU_HOST_DEVICE void
-    operator()(const typename Pair::first_type& first)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.push_front(thrust::make_pair(first, _second));
+        _pool.push_front(thrust::make_pair(_firsts[i], _second));
     }
 
 private:
     stdgpu::deque<Pair> _pool;
+    typename Pair::first_type* _firsts;
     typename Pair::second_type _second;
 };
 
-template <typename T>
+template <typename T, typename Values = T>
 class emplace_front_deque
 {
 public:
-    explicit emplace_front_deque(const stdgpu::deque<T>& pool)
+    emplace_front_deque(const stdgpu::deque<T>& pool, Values* values)
       : _pool(pool)
+      , _values(values)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.emplace_front(x);
+        _pool.emplace_front(_values[i]);
     }
 
 private:
     stdgpu::deque<T> _pool;
+    Values* _values;
 };
 
 template <typename Pair>
 class emplace_front_deque_const_type
 {
 public:
-    emplace_front_deque_const_type(const stdgpu::deque<Pair>& pool, const typename Pair::second_type& second)
+    emplace_front_deque_const_type(const stdgpu::deque<Pair>& pool,
+                                   typename Pair::first_type* firsts,
+                                   const typename Pair::second_type& second)
       : _pool(pool)
+      , _firsts(firsts)
       , _second(second)
     {
     }
 
     inline STDGPU_HOST_DEVICE void
-    operator()(const typename Pair::first_type& first)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.emplace_front(first, _second);
+        _pool.emplace_front(_firsts[i], _second);
     }
 
 private:
     stdgpu::deque<Pair> _pool;
+    typename Pair::first_type* _firsts;
     typename Pair::second_type _second;
 };
 
@@ -812,9 +831,7 @@ TEST_F(stdgpu_deque, pop_front_some)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), N_remaining);
     ASSERT_FALSE(pool.empty());
@@ -840,9 +857,7 @@ TEST_F(stdgpu_deque, pop_front_all)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -861,9 +876,7 @@ TEST_F(stdgpu_deque, pop_front_too_many)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -881,19 +894,18 @@ TEST_F(stdgpu_deque, pop_front_const_type)
 
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
     const float part_second = 2.0F;
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_deque_const_type<T>(pool, part_second));
+    stdgpu::for_each_index(thrust::device, N, push_back_deque_const_type<T>(pool, values, part_second));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     pop_front_deque_const_type<T>(pool));
+    stdgpu::for_each_index(thrust::device, N, pop_front_deque_const_type<T>(pool));
 
     EXPECT_EQ(pool.size(), 0);
     EXPECT_TRUE(pool.empty());
@@ -901,6 +913,7 @@ TEST_F(stdgpu_deque, pop_front_const_type)
     EXPECT_TRUE(pool.valid());
 
     stdgpu::deque<T>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, pop_front_nondefault_type)
@@ -909,18 +922,17 @@ TEST_F(stdgpu_deque, pop_front_nondefault_type)
 
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_deque<nondefault_int_deque>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     pop_front_deque<nondefault_int_deque>(pool));
+    stdgpu::for_each_index(thrust::device, N, pop_front_deque<nondefault_int_deque>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -928,6 +940,7 @@ TEST_F(stdgpu_deque, pop_front_nondefault_type)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::deque<nondefault_int_deque>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, push_front_some)
@@ -940,14 +953,12 @@ TEST_F(stdgpu_deque, push_front_some)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     push_front_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, push_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -964,6 +975,7 @@ TEST_F(stdgpu_deque, push_front_some)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, push_front_all)
@@ -976,14 +988,12 @@ TEST_F(stdgpu_deque, push_front_all)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     push_front_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, push_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1000,6 +1010,7 @@ TEST_F(stdgpu_deque, push_front_all)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, push_front_too_many)
@@ -1012,14 +1023,12 @@ TEST_F(stdgpu_deque, push_front_too_many)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     push_front_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, push_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1036,6 +1045,7 @@ TEST_F(stdgpu_deque, push_front_too_many)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, push_front_const_type)
@@ -1046,10 +1056,11 @@ TEST_F(stdgpu_deque, push_front_const_type)
 
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
     const float part_second = 2.0F;
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_front_deque_const_type<T>(pool, part_second));
+    stdgpu::for_each_index(thrust::device, N, push_front_deque_const_type<T>(pool, values, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -1057,6 +1068,7 @@ TEST_F(stdgpu_deque, push_front_const_type)
     EXPECT_TRUE(pool.valid());
 
     stdgpu::deque<T>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, push_front_nondefault_type)
@@ -1065,9 +1077,10 @@ TEST_F(stdgpu_deque, push_front_nondefault_type)
 
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_front_deque<nondefault_int_deque>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, push_front_deque<nondefault_int_deque, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1075,6 +1088,7 @@ TEST_F(stdgpu_deque, push_front_nondefault_type)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::deque<nondefault_int_deque>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, emplace_front_some)
@@ -1087,14 +1101,12 @@ TEST_F(stdgpu_deque, emplace_front_some)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     emplace_front_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, emplace_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1111,6 +1123,7 @@ TEST_F(stdgpu_deque, emplace_front_some)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, emplace_front_all)
@@ -1123,14 +1136,12 @@ TEST_F(stdgpu_deque, emplace_front_all)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     emplace_front_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, emplace_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1147,6 +1158,7 @@ TEST_F(stdgpu_deque, emplace_front_all)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, emplace_front_too_many)
@@ -1159,14 +1171,12 @@ TEST_F(stdgpu_deque, emplace_front_too_many)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     emplace_front_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, emplace_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1183,6 +1193,7 @@ TEST_F(stdgpu_deque, emplace_front_too_many)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, emplace_front_const_type)
@@ -1193,10 +1204,11 @@ TEST_F(stdgpu_deque, emplace_front_const_type)
 
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
     const float part_second = 2.0F;
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     emplace_front_deque_const_type<T>(pool, part_second));
+    stdgpu::for_each_index(thrust::device, N, emplace_front_deque_const_type<T>(pool, values, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -1204,6 +1216,7 @@ TEST_F(stdgpu_deque, emplace_front_const_type)
     EXPECT_TRUE(pool.valid());
 
     stdgpu::deque<T>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, emplace_front_nondefault_type)
@@ -1212,9 +1225,10 @@ TEST_F(stdgpu_deque, emplace_front_nondefault_type)
 
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     emplace_front_deque<nondefault_int_deque>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, emplace_front_deque<nondefault_int_deque, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1222,6 +1236,7 @@ TEST_F(stdgpu_deque, emplace_front_nondefault_type)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::deque<nondefault_int_deque>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, push_back_circular)
@@ -1234,18 +1249,14 @@ TEST_F(stdgpu_deque, push_back_circular)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
 
-    const stdgpu::index_t init = N - N_pop + 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     push_back_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), N - N_pop + 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, push_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1262,6 +1273,7 @@ TEST_F(stdgpu_deque, push_back_circular)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, push_front_circular)
@@ -1274,18 +1286,14 @@ TEST_F(stdgpu_deque, push_front_circular)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_front_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
 
-    const stdgpu::index_t init = N - N_pop + 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     push_front_deque<int>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), N - N_pop + 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, push_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1302,6 +1310,7 @@ TEST_F(stdgpu_deque, push_front_circular)
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, clear)
@@ -1348,16 +1357,12 @@ TEST_F(stdgpu_deque, clear_circular)
     stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N + 1);
 
     fill_deque(pool, N);
+    stdgpu::for_each_index(thrust::device, N_offset, pop_front_deque<int>(pool));
 
-    const stdgpu::index_t init = 1;
+    int* values = createDeviceArray<int>(N_offset);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(init + N_offset),
-                     pop_front_deque<int>(pool));
-
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(init + N_offset),
-                     push_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_offset, push_back_deque<int>(pool, values));
 
     pool.clear();
 
@@ -1367,6 +1372,7 @@ TEST_F(stdgpu_deque, clear_circular)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, clear_nondefault_type)
@@ -1375,9 +1381,10 @@ TEST_F(stdgpu_deque, clear_nondefault_type)
 
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N + 1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_deque<nondefault_int_deque>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
 
     pool.clear();
 
@@ -1387,6 +1394,7 @@ TEST_F(stdgpu_deque, clear_nondefault_type)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::deque<nondefault_int_deque>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, clear_nondefault_type_full)
@@ -1395,9 +1403,10 @@ TEST_F(stdgpu_deque, clear_nondefault_type_full)
 
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_deque<nondefault_int_deque>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
 
     pool.clear();
 
@@ -1407,6 +1416,7 @@ TEST_F(stdgpu_deque, clear_nondefault_type_full)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::deque<nondefault_int_deque>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, clear_nondefault_type_circular)
@@ -1416,19 +1426,14 @@ TEST_F(stdgpu_deque, clear_nondefault_type_circular)
 
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N + 1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_deque<nondefault_int_deque>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    const stdgpu::index_t init = 1;
+    stdgpu::for_each_index(thrust::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
 
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(init + N_offset),
-                     pop_front_deque<nondefault_int_deque>(pool));
+    stdgpu::for_each_index(thrust::device, N_offset, pop_front_deque<nondefault_int_deque>(pool));
 
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(init + N_offset),
-                     push_back_deque<nondefault_int_deque>(pool));
+    stdgpu::for_each_index(thrust::device, N_offset, push_back_deque<nondefault_int_deque, int>(pool, values));
 
     pool.clear();
 
@@ -1438,22 +1443,26 @@ TEST_F(stdgpu_deque, clear_nondefault_type_circular)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::deque<nondefault_int_deque>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 template <typename T>
 class simultaneous_push_back_and_pop_back_deque
 {
 public:
-    simultaneous_push_back_and_pop_back_deque(const stdgpu::deque<T>& pool, const stdgpu::deque<T>& pool_validation)
+    simultaneous_push_back_and_pop_back_deque(const stdgpu::deque<T>& pool,
+                                              const stdgpu::deque<T>& pool_validation,
+                                              T* values)
       : _pool(pool)
       , _pool_validation(pool_validation)
+      , _values(values)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.push_back(x);
+        _pool.push_back(_values[i]);
 
         thrust::pair<T, bool> popped = _pool.pop_back();
 
@@ -1466,6 +1475,7 @@ public:
 private:
     stdgpu::deque<T> _pool;
     stdgpu::deque<T> _pool_validation;
+    T* _values;
 };
 
 TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_back)
@@ -1475,10 +1485,12 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_back)
     stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
     stdgpu::deque<int> pool_validation = stdgpu::deque<int>::createDeviceObject(N);
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N + init),
-                     simultaneous_push_back_and_pop_back_deque<int>(pool, pool_validation));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device,
+                           N,
+                           simultaneous_push_back_and_pop_back_deque<int>(pool, pool_validation, values));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -1501,22 +1513,26 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_back)
     stdgpu::deque<int>::destroyDeviceObject(pool);
     stdgpu::deque<int>::destroyDeviceObject(pool_validation);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 template <typename T>
 class simultaneous_push_front_and_pop_front_deque
 {
 public:
-    simultaneous_push_front_and_pop_front_deque(const stdgpu::deque<T>& pool, const stdgpu::deque<T>& pool_validation)
+    simultaneous_push_front_and_pop_front_deque(const stdgpu::deque<T>& pool,
+                                                const stdgpu::deque<T>& pool_validation,
+                                                T* values)
       : _pool(pool)
       , _pool_validation(pool_validation)
+      , _values(values)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.push_front(x);
+        _pool.push_front(_values[i]);
 
         thrust::pair<T, bool> popped = _pool.pop_front();
 
@@ -1529,6 +1545,7 @@ public:
 private:
     stdgpu::deque<T> _pool;
     stdgpu::deque<T> _pool_validation;
+    T* _values;
 };
 
 TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_front)
@@ -1538,10 +1555,12 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_front)
     stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
     stdgpu::deque<int> pool_validation = stdgpu::deque<int>::createDeviceObject(N);
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N + init),
-                     simultaneous_push_front_and_pop_front_deque<int>(pool, pool_validation));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device,
+                           N,
+                           simultaneous_push_front_and_pop_front_deque<int>(pool, pool_validation, values));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -1564,22 +1583,26 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_front)
     stdgpu::deque<int>::destroyDeviceObject(pool);
     stdgpu::deque<int>::destroyDeviceObject(pool_validation);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 template <typename T>
 class simultaneous_push_front_and_pop_back_deque
 {
 public:
-    simultaneous_push_front_and_pop_back_deque(const stdgpu::deque<T>& pool, const stdgpu::deque<T>& pool_validation)
+    simultaneous_push_front_and_pop_back_deque(const stdgpu::deque<T>& pool,
+                                               const stdgpu::deque<T>& pool_validation,
+                                               T* values)
       : _pool(pool)
       , _pool_validation(pool_validation)
+      , _values(values)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.push_front(x);
+        _pool.push_front(_values[i]);
 
         thrust::pair<T, bool> popped = _pool.pop_back();
 
@@ -1592,6 +1615,7 @@ public:
 private:
     stdgpu::deque<T> _pool;
     stdgpu::deque<T> _pool_validation;
+    T* _values;
 };
 
 TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_back)
@@ -1601,10 +1625,12 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_back)
     stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
     stdgpu::deque<int> pool_validation = stdgpu::deque<int>::createDeviceObject(N);
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N + init),
-                     simultaneous_push_front_and_pop_back_deque<int>(pool, pool_validation));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device,
+                           N,
+                           simultaneous_push_front_and_pop_back_deque<int>(pool, pool_validation, values));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -1627,22 +1653,26 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_back)
     stdgpu::deque<int>::destroyDeviceObject(pool);
     stdgpu::deque<int>::destroyDeviceObject(pool_validation);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 template <typename T>
 class simultaneous_push_back_and_pop_front_deque
 {
 public:
-    simultaneous_push_back_and_pop_front_deque(const stdgpu::deque<T>& pool, const stdgpu::deque<T>& pool_validation)
+    simultaneous_push_back_and_pop_front_deque(const stdgpu::deque<T>& pool,
+                                               const stdgpu::deque<T>& pool_validation,
+                                               T* values)
       : _pool(pool)
       , _pool_validation(pool_validation)
+      , _values(values)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.push_back(x);
+        _pool.push_back(_values[i]);
 
         thrust::pair<T, bool> popped = _pool.pop_back();
 
@@ -1655,6 +1685,7 @@ public:
 private:
     stdgpu::deque<T> _pool;
     stdgpu::deque<T> _pool_validation;
+    T* _values;
 };
 
 TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_front)
@@ -1664,10 +1695,12 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_front)
     stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N);
     stdgpu::deque<int> pool_validation = stdgpu::deque<int>::createDeviceObject(N);
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N + init),
-                     simultaneous_push_back_and_pop_front_deque<int>(pool, pool_validation));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device,
+                           N,
+                           simultaneous_push_back_and_pop_front_deque<int>(pool, pool_validation, values));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -1690,6 +1723,7 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_front)
     stdgpu::deque<int>::destroyDeviceObject(pool);
     stdgpu::deque<int>::destroyDeviceObject(pool_validation);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 class at_non_const_deque
@@ -1701,9 +1735,10 @@ public:
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.at(x) = x * x;
+        int x = _pool.at(i);
+        _pool.at(i) = x * x;
     }
 
 private:
@@ -1718,12 +1753,12 @@ TEST_F(stdgpu_deque, at_non_const)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N), at_non_const_deque(pool));
+    stdgpu::for_each_index(thrust::device, N, at_non_const_deque(pool));
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
-        EXPECT_EQ(host_numbers[i], i * i);
+        EXPECT_EQ(host_numbers[i], static_cast<int>(i + 1) * static_cast<int>(i + 1));
     }
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
@@ -1739,9 +1774,10 @@ public:
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool[x] = x * x;
+        int x = _pool[i];
+        _pool[i] = x * x;
     }
 
 private:
@@ -1756,14 +1792,12 @@ TEST_F(stdgpu_deque, access_operator_non_const)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     access_operator_non_const_deque(pool));
+    stdgpu::for_each_index(thrust::device, N, access_operator_non_const_deque(pool));
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
-        EXPECT_EQ(host_numbers[i], i * i);
+        EXPECT_EQ(host_numbers[i], static_cast<int>(i + 1) * static_cast<int>(i + 1));
     }
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
@@ -1820,9 +1854,7 @@ TEST_F(stdgpu_deque, shrink_to_fit)
 
     fill_deque(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), N_remaining);
     ASSERT_EQ(pool.capacity(), N);
@@ -1887,9 +1919,7 @@ non_const_front(const stdgpu::deque<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     non_const_front_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, non_const_front_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1905,9 +1935,7 @@ const_front(const stdgpu::deque<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     const_front_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, const_front_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1977,9 +2005,7 @@ non_const_back(const stdgpu::deque<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     non_const_back_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, non_const_back_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1995,9 +2021,7 @@ const_back(const stdgpu::deque<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     const_back_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, const_back_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -2363,15 +2387,12 @@ TEST_F(stdgpu_deque, non_const_device_range_circular)
 
     fill_deque(pool, N);
 
-    const stdgpu::index_t init = 1;
+    stdgpu::for_each_index(thrust::device, N_offset, pop_front_deque<int>(pool));
 
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(init + N_offset),
-                     pop_front_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_offset);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(init + N_offset),
-                     push_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_offset, push_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_EQ(pool.capacity(), N + 1);
@@ -2393,6 +2414,7 @@ TEST_F(stdgpu_deque, non_const_device_range_circular)
     destroyHostArray<int>(host_numbers);
     destroyDeviceArray<int>(numbers);
     stdgpu::deque<int>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, const_device_range)
@@ -2464,15 +2486,12 @@ TEST_F(stdgpu_deque, const_device_range_circular)
 
     fill_deque(pool, N);
 
-    const stdgpu::index_t init = 1;
+    stdgpu::for_each_index(thrust::device, N_offset, pop_front_deque<int>(pool));
 
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(init + N_offset),
-                     pop_front_deque<int>(pool));
+    int* values = createDeviceArray<int>(N_offset);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(init + N_offset),
-                     push_back_deque<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_offset, push_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_EQ(pool.capacity(), N + 1);
@@ -2494,6 +2513,7 @@ TEST_F(stdgpu_deque, const_device_range_circular)
     destroyHostArray<int>(host_numbers);
     destroyDeviceArray<int>(numbers);
     stdgpu::deque<int>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_deque, get_allocator)

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cmath>
 #include <thrust/equal.h>
 #include <thrust/execution_policy.h>
@@ -1476,14 +1477,14 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_construct_destroy)
     int constructor_calls = 0;
     int destructor_calls = 0;
 
-    thrust::for_each(stdgpu::host_begin(array),
-                     stdgpu::host_end(array),
-                     traits_construct<Allocator>(&constructor_calls, &destructor_calls));
+    std::for_each(stdgpu::host_begin(array).get(),
+                  stdgpu::host_end(array).get(),
+                  traits_construct<Allocator>(&constructor_calls, &destructor_calls));
 
     EXPECT_EQ(constructor_calls, size);
     EXPECT_EQ(destructor_calls, 0);
 
-    thrust::for_each(stdgpu::host_begin(array), stdgpu::host_end(array), traits_destroy<Allocator>());
+    std::for_each(stdgpu::host_begin(array).get(), stdgpu::host_end(array).get(), traits_destroy<Allocator>());
 
     EXPECT_EQ(constructor_calls, size);
     EXPECT_EQ(destructor_calls, size);

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -112,16 +112,19 @@ namespace
 class count_buckets_hits
 {
 public:
-    count_buckets_hits(const test_unordered_datastructure& hash_datastructure, int* bucket_hits)
+    count_buckets_hits(const test_unordered_datastructure& hash_datastructure,
+                       int* bucket_hits,
+                       test_unordered_datastructure::key_type* keys)
       : _hash_datastructure(hash_datastructure)
       , _bucket_hits(bucket_hits)
+      , _keys(keys)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const test_unordered_datastructure::key_type key)
+    operator()(const stdgpu::index_t i)
     {
-        stdgpu::index_t bucket = _hash_datastructure.bucket(key);
+        stdgpu::index_t bucket = _hash_datastructure.bucket(_keys[i]);
 
         stdgpu::atomic_ref<int>(_bucket_hits[bucket]).fetch_add(1);
     }
@@ -129,6 +132,7 @@ public:
 private:
     test_unordered_datastructure _hash_datastructure;
     int* _bucket_hits;
+    test_unordered_datastructure::key_type* _keys;
 };
 
 template <int threshold>
@@ -167,9 +171,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_hits)
     test_unordered_datastructure::key_type* keys =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_keys, N);
 
-    thrust::for_each(stdgpu::device_begin(keys),
-                     stdgpu::device_end(keys),
-                     count_buckets_hits(hash_datastructure, bucket_hits));
+    stdgpu::for_each_index(thrust::device, N, count_buckets_hits(hash_datastructure, bucket_hits, keys));
 
     int* host_bucket_hits = copyCreateDevice2HostArray<int>(bucket_hits, hash_datastructure.bucket_count());
 
@@ -219,9 +221,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_collisions)
     test_unordered_datastructure::key_type* keys =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_keys, N);
 
-    thrust::for_each(stdgpu::device_begin(keys),
-                     stdgpu::device_end(keys),
-                     count_buckets_hits(hash_datastructure, bucket_hits));
+    stdgpu::for_each_index(thrust::device, N, count_buckets_hits(hash_datastructure, bucket_hits, keys));
 
     int* host_bucket_hits = copyCreateDevice2HostArray<int>(bucket_hits, hash_datastructure.bucket_count());
 
@@ -2202,59 +2202,6 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, count_sum)
 
 namespace
 {
-class for_each_counter
-{
-public:
-    for_each_counter(const stdgpu::atomic<unsigned int>& counter,
-                     const stdgpu::atomic<unsigned int>& bad_counter,
-                     const test_unordered_datastructure& hash_datastructure)
-      : _counter(counter)
-      , _bad_counter(bad_counter)
-      , _hash_datastructure(hash_datastructure)
-    {
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const test_unordered_datastructure::value_type& value)
-    {
-        if (!_hash_datastructure.contains(STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(value)))
-        {
-            ++_bad_counter;
-        }
-
-        ++_counter;
-    }
-
-private:
-    stdgpu::atomic<unsigned int> _counter;
-    stdgpu::atomic<unsigned int> _bad_counter;
-    test_unordered_datastructure _hash_datastructure;
-};
-} // namespace
-
-TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_count)
-{
-    const stdgpu::index_t N = 100000;
-
-    test_unordered_datastructure::key_type* host_positions = insert_unique_parallel(hash_datastructure, N);
-
-    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
-
-    stdgpu::atomic<unsigned int> counter = stdgpu::atomic<unsigned int>::createDeviceObject();
-    stdgpu::atomic<unsigned int> bad_counter = stdgpu::atomic<unsigned int>::createDeviceObject();
-
-    auto range = hash_datastructure.device_range();
-    thrust::for_each(range.begin(), range.end(), for_each_counter(counter, bad_counter, hash_datastructure));
-
-    EXPECT_EQ(counter.load(), static_cast<unsigned int>(hash_datastructure.size()));
-    EXPECT_EQ(bad_counter.load(), static_cast<unsigned int>(0));
-
-    stdgpu::atomic<unsigned int>::destroyDeviceObject(counter);
-    stdgpu::atomic<unsigned int>::destroyDeviceObject(bad_counter);
-}
-
-namespace
-{
 class insert_vector
 {
 public:
@@ -2302,42 +2249,6 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_keys_same)
     destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
     destroyHostArray<test_unordered_datastructure::key_type>(host_positions_inserted);
     stdgpu::vector<test_unordered_datastructure::key_type>::destroyDeviceObject(keys);
-}
-
-namespace
-{
-class erase_hash
-{
-public:
-    explicit erase_hash(const test_unordered_datastructure& hash_datastructure)
-      : _hash_datastructure(hash_datastructure)
-    {
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const test_unordered_datastructure::value_type& value)
-    {
-        _hash_datastructure.erase(STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(value));
-    }
-
-private:
-    test_unordered_datastructure _hash_datastructure;
-};
-} // namespace
-
-TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_erase)
-{
-    const stdgpu::index_t N = 100000;
-
-    test_unordered_datastructure::key_type* host_positions = insert_unique_parallel(hash_datastructure, N);
-
-    auto range = hash_datastructure.device_range();
-    thrust::for_each(range.begin(), range.end(), erase_hash(hash_datastructure));
-
-    EXPECT_EQ(hash_datastructure.size(), 0);
-    EXPECT_TRUE(hash_datastructure.valid());
-
-    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
 }
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, clear_empty)

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -17,7 +17,6 @@
 
 #include <algorithm>
 #include <thrust/copy.h>
-#include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 
 #include <stdgpu/algorithm.h>
@@ -80,7 +79,7 @@ public:
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(STDGPU_MAYBE_UNUSED const T x)
+    operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
     {
         _pool.pop_back();
     }
@@ -99,7 +98,7 @@ public:
     }
 
     inline STDGPU_HOST_DEVICE void
-    operator()(STDGPU_MAYBE_UNUSED const typename Pair::first_type& first)
+    operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
     {
         _pool.pop_back();
     }
@@ -108,83 +107,95 @@ private:
     stdgpu::vector<Pair> _pool;
 };
 
-template <typename T>
+template <typename T, typename Values = T>
 class push_back_vector
 {
 public:
-    explicit push_back_vector(const stdgpu::vector<T>& pool)
+    push_back_vector(const stdgpu::vector<T>& pool, Values* values)
       : _pool(pool)
+      , _values(values)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.push_back(x);
+        _pool.push_back(_values[i]);
     }
 
 private:
     stdgpu::vector<T> _pool;
+    Values* _values;
 };
 
 template <typename Pair>
 class push_back_vector_const_type
 {
 public:
-    explicit push_back_vector_const_type(const stdgpu::vector<Pair>& pool, const typename Pair::second_type& second)
+    push_back_vector_const_type(const stdgpu::vector<Pair>& pool,
+                                typename Pair::first_type* firsts,
+                                const typename Pair::second_type& second)
       : _pool(pool)
+      , _firsts(firsts)
       , _second(second)
     {
     }
 
     inline STDGPU_HOST_DEVICE void
-    operator()(const typename Pair::first_type& first)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.push_back(thrust::make_pair(first, _second));
+        _pool.push_back(thrust::make_pair(_firsts[i], _second));
     }
 
 private:
     stdgpu::vector<Pair> _pool;
+    typename Pair::first_type* _firsts;
     typename Pair::second_type _second;
 };
 
-template <typename T>
+template <typename T, typename Values = T>
 class emplace_back_vector
 {
 public:
-    explicit emplace_back_vector(const stdgpu::vector<T>& pool)
+    emplace_back_vector(const stdgpu::vector<T>& pool, Values* values)
       : _pool(pool)
+      , _values(values)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.emplace_back(x);
+        _pool.emplace_back(_values[i]);
     }
 
 private:
     stdgpu::vector<T> _pool;
+    Values* _values;
 };
 
 template <typename Pair>
 class emplace_back_vector_const_type
 {
 public:
-    emplace_back_vector_const_type(const stdgpu::vector<Pair>& pool, const typename Pair::second_type& second)
+    emplace_back_vector_const_type(const stdgpu::vector<Pair>& pool,
+                                   typename Pair::first_type* firsts,
+                                   const typename Pair::second_type& second)
       : _pool(pool)
+      , _firsts(firsts)
       , _second(second)
     {
     }
 
     inline STDGPU_HOST_DEVICE void
-    operator()(const typename Pair::first_type& first)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.emplace_back(first, _second);
+        _pool.emplace_back(_firsts[i], _second);
     }
 
 private:
     stdgpu::vector<Pair> _pool;
+    typename Pair::first_type* _firsts;
     typename Pair::second_type _second;
 };
 
@@ -194,10 +205,10 @@ fill_vector(stdgpu::vector<int>& pool, const stdgpu::index_t N)
     ASSERT_GE(N, 0);
     ASSERT_LE(N, pool.capacity());
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(static_cast<int>(init)),
-                     thrust::counting_iterator<int>(static_cast<int>(N + init)),
-                     push_back_vector<int>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, push_back_vector<int>(pool, values));
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -209,6 +220,7 @@ fill_vector(stdgpu::vector<int>& pool, const stdgpu::index_t N)
     ASSERT_TRUE((N == pool.capacity()) ? pool.full() : !pool.full());
 
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 void
@@ -268,9 +280,7 @@ TEST_F(stdgpu_vector, pop_back_some)
 
     fill_vector(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
 
     ASSERT_EQ(pool.size(), N_remaining);
     ASSERT_FALSE(pool.empty());
@@ -296,9 +306,7 @@ TEST_F(stdgpu_vector, pop_back_all)
 
     fill_vector(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -317,9 +325,7 @@ TEST_F(stdgpu_vector, pop_back_too_many)
 
     fill_vector(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -337,19 +343,18 @@ TEST_F(stdgpu_vector, pop_back_const_type)
 
     stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
 
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
     const float part_second = 2.0F;
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_vector_const_type<T>(pool, part_second));
+    stdgpu::for_each_index(thrust::device, N, push_back_vector_const_type<T>(pool, values, part_second));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     pop_back_vector_const_type<T>(pool));
+    stdgpu::for_each_index(thrust::device, N, pop_back_vector_const_type<T>(pool));
 
     EXPECT_EQ(pool.size(), 0);
     EXPECT_TRUE(pool.empty());
@@ -357,6 +362,7 @@ TEST_F(stdgpu_vector, pop_back_const_type)
     EXPECT_TRUE(pool.valid());
 
     stdgpu::vector<T>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, pop_back_nondefault_type)
@@ -365,18 +371,17 @@ TEST_F(stdgpu_vector, pop_back_nondefault_type)
 
     stdgpu::vector<nondefault_int_vector> pool = stdgpu::vector<nondefault_int_vector>::createDeviceObject(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_vector<nondefault_int_vector>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, push_back_vector<nondefault_int_vector, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     pop_back_vector<nondefault_int_vector>(pool));
+    stdgpu::for_each_index(thrust::device, N, pop_back_vector<nondefault_int_vector>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -384,6 +389,7 @@ TEST_F(stdgpu_vector, pop_back_nondefault_type)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::vector<nondefault_int_vector>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, push_back_some)
@@ -397,14 +403,12 @@ TEST_F(stdgpu_vector, push_back_some)
 
     fill_vector(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
 
-    const stdgpu::index_t init = 1 + N_remaining;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     push_back_vector<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
+
+    stdgpu::for_each_index(thrust::device, N_push, push_back_vector<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -421,6 +425,7 @@ TEST_F(stdgpu_vector, push_back_some)
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, push_back_all)
@@ -433,14 +438,12 @@ TEST_F(stdgpu_vector, push_back_all)
 
     fill_vector(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     push_back_vector<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, push_back_vector<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -457,6 +460,7 @@ TEST_F(stdgpu_vector, push_back_all)
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, push_back_too_many)
@@ -469,14 +473,12 @@ TEST_F(stdgpu_vector, push_back_too_many)
 
     fill_vector(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     push_back_vector<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, push_back_vector<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -493,6 +495,7 @@ TEST_F(stdgpu_vector, push_back_too_many)
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, push_back_const_type)
@@ -503,10 +506,11 @@ TEST_F(stdgpu_vector, push_back_const_type)
 
     stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
 
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
     const float part_second = 2.0F;
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_vector_const_type<T>(pool, part_second));
+    stdgpu::for_each_index(thrust::device, N, push_back_vector_const_type<T>(pool, values, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -514,6 +518,7 @@ TEST_F(stdgpu_vector, push_back_const_type)
     EXPECT_TRUE(pool.valid());
 
     stdgpu::vector<T>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, push_back_nondefault_type)
@@ -522,9 +527,10 @@ TEST_F(stdgpu_vector, push_back_nondefault_type)
 
     stdgpu::vector<nondefault_int_vector> pool = stdgpu::vector<nondefault_int_vector>::createDeviceObject(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_vector<nondefault_int_vector>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, push_back_vector<nondefault_int_vector, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -532,6 +538,7 @@ TEST_F(stdgpu_vector, push_back_nondefault_type)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::vector<nondefault_int_vector>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, emplace_back_some)
@@ -545,14 +552,12 @@ TEST_F(stdgpu_vector, emplace_back_some)
 
     fill_vector(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
 
-    const stdgpu::index_t init = 1 + N_remaining;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     push_back_vector<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
+
+    stdgpu::for_each_index(thrust::device, N_push, push_back_vector<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -569,6 +574,7 @@ TEST_F(stdgpu_vector, emplace_back_some)
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, emplace_back_all)
@@ -581,14 +587,12 @@ TEST_F(stdgpu_vector, emplace_back_all)
 
     fill_vector(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     emplace_back_vector<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, emplace_back_vector<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -605,6 +609,7 @@ TEST_F(stdgpu_vector, emplace_back_all)
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, emplace_back_too_many)
@@ -617,14 +622,12 @@ TEST_F(stdgpu_vector, emplace_back_too_many)
 
     fill_vector(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N_push + init),
-                     emplace_back_vector<int>(pool));
+    int* values = createDeviceArray<int>(N_push);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N_push, emplace_back_vector<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -641,6 +644,7 @@ TEST_F(stdgpu_vector, emplace_back_too_many)
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, emplace_back_const_type)
@@ -651,10 +655,11 @@ TEST_F(stdgpu_vector, emplace_back_const_type)
 
     stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
 
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
     const float part_second = 2.0F;
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     emplace_back_vector_const_type<T>(pool, part_second));
+    stdgpu::for_each_index(thrust::device, N, emplace_back_vector_const_type<T>(pool, values, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -662,6 +667,7 @@ TEST_F(stdgpu_vector, emplace_back_const_type)
     EXPECT_TRUE(pool.valid());
 
     stdgpu::vector<T>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, emplace_back_nondefault_type)
@@ -670,9 +676,10 @@ TEST_F(stdgpu_vector, emplace_back_nondefault_type)
 
     stdgpu::vector<nondefault_int_vector> pool = stdgpu::vector<nondefault_int_vector>::createDeviceObject(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     emplace_back_vector<nondefault_int_vector>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, emplace_back_vector<nondefault_int_vector, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -680,6 +687,7 @@ TEST_F(stdgpu_vector, emplace_back_nondefault_type)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::vector<nondefault_int_vector>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, insert)
@@ -846,9 +854,10 @@ TEST_F(stdgpu_vector, clear_nondefault_type)
 
     stdgpu::vector<nondefault_int_vector> pool = stdgpu::vector<nondefault_int_vector>::createDeviceObject(N);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     push_back_vector<nondefault_int_vector>(pool));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device, N, push_back_vector<nondefault_int_vector, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -863,22 +872,26 @@ TEST_F(stdgpu_vector, clear_nondefault_type)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::vector<nondefault_int_vector>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 template <typename T>
 class simultaneous_push_back_and_pop_back_vector
 {
 public:
-    simultaneous_push_back_and_pop_back_vector(const stdgpu::vector<T>& pool, const stdgpu::vector<T>& pool_validation)
+    simultaneous_push_back_and_pop_back_vector(const stdgpu::vector<T>& pool,
+                                               const stdgpu::vector<T>& pool_validation,
+                                               T* values)
       : _pool(pool)
       , _pool_validation(pool_validation)
+      , _values(values)
     {
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const T x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.push_back(x);
+        _pool.push_back(_values[i]);
 
         thrust::pair<T, bool> popped = _pool.pop_back();
 
@@ -891,6 +904,7 @@ public:
 private:
     stdgpu::vector<T> _pool;
     stdgpu::vector<T> _pool_validation;
+    T* _values;
 };
 
 TEST_F(stdgpu_vector, simultaneous_push_back_and_pop_back)
@@ -900,10 +914,12 @@ TEST_F(stdgpu_vector, simultaneous_push_back_and_pop_back)
     stdgpu::vector<int> pool = stdgpu::vector<int>::createDeviceObject(N);
     stdgpu::vector<int> pool_validation = stdgpu::vector<int>::createDeviceObject(N);
 
-    const stdgpu::index_t init = 1;
-    thrust::for_each(thrust::counting_iterator<int>(init),
-                     thrust::counting_iterator<int>(N + init),
-                     simultaneous_push_back_and_pop_back_vector<int>(pool, pool_validation));
+    int* values = createDeviceArray<int>(N);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+
+    stdgpu::for_each_index(thrust::device,
+                           N,
+                           simultaneous_push_back_and_pop_back_vector<int>(pool, pool_validation, values));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -926,6 +942,7 @@ TEST_F(stdgpu_vector, simultaneous_push_back_and_pop_back)
     stdgpu::vector<int>::destroyDeviceObject(pool);
     stdgpu::vector<int>::destroyDeviceObject(pool_validation);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 class at_non_const_vector
@@ -937,9 +954,10 @@ public:
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool.at(x) = x * x;
+        int x = _pool.at(i);
+        _pool.at(i) = x * x;
     }
 
 private:
@@ -954,12 +972,12 @@ TEST_F(stdgpu_vector, at_non_const)
 
     fill_vector(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(N), at_non_const_vector(pool));
+    stdgpu::for_each_index(thrust::device, N, at_non_const_vector(pool));
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
-        EXPECT_EQ(host_numbers[i], i * i);
+        EXPECT_EQ(host_numbers[i], static_cast<int>(i + 1) * static_cast<int>(i + 1));
     }
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
@@ -975,9 +993,10 @@ public:
     }
 
     STDGPU_DEVICE_ONLY void
-    operator()(const int x)
+    operator()(const stdgpu::index_t i)
     {
-        _pool[x] = x * x;
+        int x = _pool[i];
+        _pool[i] = x * x;
     }
 
 private:
@@ -992,14 +1011,12 @@ TEST_F(stdgpu_vector, access_operator_non_const)
 
     fill_vector(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N),
-                     access_operator_non_const_vector(pool));
+    stdgpu::for_each_index(thrust::device, N, access_operator_non_const_vector(pool));
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
-        EXPECT_EQ(host_numbers[i], i * i);
+        EXPECT_EQ(host_numbers[i], static_cast<int>(i + 1) * static_cast<int>(i + 1));
     }
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
@@ -1056,9 +1073,7 @@ TEST_F(stdgpu_vector, shrink_to_fit)
 
     fill_vector(pool);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(N_pop),
-                     pop_back_vector<int>(pool));
+    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
 
     ASSERT_EQ(pool.size(), N_remaining);
     ASSERT_EQ(pool.capacity(), N);
@@ -1123,9 +1138,7 @@ non_const_front(const stdgpu::vector<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     non_const_front_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, non_const_front_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1141,9 +1154,7 @@ const_front(const stdgpu::vector<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    thrust::for_each(thrust::counting_iterator<int>(0),
-                     thrust::counting_iterator<int>(1),
-                     const_front_functor<T>(pool, result));
+    stdgpu::for_each_index(thrust::device, 1, const_front_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);


### PR DESCRIPTION
The trivial `thrust::for_each` invocations that directly use indexing through `thrust::counting_iterator` were ported in #281. However, there are still many other non-trivial use cases where a a different type of iterator is used. Port (almost) all of these to the new `for_each_index` function.

Partially addresses #279