### PR TITLE
utility: Add pair as alias to thrust implementation

### DIFF
--- a/examples/cuda/unordered_map.cu
+++ b/examples/cuda/unordered_map.cu
@@ -43,10 +43,10 @@ struct square
 
 struct int_pair_plus
 {
-    STDGPU_HOST_DEVICE thrust::pair<int, int>
-    operator()(const thrust::pair<int, int>& lhs, const thrust::pair<int, int>& rhs) const
+    STDGPU_HOST_DEVICE stdgpu::pair<int, int>
+    operator()(const stdgpu::pair<int, int>& lhs, const stdgpu::pair<int, int>& rhs) const
     {
-        return thrust::make_pair(lhs.first + rhs.first, lhs.second + rhs.second);
+        return { lhs.first + rhs.first, lhs.second + rhs.second };
     }
 };
 
@@ -101,10 +101,10 @@ main()
     // map : 0, 1, 2, 3, ..., 100
 
     auto range_map = map.device_range();
-    thrust::pair<int, int> sum =
-            thrust::reduce(range_map.begin(), range_map.end(), thrust::make_pair(0, 0), int_pair_plus());
+    stdgpu::pair<int, int> sum =
+            thrust::reduce(range_map.begin(), range_map.end(), stdgpu::pair<int, int>(0, 0), int_pair_plus());
 
-    const thrust::pair<int, int> sum_closed_form = { n * (n + 1) / 2, n * (n + 1) * (2 * n + 1) / 6 };
+    const stdgpu::pair<int, int> sum_closed_form = { n * (n + 1) / 2, n * (n + 1) * (2 * n + 1) / 6 };
 
     std::cout << "The duplicate-free map of numbers contains " << map.size() << " elements (" << n + 1
               << " expected) and the computed sums are (" << sum.first << ", " << sum.second << ") (("

--- a/examples/openmp/unordered_map.cpp
+++ b/examples/openmp/unordered_map.cpp
@@ -43,10 +43,10 @@ struct square
 
 struct int_pair_plus
 {
-    STDGPU_HOST_DEVICE thrust::pair<int, int>
-    operator()(const thrust::pair<int, int>& lhs, const thrust::pair<int, int>& rhs) const
+    STDGPU_HOST_DEVICE stdgpu::pair<int, int>
+    operator()(const stdgpu::pair<int, int>& lhs, const stdgpu::pair<int, int>& rhs) const
     {
-        return thrust::make_pair(lhs.first + rhs.first, lhs.second + rhs.second);
+        return { lhs.first + rhs.first, lhs.second + rhs.second };
     }
 };
 
@@ -97,10 +97,10 @@ main()
     // map : 0, 1, 2, 3, ..., 100
 
     auto range_map = map.device_range();
-    thrust::pair<int, int> sum =
-            thrust::reduce(range_map.begin(), range_map.end(), thrust::make_pair(0, 0), int_pair_plus());
+    stdgpu::pair<int, int> sum =
+            thrust::reduce(range_map.begin(), range_map.end(), stdgpu::pair<int, int>(0, 0), int_pair_plus());
 
-    const thrust::pair<int, int> sum_closed_form = { n * (n + 1) / 2, n * (n + 1) * (2 * n + 1) / 6 };
+    const stdgpu::pair<int, int> sum_closed_form = { n * (n + 1) / 2, n * (n + 1) * (2 * n + 1) / 6 };
 
     std::cout << "The duplicate-free map of numbers contains " << map.size() << " elements (" << n + 1
               << " expected) and the computed sums are (" << sum.first << ", " << sum.second << ") (("

--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -28,8 +28,6 @@
  * \file stdgpu/deque.cuh
  */
 
-#include <thrust/pair.h>
-
 #include <stdgpu/atomic.cuh>
 #include <stdgpu/attribute.h>
 #include <stdgpu/bitset.cuh>
