### PR TITLE
algorithm,memory: Add *_n versions of algorithms and cleanup destroy

### DIFF
--- a/src/stdgpu/algorithm.h
+++ b/src/stdgpu/algorithm.h
@@ -118,6 +118,23 @@ fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const T& value);
 
 /**
  * \ingroup algorithm
+ * \brief Writes the given value into the given range using the copy assignment operator
+ * \tparam ExecutionPolicy The type of the execution policy
+ * \tparam Iterator The type of the iterators
+ * \tparam Size The size type
+ * \tparam T The type of the value
+ * \param[in] policy The execution policy, e.g. host or device
+ * \param[in] begin The iterator pointing to the first element
+ * \param[in] n The number of elements in the value range
+ * \param[in] value The value that will be written
+ * \return The iterator pointing to the last element
+ */
+template <typename ExecutionPolicy, typename Iterator, typename Size, typename T>
+Iterator
+fill_n(ExecutionPolicy&& policy, Iterator begin, Size n, const T& value);
+
+/**
+ * \ingroup algorithm
  * \brief Copies all elements of the input range to the output range using the copy assignment operator
  * \tparam ExecutionPolicy The type of the execution policy
  * \tparam InputIt The type of the input iterators
@@ -126,10 +143,28 @@ fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const T& value);
  * \param[in] begin The input iterator pointing to the first element
  * \param[in] end The input iterator pointing past to the last element
  * \param[in] output_begin The output iterator pointing to the first element
+ * \return The output iterator pointing to the last element
  */
 template <typename ExecutionPolicy, typename InputIt, typename OutputIt>
-void
+OutputIt
 copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputIt output_begin);
+
+/**
+ * \ingroup algorithm
+ * \brief Copies all elements of the input range to the output range using the copy assignment operator
+ * \tparam ExecutionPolicy The type of the execution policy
+ * \tparam InputIt The type of the input iterators
+ * \tparam Size The size type
+ * \tparam OutputIt The type of the output iterator
+ * \param[in] policy The execution policy, e.g. host or device
+ * \param[in] begin The input iterator pointing to the first element
+ * \param[in] n The number of elements in the value range
+ * \param[in] output_begin The output iterator pointing to the first element
+ * \return The output iterator pointing to the last element
+ */
+template <typename ExecutionPolicy, typename InputIt, typename Size, typename OutputIt>
+OutputIt
+copy_n(ExecutionPolicy&& policy, InputIt begin, Size n, OutputIt output_begin);
 
 } // namespace stdgpu
 

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -473,18 +473,24 @@ deque<T, Allocator>::clear()
         // Full, i.e. one large block and begin == end
         if (full())
         {
-            stdgpu::detail::unoptimized_destroy(stdgpu::device_begin(_data), stdgpu::device_end(_data));
+            stdgpu::detail::unoptimized_destroy(thrust::device, stdgpu::device_begin(_data), stdgpu::device_end(_data));
         }
         // One large block
         else if (begin <= end)
         {
-            stdgpu::detail::unoptimized_destroy(stdgpu::make_device(_data + begin), stdgpu::make_device(_data + end));
+            stdgpu::detail::unoptimized_destroy(thrust::device,
+                                                stdgpu::make_device(_data + begin),
+                                                stdgpu::make_device(_data + end));
         }
         // Two disconnected blocks
         else
         {
-            stdgpu::detail::unoptimized_destroy(stdgpu::device_begin(_data), stdgpu::make_device(_data + end));
-            stdgpu::detail::unoptimized_destroy(stdgpu::make_device(_data + begin), stdgpu::device_end(_data));
+            stdgpu::detail::unoptimized_destroy(thrust::device,
+                                                stdgpu::device_begin(_data),
+                                                stdgpu::make_device(_data + end));
+            stdgpu::detail::unoptimized_destroy(thrust::device,
+                                                stdgpu::make_device(_data + begin),
+                                                stdgpu::device_end(_data));
         }
     }
 

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -487,7 +487,9 @@ vector<T, Allocator>::clear()
     {
         const index_t current_size = size();
 
-        stdgpu::detail::unoptimized_destroy(stdgpu::device_begin(_data), stdgpu::device_begin(_data) + current_size);
+        stdgpu::detail::unoptimized_destroy(thrust::device,
+                                            stdgpu::device_begin(_data),
+                                            stdgpu::device_begin(_data) + current_size);
     }
 
     _occupied.reset();

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -794,6 +794,23 @@ uninitialized_fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const
 
 /**
  * \ingroup memory
+ * \brief Writes the given value to into the given range using the copy constructor
+ * \tparam ExecutionPolicy The type of the execution policy
+ * \tparam Iterator The type of the iterators
+ * \tparam Size The size type
+ * \tparam T The type of the value
+ * \param[in] policy The execution policy, e.g. host or device
+ * \param[in] begin The iterator pointing to the first element
+ * \param[in] n The number of elements in the value range
+ * \param[in] value The value that will be written
+ * \return The iterator pointing to the last element
+ */
+template <typename ExecutionPolicy, typename Iterator, typename Size, typename T>
+Iterator
+uninitialized_fill_n(ExecutionPolicy&& policy, Iterator begin, Size n, const T& value);
+
+/**
+ * \ingroup memory
  * \brief Copies all elements of the input range to the output range using the copy constructor
  * \tparam ExecutionPolicy The type of the execution policy
  * \tparam InputIt The type of the input iterators
@@ -802,34 +819,56 @@ uninitialized_fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const
  * \param[in] begin The input iterator pointing to the first element
  * \param[in] end The input iterator pointing past to the last element
  * \param[in] output_begin The output iterator pointing to the first element
+ * \return The output iterator pointing to the last element
  */
 template <typename ExecutionPolicy, typename InputIt, typename OutputIt>
