### PR TITLE
src, test: Port away from copy and fill

### DIFF
--- a/src/stdgpu/algorithm.h
+++ b/src/stdgpu/algorithm.h
@@ -101,6 +101,36 @@ template <typename ExecutionPolicy, typename Iterator, typename T>
 void
 iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value);
 
+/**
+ * \ingroup algorithm
+ * \brief Writes the given value to into the given range
+ * \tparam ExecutionPolicy The type of the execution policy
+ * \tparam Iterator The type of the iterators
+ * \tparam T The type of the value
+ * \param[in] policy The execution policy, e.g. host or device
+ * \param[in] begin The iterator pointing to the first element
+ * \param[in] end The iterator pointing past to the last element
+ * \param[in] value The value that will be written
+ */
+template <typename ExecutionPolicy, typename Iterator, typename T>
+void
+fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const T& value);
+
+/**
+ * \ingroup algorithm
+ * \brief Copies all elements of the input range to the output range
+ * \tparam ExecutionPolicy The type of the execution policy
+ * \tparam InputIt The type of the input iterators
+ * \tparam OutputIt The type of the output iterator
+ * \param[in] policy The execution policy, e.g. host or device
+ * \param[in] begin The input iterator pointing to the first element
+ * \param[in] end The input iterator pointing past to the last element
+ * \param[in] output_begin The output iterator pointing to the first element
+ */
+template <typename ExecutionPolicy, typename InputIt, typename OutputIt>
+void
+copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputIt output_begin);
+
 } // namespace stdgpu
 
 /**

--- a/src/stdgpu/impl/algorithm_detail.h
+++ b/src/stdgpu/impl/algorithm_detail.h
@@ -86,6 +86,70 @@ iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value)
     for_each_index(policy, N, detail::iota_functor<Iterator, T>(begin, value));
 }
 
+namespace detail
+{
+template <typename Iterator, typename T>
+class fill_functor
+{
+public:
+    fill_functor(Iterator begin, T value)
+      : _begin(begin)
+      , _value(value)
+    {
+    }
+
+    STDGPU_HOST_DEVICE void
+    operator()(const index_t i)
+    {
+        _begin[i] = _value;
+    }
+
+private:
+    Iterator _begin;
+    T _value;
+};
+} // namespace detail
+
+template <typename ExecutionPolicy, typename Iterator, typename T>
+void
+fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const T& value)
+{
+    index_t N = static_cast<index_t>(end - begin);
+    for_each_index(policy, N, detail::fill_functor<Iterator, T>(begin, value));
+}
+
+namespace detail
+{
+template <typename InputIt, typename OutputIt>
+class copy_functor
+{
+public:
+    copy_functor(InputIt begin, OutputIt output_begin)
+      : _begin(begin)
+      , _output_begin(output_begin)
+    {
+    }
+
+    STDGPU_HOST_DEVICE void
+    operator()(const index_t i)
+    {
+        _output_begin[i] = _begin[i];
+    }
+
+private:
+    InputIt _begin;
+    OutputIt _output_begin;
+};
+} // namespace detail
+
+template <typename ExecutionPolicy, typename InputIt, typename OutputIt>
+void
+copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputIt output_begin)
+{
+    index_t N = static_cast<index_t>(end - begin);
+    for_each_index(policy, N, detail::copy_functor<InputIt, OutputIt>(begin, output_begin));
+}
+
 } // namespace stdgpu
 
 #endif // STDGPU_ALGORTIMH_DETAIL_H

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -17,7 +17,6 @@
 #define STDGPU_BITSET_DETAIL_H
 
 #include <limits>
-#include <thrust/fill.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform_reduce.h>
 
@@ -219,7 +218,7 @@ template <typename Block, typename Allocator>
 inline void
 bitset<Block, Allocator>::set()
 {
-    thrust::fill(device_begin(_bit_blocks), device_end(_bit_blocks), ~block_type(0));
+    stdgpu::fill(thrust::device, device_begin(_bit_blocks), device_end(_bit_blocks), ~block_type(0));
 
     STDGPU_ENSURES(count() == size());
 }
@@ -238,7 +237,7 @@ template <typename Block, typename Allocator>
 inline void
 bitset<Block, Allocator>::reset()
 {
-    thrust::fill(device_begin(_bit_blocks), device_end(_bit_blocks), block_type(0));
+    stdgpu::fill(thrust::device, device_begin(_bit_blocks), device_end(_bit_blocks), block_type(0));
 
     STDGPU_ENSURES(count() == 0);
 }

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -1057,7 +1057,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::clear()
                                destroy_values<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>(*this));
     }
 
-    thrust::fill(device_begin(_offsets), device_end(_offsets), 0);
+    stdgpu::fill(thrust::device, device_begin(_offsets), device_end(_offsets), 0);
 
     _occupied.reset();
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -16,7 +16,6 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <thrust/copy.h>
 
 #include <stdgpu/algorithm.h>
 #include <stdgpu/deque.cuh>
@@ -2334,7 +2333,7 @@ TEST_F(stdgpu_deque, non_const_device_range)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = pool.device_range();
-    thrust::copy(range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -2364,7 +2363,7 @@ TEST_F(stdgpu_deque, non_const_device_range_full)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = pool.device_range();
-    thrust::copy(range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -2402,7 +2401,7 @@ TEST_F(stdgpu_deque, non_const_device_range_circular)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = pool.device_range();
-    thrust::copy(range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -2433,7 +2432,7 @@ TEST_F(stdgpu_deque, const_device_range)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range();
-    thrust::copy(range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -2463,7 +2462,7 @@ TEST_F(stdgpu_deque, const_device_range_full)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range();
-    thrust::copy(range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -2501,7 +2500,7 @@ TEST_F(stdgpu_deque, const_device_range_circular)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range();
-    thrust::copy(range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());

--- a/test/stdgpu/iterator.cpp
+++ b/test/stdgpu/iterator.cpp
@@ -17,9 +17,9 @@
 
 #include <algorithm>
 #include <numeric>
-#include <thrust/copy.h>
 #include <vector>
 
+#include <stdgpu/algorithm.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
 
@@ -398,7 +398,7 @@ TEST_F(stdgpu_iterator, back_inserter)
     std::iota(stdgpu::host_begin(array), stdgpu::host_end(array), 1);
 
     back_insert_interface ci(numbers);
-    thrust::copy(stdgpu::host_cbegin(array), stdgpu::host_cend(array), stdgpu::back_inserter(ci));
+    stdgpu::copy(thrust::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), stdgpu::back_inserter(ci));
 
     int* array_result = copyCreateHost2HostArray<int>(numbers.data(), N, MemoryCopy::NO_CHECK);
 
@@ -423,7 +423,7 @@ TEST_F(stdgpu_iterator, front_inserter)
     std::iota(stdgpu::host_begin(array), stdgpu::host_end(array), 1);
 
     front_insert_interface ci(numbers);
-    thrust::copy(stdgpu::host_cbegin(array), stdgpu::host_cend(array), stdgpu::front_inserter(ci));
+    stdgpu::copy(thrust::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), stdgpu::front_inserter(ci));
 
     int* array_result = copyCreateHost2HostArray<int>(numbers.data(), N, MemoryCopy::NO_CHECK);
 
@@ -448,7 +448,7 @@ TEST_F(stdgpu_iterator, inserter)
     std::iota(stdgpu::host_begin(array), stdgpu::host_end(array), 1);
 
     insert_interface ci(numbers);
-    thrust::copy(stdgpu::host_cbegin(array), stdgpu::host_cend(array), stdgpu::inserter(ci));
+    stdgpu::copy(thrust::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), stdgpu::inserter(ci));
 
     int* array_result = copyCreateHost2HostArray<int>(numbers.data(), N, MemoryCopy::NO_CHECK);
 

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -23,9 +23,9 @@
 #include <cmath>
 #include <thrust/equal.h>
 #include <thrust/execution_policy.h>
-#include <thrust/fill.h>
 #include <thrust/logical.h>
 
+#include <stdgpu/algorithm.h>
 #include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
@@ -1252,7 +1252,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_device_allocator)
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
     const int default_value = 10;
-    thrust::fill(stdgpu::device_begin(array), stdgpu::device_end(array), default_value);
+    stdgpu::fill(thrust::device, stdgpu::device_begin(array), stdgpu::device_end(array), default_value);
 
     EXPECT_TRUE(
             thrust::all_of(stdgpu::device_cbegin(array), stdgpu::device_cend(array), equal_to_number(default_value)));
@@ -1269,7 +1269,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_host_allocator)
     int* array = a.allocate(size);
 
     const int default_value = 10;
-    thrust::fill(stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+    stdgpu::fill(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
 
     EXPECT_TRUE(thrust::all_of(stdgpu::host_cbegin(array), stdgpu::host_cend(array), equal_to_number(default_value)));
 
@@ -1284,7 +1284,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_managed_allocator)
     int* array = a.allocate(size);
 
     const int default_value = 10;
-    thrust::fill(stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+    stdgpu::fill(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
 
     EXPECT_TRUE(thrust::all_of(stdgpu::host_cbegin(array), stdgpu::host_cend(array), equal_to_number(default_value)));
 
@@ -1301,7 +1301,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_deallocate)
     int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
 
     const int default_value = 10;
-    thrust::fill(stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+    stdgpu::fill(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
 
     EXPECT_TRUE(thrust::all_of(stdgpu::host_cbegin(array), stdgpu::host_cend(array), equal_to_number(default_value)));
 
@@ -1319,7 +1319,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_hint_deallocate)
     int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size, array_hint);
 
     const int default_value = 10;
-    thrust::fill(stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+    stdgpu::fill(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
 
     EXPECT_TRUE(thrust::all_of(stdgpu::host_cbegin(array), stdgpu::host_cend(array), equal_to_number(default_value)));
 
@@ -1341,7 +1341,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_device)
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
     const int default_value = 10;
-    thrust::fill(stdgpu::device_begin(array), stdgpu::device_end(array), default_value);
+    stdgpu::fill(thrust::device, stdgpu::device_begin(array), stdgpu::device_end(array), default_value);
 
     EXPECT_TRUE(
             thrust::all_of(stdgpu::device_cbegin(array), stdgpu::device_cend(array), equal_to_number(default_value)));
@@ -1363,7 +1363,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_host)
     int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
 
     const int default_value = 10;
-    thrust::fill(stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+    stdgpu::fill(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
 
     EXPECT_TRUE(thrust::all_of(stdgpu::host_cbegin(array), stdgpu::host_cend(array), equal_to_number(default_value)));
 
@@ -1383,7 +1383,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_managed)
     int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
 
     const int default_value = 10;
-    thrust::fill(stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+    stdgpu::fill(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
 
     EXPECT_TRUE(thrust::all_of(stdgpu::host_cbegin(array), stdgpu::host_cend(array), equal_to_number(default_value)));
 

--- a/test/stdgpu/ranges.cpp
+++ b/test/stdgpu/ranges.cpp
@@ -16,8 +16,8 @@
 #include <gtest/gtest.h>
 
 #include <numeric>
-#include <thrust/copy.h>
 
+#include <stdgpu/algorithm.h>
 #include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
@@ -285,7 +285,7 @@ TEST_F(stdgpu_ranges, transform_range_with_range)
     std::iota(array_range.begin(), array_range.end(), 0);
 
     // Execute transformation and write into array_result
-    thrust::copy(square_range.begin(), square_range.end(), stdgpu::host_begin(array_result));
+    stdgpu::copy(thrust::host, square_range.begin(), square_range.end(), stdgpu::host_begin(array_result));
 
     for (stdgpu::index_t i = 0; i < size; ++i)
     {
@@ -310,7 +310,7 @@ TEST_F(stdgpu_ranges, transform_range_with_range_and_function)
     std::iota(array_range.begin(), array_range.end(), 0);
 
     // Execute transformation and write into array_result
-    thrust::copy(square_range.begin(), square_range.end(), stdgpu::host_begin(array_result));
+    stdgpu::copy(thrust::host, square_range.begin(), square_range.end(), stdgpu::host_begin(array_result));
 
     for (stdgpu::index_t i = 0; i < size; ++i)
     {

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -16,7 +16,6 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <thrust/copy.h>
 #include <thrust/iterator/counting_iterator.h>
 
 #include <stdgpu/algorithm.h>
@@ -1597,7 +1596,7 @@ TEST_F(stdgpu_vector, non_const_device_range)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = pool.device_range();
-    thrust::copy(range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -1627,7 +1626,7 @@ TEST_F(stdgpu_vector, const_device_range)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = static_cast<const stdgpu::vector<int>&>(pool).device_range();
-    thrust::copy(range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());


### PR DESCRIPTION
The `fill`  and `copy` functions are used in the library itself as well as in the unit tests. Port away from these functions by re-implementing them in terms of `for_each_index`.

Partially addresses #279