@@ -39,6 +37,7 @@
 #include <stdgpu/mutex.cuh>
 #include <stdgpu/platform.h>
 #include <stdgpu/ranges.h>
+#include <stdgpu/utility.h>
 
 ///////////////////////////////////////////////////////////
 
@@ -195,7 +194,7 @@ public:
      * \brief Removes and returns the current element from end of the object
      * \return The currently popped element and true if not empty, an empty element T() and false otherwise
      */
-    STDGPU_DEVICE_ONLY thrust::pair<T, bool>
+    STDGPU_DEVICE_ONLY pair<T, bool>
     pop_back();
 
     /**
@@ -219,7 +218,7 @@ public:
      * \brief Removes and returns the current element from front of the object
      * \return The currently popped element and true if not empty, an empty element T() and false otherwise
      */
-    STDGPU_DEVICE_ONLY thrust::pair<T, bool>
+    STDGPU_DEVICE_ONLY pair<T, bool>
     pop_front();
 
     /**

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -214,11 +214,11 @@ deque<T, Allocator>::push_back(const T& element)
 }
 
 template <typename T, typename Allocator>
-inline STDGPU_DEVICE_ONLY thrust::pair<T, bool>
+inline STDGPU_DEVICE_ONLY pair<T, bool>
 deque<T, Allocator>::pop_back()
 {
     // Value if no element will be popped, i.e. undefined behavior for element of type T
-    thrust::pair<T, bool> popped = thrust::make_pair(_data[0], false);
+    pair<T, bool> popped(_data[0], false);
 
     // Preemptive check
     if (empty())
@@ -327,11 +327,11 @@ deque<T, Allocator>::push_front(const T& element)
 }
 
 template <typename T, typename Allocator>
-inline STDGPU_DEVICE_ONLY thrust::pair<T, bool>
+inline STDGPU_DEVICE_ONLY pair<T, bool>
 deque<T, Allocator>::pop_front()
 {
     // Value if no element will be popped, i.e. undefined behavior for element of type T
-    thrust::pair<T, bool> popped = thrust::make_pair(_data[0], false);
+    pair<T, bool> popped(_data[0], false);
 
     // Preemptive check
     if (empty())

--- a/src/stdgpu/impl/queue_detail.cuh
+++ b/src/stdgpu/impl/queue_detail.cuh
@@ -46,7 +46,7 @@ queue<T, ContainerT>::push(const T& element)
 }
 
 template <typename T, typename ContainerT>
-inline STDGPU_DEVICE_ONLY thrust::pair<T, bool>
+inline STDGPU_DEVICE_ONLY pair<T, bool>
 queue<T, ContainerT>::pop()
 {
     return _c.pop_front();

--- a/src/stdgpu/impl/stack_detail.cuh
+++ b/src/stdgpu/impl/stack_detail.cuh
@@ -46,7 +46,7 @@ stack<T, ContainerT>::push(const T& element)
 }
 
 template <typename T, typename ContainerT>
-inline STDGPU_DEVICE_ONLY thrust::pair<T, bool>
+inline STDGPU_DEVICE_ONLY pair<T, bool>
 stack<T, ContainerT>::pop()
 {
     return _c.pop_back();

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -16,8 +16,6 @@
 #ifndef STDGPU_UNORDERED_BASE_H
 #define STDGPU_UNORDERED_BASE_H
 
-#include <thrust/pair.h>
-
 #include <stdgpu/atomic.cuh>
 #include <stdgpu/attribute.h>
 #include <stdgpu/bitset.cuh>
@@ -29,6 +27,7 @@
 #include <stdgpu/mutex.cuh>
 #include <stdgpu/platform.h>
 #include <stdgpu/ranges.h>
+#include <stdgpu/utility.h>
 #include <stdgpu/vector.cuh>
 
 namespace stdgpu
@@ -259,7 +258,7 @@ public:
      * \return An iterator to the inserted pair and the operation_status::success if the insertion was successful, end()
      * and failure status otherwise
      */