-void
+OutputIt
 uninitialized_copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputIt output_begin);
 
 /**
  * \ingroup memory
- * \brief Destroys the range of values
- * \tparam Iterator The iterator type of the values
- * \param[in] first An iterator to the begin of the value range
- * \param[in] last An iterator to the end of the value range
+ * \brief Copies all elements of the input range to the output range using the copy constructor
+ * \tparam ExecutionPolicy The type of the execution policy
+ * \tparam InputIt The type of the input iterators
+ * \tparam Size The size type
+ * \tparam OutputIt The type of the output iterator
+ * \param[in] policy The execution policy, e.g. host or device
+ * \param[in] begin The input iterator pointing to the first element
+ * \param[in] n The number of elements in the value range
+ * \param[in] output_begin The output iterator pointing to the first element
+ * \return The output iterator pointing to the last element
  */
-template <typename Iterator>
-void
-destroy(Iterator first, Iterator last);
+template <typename ExecutionPolicy, typename InputIt, typename Size, typename OutputIt>
+OutputIt
+uninitialized_copy_n(ExecutionPolicy&& policy, InputIt begin, Size n, OutputIt output_begin);
 
 /**
  * \ingroup memory
  * \brief Destroys the range of values
+ * \tparam ExecutionPolicy The type of the execution policy
+ * \tparam Iterator The iterator type of the values
+ * \param[in] policy The execution policy, e.g. host or device
+ * \param[in] first An iterator to the begin of the value range
+ * \param[in] last An iterator to the end of the value range
+ */
+template <typename ExecutionPolicy, typename Iterator>
+void
+destroy(ExecutionPolicy&& policy, Iterator first, Iterator last);
+
+/**
+ * \ingroup memory
+ * \brief Destroys the range of values
+ * \tparam ExecutionPolicy The type of the execution policy
  * \tparam Iterator The iterator type of the values
  * \tparam Size The size type
+ * \param[in] policy The execution policy, e.g. host or device
  * \param[in] first An iterator to the begin of the value range
  * \param[in] n The number of elements in the value range
  * \return An iterator to the end of the value range
  */
-template <typename Iterator, typename Size>
+template <typename ExecutionPolicy, typename Iterator, typename Size>
 Iterator
