### PR TITLE
memory: Add uninitialized_copy and uninitialized_fill

### DIFF
--- a/src/stdgpu/algorithm.h
+++ b/src/stdgpu/algorithm.h
@@ -103,7 +103,7 @@ iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value);
 
 /**
  * \ingroup algorithm
- * \brief Writes the given value to into the given range
+ * \brief Writes the given value into the given range using the copy assignment operator
  * \tparam ExecutionPolicy The type of the execution policy
  * \tparam Iterator The type of the iterators
  * \tparam T The type of the value
@@ -118,7 +118,7 @@ fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const T& value);
 
 /**
  * \ingroup algorithm
- * \brief Copies all elements of the input range to the output range
+ * \brief Copies all elements of the input range to the output range using the copy assignment operator
  * \tparam ExecutionPolicy The type of the execution policy
  * \tparam InputIt The type of the input iterators
  * \tparam OutputIt The type of the output iterator

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -779,6 +779,36 @@ destroy_at(T* p);
 
 /**
  * \ingroup memory
+ * \brief Writes the given value to into the given range using the copy constructor
+ * \tparam ExecutionPolicy The type of the execution policy
+ * \tparam Iterator The type of the iterators
+ * \tparam T The type of the value
+ * \param[in] policy The execution policy, e.g. host or device
+ * \param[in] begin The iterator pointing to the first element
+ * \param[in] end The iterator pointing past to the last element
+ * \param[in] value The value that will be written
+ */
+template <typename ExecutionPolicy, typename Iterator, typename T>
+void
+uninitialized_fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const T& value);
+
+/**
+ * \ingroup memory
+ * \brief Copies all elements of the input range to the output range using the copy constructor
+ * \tparam ExecutionPolicy The type of the execution policy
+ * \tparam InputIt The type of the input iterators
+ * \tparam OutputIt The type of the output iterator
+ * \param[in] policy The execution policy, e.g. host or device
+ * \param[in] begin The input iterator pointing to the first element
+ * \param[in] end The input iterator pointing past to the last element
+ * \param[in] output_begin The output iterator pointing to the first element
+ */
+template <typename ExecutionPolicy, typename InputIt, typename OutputIt>
+void
+uninitialized_copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputIt output_begin);
+
+/**
+ * \ingroup memory
  * \brief Destroys the range of values
  * \tparam Iterator The iterator type of the values
  * \param[in] first An iterator to the begin of the value range

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -21,9 +21,11 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
 #include <thrust/equal.h>
 #include <thrust/execution_policy.h>
 #include <thrust/logical.h>
+#include <vector>
 
 #include <stdgpu/algorithm.h>
 #include <stdgpu/functional.h>
@@ -1684,6 +1686,111 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroy_at)
     EXPECT_EQ(destructor_calls, size);
 
     stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
+}
+
+namespace
+{
+class copyable_float
+{
+public:
+    copyable_float() = default;
+
+    explicit copyable_float(const float f)
+      : _f(f)
+    {
+    }
+
+    copyable_float(const copyable_float&) = default;
+    copyable_float&
+    operator=(const copyable_float&) = delete;
+
+    // Move constructor needed for uninitialized_copy implementation
+    copyable_float(copyable_float&&) = default;
+    copyable_float&
+    operator=(copyable_float&&) = delete;
+
+    bool
+    operator==(const copyable_float& other) const
+    {
+        // Avoids float-equal warning
+        return std::equal_to<>{}(_f, other._f);
+    }
+
+private:
+    float _f;
+};
+} // namespace
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill)
+{
+    using T = float;
+
+    const stdgpu::index_t N = 100000000;
+    std::vector<T> values_vector(N);
+    T* values = values_vector.data();
+
+    T init(42.0F);
+    stdgpu::uninitialized_fill(thrust::host, stdgpu::make_host(values), stdgpu::make_host(values + N), init);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(values[i], init);
+    }
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill_only_copyable)
+{
+    using T = copyable_float;
+
+    const stdgpu::index_t N = 100000000;
+    std::vector<T> values_vector(N);
+    T* values = values_vector.data();
+
+    T init(42.0F);
+    stdgpu::uninitialized_fill(thrust::host, stdgpu::make_host(values), stdgpu::make_host(values + N), init);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(values[i], init);
+    }
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy)
+{
+    using T = float;
+
+    const stdgpu::index_t N = 100000000;
+    std::vector<T> values_vector(N);
+    T* values = values_vector.data();
+
+    std::vector<T> values_copied_vector(N);
+    T* values_copied = values_copied_vector.data();
+
+    stdgpu::uninitialized_copy(thrust::host, stdgpu::make_host(values), stdgpu::make_host(values + N), values_copied);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(values[i], values_copied[i]);
+    }
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy_only_copyable)
+{
+    using T = copyable_float;
+
+    const stdgpu::index_t N = 100000000;
+    std::vector<T> values_vector(N);
+    T* values = values_vector.data();
+
+    std::vector<T> values_copied_vector(N);
+    T* values_copied = values_copied_vector.data();
+
+    stdgpu::uninitialized_copy(thrust::host, stdgpu::make_host(values), stdgpu::make_host(values + N), values_copied);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(values[i], values_copied[i]);
+    }
 }
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory)

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -35,13 +35,11 @@
 #include <numeric>
 #include <random>
 #include <thread>
-#include <thrust/for_each.h>
 #include <unordered_set>
 
 #include <stdgpu/algorithm.h>
 #include <stdgpu/functional.h>
 #include <stdgpu/memory.h>
-#include <stdgpu/vector.cuh>
 #include <test_utils.h>
 
 // convenience wrapper to improve readability
@@ -2200,55 +2198,40 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, count_sum)
     destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
 }
 
-namespace
-{
-class insert_vector
-{
-public:
-    explicit insert_vector(const stdgpu::vector<test_unordered_datastructure::key_type>& keys)
-      : _keys(keys)
-    {
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const test_unordered_datastructure::value_type& value)
-    {
-        _keys.push_back(STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(value));
-    }
-
-private:
-    stdgpu::vector<test_unordered_datastructure::key_type> _keys;
-};
-} // namespace
-
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_keys_same)
 {
     const stdgpu::index_t N = 100000;
 
     test_unordered_datastructure::key_type* host_positions = insert_unique_parallel(hash_datastructure, N);
 
-    stdgpu::vector<test_unordered_datastructure::key_type> keys =
-            stdgpu::vector<test_unordered_datastructure::key_type>::createDeviceObject(N);
+    test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
 
     auto range = hash_datastructure.device_range();
-    thrust::for_each(range.begin(), range.end(), insert_vector(keys));
+    // unordered_map's value_type cannot be copied using copy(), so use uninitialized_copy() instead
+    stdgpu::uninitialized_copy(thrust::device, range.begin(), range.end(), values);
 
-    ASSERT_EQ(keys.size(), N);
-
-    test_unordered_datastructure::key_type* host_positions_inserted =
-            copyCreateDevice2HostArray<test_unordered_datastructure::key_type>(keys.data(), keys.size());
-
-    std::sort(host_positions, host_positions + N, less());
-    std::sort(host_positions_inserted, host_positions_inserted + N, less());
+    test_unordered_datastructure::value_type* host_values =
+            copyCreateDevice2HostArray<test_unordered_datastructure::value_type>(values, N);
+    test_unordered_datastructure::key_type* host_positions_copied =
+            createHostArray<test_unordered_datastructure::key_type>(N);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
-        EXPECT_EQ(host_positions[i], host_positions_inserted[i]);
+        host_positions_copied[i] = STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(host_values[i]);
+    }
+
+    std::sort(host_positions, host_positions + N, less());
+    std::sort(host_positions_copied, host_positions_copied + N, less());
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(host_positions[i], host_positions_copied[i]);
     }
 
     destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
-    destroyHostArray<test_unordered_datastructure::key_type>(host_positions_inserted);
-    stdgpu::vector<test_unordered_datastructure::key_type>::destroyDeviceObject(keys);
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions_copied);
+    destroyHostArray<test_unordered_datastructure::value_type>(host_values);
+    destroyDeviceArray<test_unordered_datastructure::value_type>(values);
 }
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, clear_empty)


### PR DESCRIPTION
One remaining non-trivial use case of `thrust::for_each` is the unit test of `unordered_map` and `unordered_set` where the range function is checked. Since the value type of `unordered_map` is not assignable, the recently introduced `copy` in #297 cannot be used. Add `uninitialized_copy` and `uninitialized_fill` as the corresponding versions that use the copy constructor rather than copy assignment and port this use case to the new functions. This also exposes the so-far hidden `uninitialized_fill` function and adds respective unit tests for it.

Partially addresses #279