-    STDGPU_DEVICE_ONLY thrust::pair<iterator, operation_status>
+    STDGPU_DEVICE_ONLY pair<iterator, operation_status>
     try_insert(const value_type& value);
 
     /**
@@ -276,7 +275,7 @@ public:
      * \return An iterator to the inserted pair and true if the insertion was successful, end() and false otherwise
      */
     template <class... Args>
-    STDGPU_DEVICE_ONLY thrust::pair<iterator, bool>
+    STDGPU_DEVICE_ONLY pair<iterator, bool>
     emplace(Args&&... args);
 
     /**
@@ -284,7 +283,7 @@ public:
      * \param[in] value The new value
      * \return An iterator to the inserted pair and true if the insertion was successful, end() and false otherwise
      */
-    STDGPU_DEVICE_ONLY thrust::pair<iterator, bool>
+    STDGPU_DEVICE_ONLY pair<iterator, bool>
     insert(const value_type& value);
 
     /**

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -619,8 +619,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::contains_im
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY
-        thrust::pair<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::iterator,
-                     operation_status>
+        pair<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::iterator, operation_status>
         unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::try_insert(
                 const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::value_type& value)
 {
@@ -677,7 +676,7 @@ inline STDGPU_DEVICE_ONLY
                 index_t checked_linked_list_end = find_linked_list_end(bucket_index);
                 if (!contains(block) && linked_list_end == checked_linked_list_end)
                 {
-                    thrust::pair<index_t, bool> popped = _excess_list_positions.pop_back();
+                    pair<index_t, bool> popped = _excess_list_positions.pop_back();
 
                     if (!popped.second)
                     {
@@ -718,7 +717,7 @@ inline STDGPU_DEVICE_ONLY
         status = operation_status::failed_no_action_required;
     }
 
-    return thrust::make_pair(inserted_it, status);
+    return pair<iterator, operation_status>(inserted_it, status);
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
@@ -871,7 +870,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::find_previo
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 template <class... Args>
 inline STDGPU_DEVICE_ONLY
-        thrust::pair<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::iterator, bool>
+        pair<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::iterator, bool>
         unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::emplace(Args&&... args)
 {
     return insert(value_type(forward<Args>(args)...));
@@ -879,11 +878,11 @@ inline STDGPU_DEVICE_ONLY
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY
-        thrust::pair<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::iterator, bool>
+        pair<typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::iterator, bool>
         unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::insert(
                 const unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::value_type& value)
 {
-    thrust::pair<iterator, operation_status> result = thrust::make_pair(end(), operation_status::failed_collision);
+    pair<iterator, operation_status> result(end(), operation_status::failed_collision);
 
     while (true)
     {
@@ -897,8 +896,8 @@ inline STDGPU_DEVICE_ONLY
         }
     }
 
-    return result.second == operation_status::success ? thrust::make_pair(result.first, true)
-                                                      : thrust::make_pair(result.first, false);
+    return result.second == operation_status::success ? pair<iterator, bool>(result.first, true)
+                                                      : pair<iterator, bool>(result.first, false);
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -178,14 +178,14 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::contains(const KeyLike& key) c
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 template <class... Args>
-inline STDGPU_DEVICE_ONLY thrust::pair<typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::iterator, bool>
+inline STDGPU_DEVICE_ONLY pair<typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::iterator, bool>
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::emplace(Args&&... args)
 {
     return _base.emplace(forward<Args>(args)...);
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
-inline STDGPU_DEVICE_ONLY thrust::pair<typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::iterator, bool>
+inline STDGPU_DEVICE_ONLY pair<typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::iterator, bool>
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::insert(
         const unordered_map<Key, T, Hash, KeyEqual, Allocator>::value_type& value)
 {

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -163,14 +163,14 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::contains(const KeyLike& key) cons
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 template <class... Args>
-inline STDGPU_DEVICE_ONLY thrust::pair<typename unordered_set<Key, Hash, KeyEqual, Allocator>::iterator, bool>
+inline STDGPU_DEVICE_ONLY pair<typename unordered_set<Key, Hash, KeyEqual, Allocator>::iterator, bool>
 unordered_set<Key, Hash, KeyEqual, Allocator>::emplace(Args&&... args)
 {
     return _base.emplace(forward<Args>(args)...);
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
-inline STDGPU_DEVICE_ONLY thrust::pair<typename unordered_set<Key, Hash, KeyEqual, Allocator>::iterator, bool>
+inline STDGPU_DEVICE_ONLY pair<typename unordered_set<Key, Hash, KeyEqual, Allocator>::iterator, bool>
 unordered_set<Key, Hash, KeyEqual, Allocator>::insert(
         const unordered_set<Key, Hash, KeyEqual, Allocator>::value_type& value)
 {

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -200,11 +200,11 @@ vector<T, Allocator>::push_back(const T& element)
 }
 
 template <typename T, typename Allocator>
-inline STDGPU_DEVICE_ONLY thrust::pair<T, bool>
+inline STDGPU_DEVICE_ONLY pair<T, bool>
 vector<T, Allocator>::pop_back()
 {
     // Value if no element will be popped, i.e. undefined behavior for element of type T
-    thrust::pair<T, bool> popped = thrust::make_pair(_data[0], false);
+    pair<T, bool> popped(_data[0], false);
 
     // Preemptive check
     if (empty())

--- a/src/stdgpu/queue.cuh
+++ b/src/stdgpu/queue.cuh
@@ -28,12 +28,11 @@
  * \file stdgpu/queue.cuh
  */
 