-destroy_n(Iterator first, Size n);
+destroy_n(ExecutionPolicy&& policy, Iterator first, Size n);
 
 /**
  * \ingroup memory

--- a/test/stdgpu/algorithm.cpp
+++ b/test/stdgpu/algorithm.cpp
@@ -376,7 +376,7 @@ TEST_F(stdgpu_algorithm, fill)
     }
 }
 
-TEST_F(stdgpu_algorithm, copy)
+TEST_F(stdgpu_algorithm, fill_n)
 {
     using T = float;
 
@@ -384,14 +384,12 @@ TEST_F(stdgpu_algorithm, copy)
     std::vector<T> values_vector(N);
     T* values = values_vector.data();
 
-    std::vector<T> values_copied_vector(N);
-    T* values_copied = values_copied_vector.data();
-
-    stdgpu::copy(thrust::host, values_vector.begin(), values_vector.end(), values_copied_vector.begin());
+    T init(42.0F);
+    stdgpu::fill_n(thrust::host, values_vector.begin(), N, init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
-        EXPECT_EQ(values[i], values_copied[i]);
+        EXPECT_EQ(values[i], init);
     }
 }
 
@@ -424,6 +422,25 @@ private:
     float _f;
 };
 
+TEST_F(stdgpu_algorithm, copy)
+{
+    using T = float;
+
+    const stdgpu::index_t N = 100000000;
+    std::vector<T> values_vector(N);
+    T* values = values_vector.data();
+
+    std::vector<T> values_copied_vector(N);
+    T* values_copied = values_copied_vector.data();
+
+    stdgpu::copy(thrust::host, values_vector.begin(), values_vector.end(), values_copied_vector.begin());
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(values[i], values_copied[i]);
+    }
+}
+
 TEST_F(stdgpu_algorithm, copy_only_assignable)
 {
     using T = assignable_float;
@@ -436,6 +453,44 @@ TEST_F(stdgpu_algorithm, copy_only_assignable)
     T* values_copied = values_copied_vector.data();
 
     stdgpu::copy(thrust::host, values_vector.begin(), values_vector.end(), values_copied_vector.begin());
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(values[i], values_copied[i]);
+    }
+}
+
+TEST_F(stdgpu_algorithm, copy_n)
+{
+    using T = float;
+
+    const stdgpu::index_t N = 100000000;
+    std::vector<T> values_vector(N);
+    T* values = values_vector.data();
+
+    std::vector<T> values_copied_vector(N);
+    T* values_copied = values_copied_vector.data();
+
+    stdgpu::copy_n(thrust::host, values_vector.begin(), N, values_copied_vector.begin());
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(values[i], values_copied[i]);
+    }
+}
+
+TEST_F(stdgpu_algorithm, copy_n_only_assignable)
+{
+    using T = assignable_float;
+
+    const stdgpu::index_t N = 100000000;
+    std::vector<T> values_vector(N);
+    T* values = values_vector.data();
+
+    std::vector<T> values_copied_vector(N);
+    T* values_copied = values_copied_vector.data();
+
+    stdgpu::copy_n(thrust::host, values_vector.begin(), N, values_copied_vector.begin());
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -135,12 +135,6 @@ construct_at<int>(int*);
 template STDGPU_HOST_DEVICE void
 destroy_at<int>(int*);
 
-template void
-destroy<int*>(int*, int*);
-
-template int*
-destroy_n<int*, index_t>(int*, index_t);
-
 template dynamic_memory_type
 get_dynamic_memory_type<int>(int*);
 
@@ -1617,7 +1611,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroy)
     ASSERT_EQ(constructor_calls, 0);
     ASSERT_EQ(destructor_calls, 0);
 
-    stdgpu::destroy(stdgpu::host_begin(array), stdgpu::host_end(array));
+    stdgpu::destroy(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array));
 
     EXPECT_EQ(constructor_calls, 0);
     EXPECT_EQ(destructor_calls, size);
@@ -1647,7 +1641,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroy_n)
     ASSERT_EQ(constructor_calls, 0);
     ASSERT_EQ(destructor_calls, 0);
 
-    stdgpu::destroy_n(stdgpu::host_begin(array), size);
+    stdgpu::destroy_n(thrust::host, stdgpu::host_begin(array), size);
 
     EXPECT_EQ(constructor_calls, 0);
     EXPECT_EQ(destructor_calls, size);
@@ -1755,6 +1749,40 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill_only_copyable)
     }
 }
 
+TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill_n)
+{
+    using T = float;
+
+    const stdgpu::index_t N = 100000000;
+    std::vector<T> values_vector(N);
+    T* values = values_vector.data();
+
+    T init(42.0F);
+    stdgpu::uninitialized_fill_n(thrust::host, stdgpu::make_host(values), N, init);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(values[i], init);
+    }
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill_n_only_copyable)
+{
+    using T = copyable_float;
+
+    const stdgpu::index_t N = 100000000;
+    std::vector<T> values_vector(N);
+    T* values = values_vector.data();
+
+    T init(42.0F);
+    stdgpu::uninitialized_fill_n(thrust::host, stdgpu::make_host(values), N, init);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(values[i], init);
+    }
+}
+
 TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy)
 {
     using T = float;
@@ -1786,6 +1814,44 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy_only_copyable)
     T* values_copied = values_copied_vector.data();
 
     stdgpu::uninitialized_copy(thrust::host, stdgpu::make_host(values), stdgpu::make_host(values + N), values_copied);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(values[i], values_copied[i]);
+    }
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy_n)
+{
+    using T = float;
+
+    const stdgpu::index_t N = 100000000;
+    std::vector<T> values_vector(N);
+    T* values = values_vector.data();
+
+    std::vector<T> values_copied_vector(N);
+    T* values_copied = values_copied_vector.data();
+
+    stdgpu::uninitialized_copy_n(thrust::host, stdgpu::make_host(values), N, values_copied);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(values[i], values_copied[i]);
+    }
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy_n_only_copyable)
+{
+    using T = copyable_float;
+
+    const stdgpu::index_t N = 100000000;
+    std::vector<T> values_vector(N);
+    T* values = values_vector.data();
+
+    std::vector<T> values_copied_vector(N);
+    T* values_copied = values_copied_vector.data();
+
+    stdgpu::uninitialized_copy_n(thrust::host, stdgpu::make_host(values), N, values_copied);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {


### PR DESCRIPTION
The recently added algorithms cover most use cases to abstract over `for_each_index`. However, their signatures are not always consistent and the `*_n` versions are also missing. Clean up these inconsistencies and also port `destroy` away from thrust's `for_each`.  Furthermore, use perfect forwarding and add the respective unit tests. This ensures that, although the algorithm module should be kept minimal, all relevant variants are provided.

Partially addresses #279