### PR TITLE
memory: Add to_address function

### DIFF
--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -687,6 +687,28 @@ allocator_traits<Allocator>::select_on_container_copy_construction(const Allocat
     return a;
 }
 
+template <typename T>
+STDGPU_HOST_DEVICE T*
+to_address(T* p)
+{
+    return p;
+}
+
+template <typename Ptr, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::has_arrow_operator<Ptr>::value)>
+STDGPU_HOST_DEVICE auto
+to_address(const Ptr& p)
+{
+    return to_address(p.operator->());
+}
+
+template <typename Ptr,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(!detail::has_arrow_operator<Ptr>::value && detail::has_get<Ptr>::value)>
+STDGPU_HOST_DEVICE auto
+to_address(const Ptr& p)
+{
+    return to_address(p.get());
+}
+
 template <typename T, typename... Args>
 STDGPU_HOST_DEVICE T*
 construct_at(T* p, Args&&... args)

--- a/src/stdgpu/impl/type_traits.h
+++ b/src/stdgpu/impl/type_traits.h
@@ -17,6 +17,7 @@
 #define STDGPU_TYPE_TRAITS_H
 
 #include <type_traits>
+#include <utility>
 
 namespace stdgpu
 {
@@ -56,7 +57,7 @@ using void_t = typename void_helper<Types...>::type;
     };                                                                                                                 \
                                                                                                                        \
     template <typename T>                                                                                              \
-    struct name<T, void_t<__VA_ARGS__>> : std::true_type                                                               \
+    struct name<T, stdgpu::detail::void_t<__VA_ARGS__>> : std::true_type                                               \
     {                                                                                                                  \
     };
 
@@ -70,6 +71,12 @@ STDGPU_DETAIL_DEFINE_TRAIT(is_iterator,
 STDGPU_DETAIL_DEFINE_TRAIT(is_transparent, typename T::is_transparent)
 
 STDGPU_DETAIL_DEFINE_TRAIT(is_base, typename T::is_base)
+
+STDGPU_DETAIL_DEFINE_TRAIT(has_get, decltype(std::declval<T>().get()))
+STDGPU_DETAIL_DEFINE_TRAIT(has_arrow_operator,
+                           decltype(std::declval<T>()
+                                            .
+                                            operator->()))
 
 } // namespace detail
 

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -394,7 +394,7 @@ public:
     STDGPU_DEVICE_ONLY void
     operator()(const index_t i)
     {
-        _base.insert(*(_begin + i));
+        _base.insert(*to_address(_begin + i));
     }
 
 private:

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -32,6 +32,7 @@
 #include <stdgpu/attribute.h>
 #include <stdgpu/config.h>
 #include <stdgpu/cstddef.h>
+#include <stdgpu/impl/type_traits.h>
 #include <stdgpu/platform.h>
 
 /**
@@ -723,6 +724,35 @@ struct allocator_traits : public detail::allocator_traits_base<Allocator>
     static Allocator
     select_on_container_copy_construction(const Allocator& a);
 };
+
+/**
+ * \ingroup memory
+ * \brief Converts a potential fancy pointer to a raw pointer
+ * \tparam T The raw pointer type
+ * \param[in] p A raw pointer
+ * \return The given raw pointer as provided
+ */
+template <typename T>
+STDGPU_HOST_DEVICE T*
+to_address(T* p);
+
+/**
+ * \ingroup memory
+ * \brief Converts a potential fancy pointer to a raw pointer
+ * \tparam Ptr The fancy pointer type
+ * \param[in] p A fancy pointer
+ * \return The raw pointer held by the fancy pointer obtained via operator->()
+ */
+template <typename Ptr, STDGPU_DETAIL_OVERLOAD_IF(detail::has_arrow_operator<Ptr>::value)>
+STDGPU_HOST_DEVICE auto
+to_address(const Ptr& p);
+
+//! @cond Doxygen_Suppress
+template <typename Ptr,
+          STDGPU_DETAIL_OVERLOAD_IF(!detail::has_arrow_operator<Ptr>::value && detail::has_get<Ptr>::value)>
+STDGPU_HOST_DEVICE auto
+to_address(const Ptr& p);
+//! @endcond
 
 /**
  * \ingroup memory

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -1503,6 +1503,73 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_max_size_and_select)
     EXPECT_EQ(stdgpu::allocator_traits<Allocator>::max_size(a), stdgpu::allocator_traits<Allocator>::max_size(b));
 }
 
+TEST_F(STDGPU_MEMORY_TEST_CLASS, to_address_raw_pointer)
+{
+    int i = 42;
+
+    int* p = &i;
+
+    EXPECT_EQ(p, stdgpu::to_address(p));
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, to_address_device_ptr)
+{
+    int i = 42;
+
+    int* p = &i;
+    stdgpu::device_ptr<int> device_p(&i);
+
+    EXPECT_EQ(p, stdgpu::to_address(device_p));
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, to_address_host_ptr)
+{
+    int i = 42;
+
+    int* p = &i;
+    stdgpu::host_ptr<int> host_p(&i);
+
+    EXPECT_EQ(p, stdgpu::to_address(host_p));
+}
+
+namespace
+{
+template <typename T>
+class FancyPtr
+{
+public:
+    explicit FancyPtr(T* ptr)
+      : _ptr(ptr)
+    {
+    }
+
+    STDGPU_HOST_DEVICE T*
+    get() const
+    {
+        return _ptr;
+    }
+
+    STDGPU_HOST_DEVICE T*
+    operator->() const
+    {
+        return _ptr;
+    }
+
+private:
+    T* _ptr;
+};
+} // namespace
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, to_address_custom_fancy_ptr)
+{
+    int i = 42;
+
+    int* p = &i;
+    FancyPtr<int> fancy_p(&i);
+
+    EXPECT_EQ(p, stdgpu::to_address(fancy_p));
+}
+
 TEST_F(STDGPU_MEMORY_TEST_CLASS, construct_at)
 {
     using Allocator = stdgpu::safe_host_allocator<Counter>;


### PR DESCRIPTION
The recent refactoring of `for_each` in #294 introduced a regression for `unordered_map` where the `insert` function no longer worked for a `device_ptr` of constant type as the internal cast to a raw pointer is no longer present. Fortunately, C++20 added the `to_address` function for such use cases where the raw pointer of a fancy pointer can be obtained. Add `to_address` as well as the respective unit tests to fix the regression. Furthermore, this will be useful for the remaining porting effort.