-#include <thrust/pair.h>
-
 #include <stdgpu/attribute.h>
 #include <stdgpu/cstddef.h>
 #include <stdgpu/deque.cuh>
 #include <stdgpu/platform.h>
+#include <stdgpu/utility.h>
 
 ///////////////////////////////////////////////////////////
 
@@ -100,7 +99,7 @@ public:
      * \brief Removes and returns the first element from the queue
      * \return The currently popped element and true if not empty, an empty element T() and false otherwise
      */
-    STDGPU_DEVICE_ONLY thrust::pair<T, bool>
+    STDGPU_DEVICE_ONLY pair<T, bool>
     pop();
 
     /**

--- a/src/stdgpu/stack.cuh
+++ b/src/stdgpu/stack.cuh
@@ -28,12 +28,11 @@
  * \file stdgpu/stack.cuh
  */
 
-#include <thrust/pair.h>
-
 #include <stdgpu/attribute.h>
 #include <stdgpu/cstddef.h>
 #include <stdgpu/deque.cuh>
 #include <stdgpu/platform.h>
+#include <stdgpu/utility.h>
 
 ///////////////////////////////////////////////////////////
 
@@ -100,7 +99,7 @@ public:
      * \brief Removes and returns the current element from stack
      * \return The currently popped element and true if not empty, an empty element T() and false otherwise
      */
-    STDGPU_DEVICE_ONLY thrust::pair<T, bool>
+    STDGPU_DEVICE_ONLY pair<T, bool>
     pop();
 
     /**

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -28,14 +28,13 @@
  * \file stdgpu/unordered_map.cuh
  */
 
-#include <thrust/pair.h>
-
 #include <stdgpu/attribute.h>
 #include <stdgpu/functional.h>
 #include <stdgpu/impl/type_traits.h>
 #include <stdgpu/impl/unordered_base.cuh>
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
+#include <stdgpu/utility.h>
 
 ///////////////////////////////////////////////////////////
 
@@ -79,9 +78,9 @@ template <typename Key, typename T, typename Hash, typename KeyEqual, typename A
 class unordered_map
 {
 public:
-    using key_type = Key;                          /**< Key */
-    using mapped_type = T;                         /**< T */
-    using value_type = thrust::pair<const Key, T>; /**< thrust::pair<const Key, T> */
+    using key_type = Key;                  /**< Key */
+    using mapped_type = T;                 /**< T */
+    using value_type = pair<const Key, T>; /**< pair<const Key, T> */
 
     using index_type = index_t;             /**< index_t */
     using difference_type = std::ptrdiff_t; /**< std::ptrdiff_t */
@@ -278,7 +277,7 @@ public:
      * \return An iterator to the inserted pair and true if the insertion was successful, end() and false otherwise
      */
     template <class... Args>
-    STDGPU_DEVICE_ONLY thrust::pair<iterator, bool>
+    STDGPU_DEVICE_ONLY pair<iterator, bool>
     emplace(Args&&... args);
 
     /**
@@ -286,7 +285,7 @@ public:
      * \param[in] value The new value
      * \return An iterator to the inserted pair and true if the insertion was successful, end() and false otherwise
      */
-    STDGPU_DEVICE_ONLY thrust::pair<iterator, bool>
+    STDGPU_DEVICE_ONLY pair<iterator, bool>
     insert(const value_type& value);
 
     /**

--- a/src/stdgpu/unordered_map_fwd
+++ b/src/stdgpu/unordered_map_fwd
@@ -26,6 +26,9 @@
  * \file stdgpu/unordered_map_fwd
  */
 
+// Needed for pair which cannot be forward declared since it is a typedef declaration
+#include <stdgpu/utility.h>
+
 namespace stdgpu
 {
 
@@ -42,7 +45,7 @@ template <typename Key,
           typename T,
           typename Hash = hash<Key>,
           typename KeyEqual = equal_to<Key>,
-          typename Allocator = safe_device_allocator<thrust::pair<const Key, T>>>
+          typename Allocator = safe_device_allocator<pair<const Key, T>>>
 class unordered_map;
 
 } // namespace stdgpu

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -34,6 +34,7 @@
 #include <stdgpu/impl/unordered_base.cuh>
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
+#include <stdgpu/utility.h>
 
 ///////////////////////////////////////////////////////////
 
@@ -266,7 +267,7 @@ public:
      * \return An iterator to the inserted pair and true if the insertion was successful, end() and false otherwise
      */
     template <class... Args>
-    STDGPU_DEVICE_ONLY thrust::pair<iterator, bool>
+    STDGPU_DEVICE_ONLY pair<iterator, bool>
     emplace(Args&&... args);
 
     /**
@@ -274,7 +275,7 @@ public:
      * \param[in] value The new value
      * \return An iterator to the inserted pair and true if the insertion was successful, end() and false otherwise
      */
-    STDGPU_DEVICE_ONLY thrust::pair<iterator, bool>
+    STDGPU_DEVICE_ONLY pair<iterator, bool>
     insert(const value_type& value);
 
     /**

--- a/src/stdgpu/utility.h
+++ b/src/stdgpu/utility.h
@@ -26,12 +26,22 @@
  * \file stdgpu/utility.h
  */
 
+#include <thrust/pair.h>
 #include <type_traits>
 
 #include <stdgpu/platform.h>
 
 namespace stdgpu
 {
+
+/**
+ * \ingroup utility
+ * \tparam T1 The type of the first value
+ * \tparam T2 The type of the second value
+ * \brief A pair of two values of potentially different types
+ */
+template <typename T1, typename T2>
+using pair = thrust::pair<T1, T2>;
 
 /**
  * \ingroup utility

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -28,8 +28,6 @@
  * \file stdgpu/vector.cuh
  */
 
-#include <thrust/pair.h>
-
 #include <stdgpu/atomic.cuh>
 #include <stdgpu/attribute.h>
 #include <stdgpu/bitset.cuh>
@@ -40,6 +38,7 @@
 #include <stdgpu/mutex.cuh>
 #include <stdgpu/platform.h>
 #include <stdgpu/ranges.h>
+#include <stdgpu/utility.h>
 
 ///////////////////////////////////////////////////////////
 
@@ -211,7 +210,7 @@ public:
      * \brief Removes and returns the current element from end of the object
      * \return The currently popped element and true if not empty, an empty element T() and false otherwise
      */
-    STDGPU_DEVICE_ONLY thrust::pair<T, bool>
+    STDGPU_DEVICE_ONLY pair<T, bool>
     pop_back();
 
     /**

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -23,6 +23,7 @@
 #include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
+#include <stdgpu/utility.h>
 #include <test_memory_utils.h>
 
 class stdgpu_deque : public ::testing::Test
@@ -145,7 +146,7 @@ public:
     inline STDGPU_HOST_DEVICE void
     operator()(const stdgpu::index_t i)
     {
-        _pool.push_back(thrust::make_pair(_firsts[i], _second));
+        _pool.push_back(stdgpu::pair<typename Pair::first_type, typename Pair::second_type>(_firsts[i], _second));
     }
 
 private:
@@ -338,7 +339,7 @@ TEST_F(stdgpu_deque, pop_back_too_many)
 
 TEST_F(stdgpu_deque, pop_back_const_type)
 {
-    using T = thrust::pair<int, const float>;
+    using T = stdgpu::pair<int, const float>;
 
     const stdgpu::index_t N = 10000;
 
@@ -501,7 +502,7 @@ TEST_F(stdgpu_deque, push_back_too_many)
 
 TEST_F(stdgpu_deque, push_back_const_type)
 {
-    using T = thrust::pair<int, const float>;
+    using T = stdgpu::pair<int, const float>;
 
     const stdgpu::index_t N = 10000;
 
@@ -650,7 +651,7 @@ TEST_F(stdgpu_deque, emplace_back_too_many)
 
 TEST_F(stdgpu_deque, emplace_back_const_type)
 {
-    using T = thrust::pair<int, const float>;
+    using T = stdgpu::pair<int, const float>;
 
     const stdgpu::index_t N = 10000;
 
@@ -766,7 +767,7 @@ public:
     inline STDGPU_HOST_DEVICE void
     operator()(const stdgpu::index_t i)
     {
-        _pool.push_front(thrust::make_pair(_firsts[i], _second));
+        _pool.push_front(stdgpu::pair<typename Pair::first_type, typename Pair::second_type>(_firsts[i], _second));
     }
 
 private:
@@ -888,7 +889,7 @@ TEST_F(stdgpu_deque, pop_front_too_many)
 
 TEST_F(stdgpu_deque, pop_front_const_type)
 {
-    using T = thrust::pair<int, const float>;
+    using T = stdgpu::pair<int, const float>;
 
     const stdgpu::index_t N = 10000;
 
@@ -1050,7 +1051,7 @@ TEST_F(stdgpu_deque, push_front_too_many)
 
 TEST_F(stdgpu_deque, push_front_const_type)
 {
-    using T = thrust::pair<int, const float>;
+    using T = stdgpu::pair<int, const float>;
 
     const stdgpu::index_t N = 10000;
 
@@ -1198,7 +1199,7 @@ TEST_F(stdgpu_deque, emplace_front_too_many)
 
 TEST_F(stdgpu_deque, emplace_front_const_type)
 {
-    using T = thrust::pair<int, const float>;
+    using T = stdgpu::pair<int, const float>;
 
     const stdgpu::index_t N = 10000;
 
@@ -1464,7 +1465,7 @@ public:
     {
         _pool.push_back(_values[i]);
 
-        thrust::pair<T, bool> popped = _pool.pop_back();
+        stdgpu::pair<T, bool> popped = _pool.pop_back();
 
         if (popped.second)
         {
@@ -1534,7 +1535,7 @@ public:
     {
         _pool.push_front(_values[i]);
 
-        thrust::pair<T, bool> popped = _pool.pop_front();
+        stdgpu::pair<T, bool> popped = _pool.pop_front();
 
         if (popped.second)
         {
@@ -1604,7 +1605,7 @@ public:
     {
         _pool.push_front(_values[i]);
 
-        thrust::pair<T, bool> popped = _pool.pop_back();
+        stdgpu::pair<T, bool> popped = _pool.pop_back();
 
         if (popped.second)
         {
@@ -1674,7 +1675,7 @@ public:
     {
         _pool.push_back(_values[i]);
 
-        thrust::pair<T, bool> popped = _pool.pop_back();
+        stdgpu::pair<T, bool> popped = _pool.pop_back();
 
         if (popped.second)
         {

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -30,6 +30,7 @@
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
+#include <stdgpu/utility.h>
 #include <test_utils.h>
 
 class STDGPU_MEMORY_TEST_CLASS : public ::testing::Test
@@ -456,7 +457,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyDeviceArray)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyDeviceArray_const_type)
 {
-    using T = thrust::pair<const int, float>;
+    using T = stdgpu::pair<const int, float>;
     const T default_value = { 10, 2.0F };
     const stdgpu::index64_t size = 42;
 
@@ -481,7 +482,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyHostArray)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyHostArray_const_type)
 {
-    using T = thrust::pair<const int, float>;
+    using T = stdgpu::pair<const int, float>;
     const T default_value = { 10, 2.0F };
     const stdgpu::index64_t size = 42;
 
@@ -506,7 +507,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyManagedArray)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, createDestroyManagedArray_const_type)
 {
-    using T = thrust::pair<const int, float>;
+    using T = stdgpu::pair<const int, float>;
     const T default_value = { 10, 2.0F };
     const stdgpu::index64_t size = 42;
 

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -284,7 +284,7 @@ public:
     STDGPU_DEVICE_ONLY void
     operator()(STDGPU_MAYBE_UNUSED const stdgpu::index_t i)
     {
-        thrust::pair<typename HashDataStructure::iterator, bool> success =
+        stdgpu::pair<typename HashDataStructure::iterator, bool> success =
                 _hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(_key));
 
         *_inserted = success.second ? 1 : 0;
@@ -1161,7 +1161,7 @@ public:
     STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
-        thrust::pair<test_unordered_datastructure::iterator, bool> success =
+        stdgpu::pair<test_unordered_datastructure::iterator, bool> success =
                 _hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(_key));
 
         _inserted[i] = success.second ? 1 : 0;
@@ -1455,7 +1455,7 @@ public:
     STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
-        thrust::pair<test_unordered_datastructure::iterator, bool> success =
+        stdgpu::pair<test_unordered_datastructure::iterator, bool> success =
                 _hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(_keys[i]));
 
         _inserted[i] = success.second ? 1 : 0;
@@ -1482,7 +1482,7 @@ public:
     STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
-        thrust::pair<test_unordered_datastructure::iterator, bool> success =
+        stdgpu::pair<test_unordered_datastructure::iterator, bool> success =
                 _hash_datastructure.emplace(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(_keys[i]));
 
         _inserted[i] = success.second ? 1 : 0;
@@ -2005,7 +2005,7 @@ public:
     STDGPU_DEVICE_ONLY void
     operator()(const stdgpu::index_t i)
     {
-        thrust::pair<test_unordered_datastructure::iterator, bool> success_insert =
+        stdgpu::pair<test_unordered_datastructure::iterator, bool> success_insert =
                 _hash_datastructure.insert(STDGPU_UNORDERED_DATASTRUCTURE_KEY2VALUE(_keys[i]));
 
         _inserted[i] = success_insert.second ? 1 : 0;

--- a/test/stdgpu/unordered_map.inc
+++ b/test/stdgpu/unordered_map.inc
@@ -41,7 +41,7 @@ template class unordered_map<int, float>;
 // Instantiation of variadic templates emit warnings in CUDA backend
 /*
 template
-STDGPU_DEVICE_ONLY thrust::pair<typename unordered_map<int, float>::iterator, bool>
+STDGPU_DEVICE_ONLY pair<typename unordered_map<int, float>::iterator, bool>
 unordered_map<int, float>::emplace<int, float>(int&&, float&&);
 */
 
@@ -230,7 +230,7 @@ key_to_keylike(const vec3int16& key)
 #define STDGPU_UNORDERED_DATASTRUCTURE_NONTRIVIAL_TYPE                                                                 \
     stdgpu::unordered_map<vec3int32, dummy, vec_hash, stdgpu::equal_to<>>
 #define STDGPU_UNORDERED_DATASTRUCTURE_CUSTOM_ALLOCATOR                                                                \
-    test_utils::test_device_allocator<thrust::pair<const vec3int16, dummy>>
+    test_utils::test_device_allocator<stdgpu::pair<const vec3int16, dummy>>
 #define STDGPU_UNORDERED_DATASTRUCTURE_CUSTOM_TYPE                                                                     \
     stdgpu::unordered_map<vec3int16,                                                                                   \
                           dummy,                                                                                       \

--- a/test/stdgpu/unordered_set.inc
+++ b/test/stdgpu/unordered_set.inc
@@ -41,7 +41,7 @@ template class unordered_set<int>;
 // Instantiation of variadic templates emit warnings in CUDA backend
 /*
 template
-STDGPU_DEVICE_ONLY thrust::pair<typename unordered_set<int>::iterator, bool>
+STDGPU_DEVICE_ONLY pair<typename unordered_set<int>::iterator, bool>
 unordered_set<int>::emplace<int>(int&&);
 */
 

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -23,6 +23,7 @@
 #include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
+#include <stdgpu/utility.h>
 #include <stdgpu/vector.cuh>
 #include <test_memory_utils.h>
 
@@ -144,7 +145,7 @@ public:
     inline STDGPU_HOST_DEVICE void
     operator()(const stdgpu::index_t i)
     {
-        _pool.push_back(thrust::make_pair(_firsts[i], _second));
+        _pool.push_back(stdgpu::pair<typename Pair::first_type, typename Pair::second_type>(_firsts[i], _second));
     }
 
 private:
@@ -337,7 +338,7 @@ TEST_F(stdgpu_vector, pop_back_too_many)
 
 TEST_F(stdgpu_vector, pop_back_const_type)
 {
-    using T = thrust::pair<int, const float>;
+    using T = stdgpu::pair<int, const float>;
 
     const stdgpu::index_t N = 10000;
 
@@ -500,7 +501,7 @@ TEST_F(stdgpu_vector, push_back_too_many)
 
 TEST_F(stdgpu_vector, push_back_const_type)
 {
-    using T = thrust::pair<int, const float>;
+    using T = stdgpu::pair<int, const float>;
 
     const stdgpu::index_t N = 10000;
 
@@ -649,7 +650,7 @@ TEST_F(stdgpu_vector, emplace_back_too_many)
 
 TEST_F(stdgpu_vector, emplace_back_const_type)
 {
-    using T = thrust::pair<int, const float>;
+    using T = stdgpu::pair<int, const float>;
 
     const stdgpu::index_t N = 10000;
 
@@ -893,7 +894,7 @@ public:
     {
         _pool.push_back(_values[i]);
 
-        thrust::pair<T, bool> popped = _pool.pop_back();
+        stdgpu::pair<T, bool> popped = _pool.pop_back();
 
         if (popped.second)
         {


### PR DESCRIPTION
Several data structures including their unit tests use `thrust::pair` to have a device-side version of `std::pair`. Although we could re-implement the `pair` data structure and also fix some of thrust's limitations in their implementation, it is sufficient to only define an alias and port all use cases to the new alias. A full replacement can still be considered in the future.

Partially addresses #279