### PR TITLE
numeric: Move iota from algorithm header

### DIFF
--- a/src/stdgpu/algorithm.h
+++ b/src/stdgpu/algorithm.h
@@ -88,21 +88,6 @@ for_each_index(ExecutionPolicy&& policy, IndexType size, UnaryFunction f);
 
 /**
  * \ingroup algorithm
- * \brief Writes ascending values {values + i} to the i-th position of the given range
- * \tparam ExecutionPolicy The type of the execution policy
- * \tparam Iterator The type of the iterators
- * \tparam T The type of the values
- * \param[in] policy The execution policy, e.g. host or device
- * \param[in] begin The iterator pointing to the first element
- * \param[in] end The iterator pointing past to the last element
- * \param[in] value The starting value that will be incremented
- */
-template <typename ExecutionPolicy, typename Iterator, typename T>
-void
-iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value);
-
-/**
- * \ingroup algorithm
  * \brief Writes the given value into the given range using the copy assignment operator
  * \tparam ExecutionPolicy The type of the execution policy
  * \tparam Iterator The type of the iterators

--- a/src/stdgpu/impl/algorithm_detail.h
+++ b/src/stdgpu/impl/algorithm_detail.h
@@ -60,39 +60,6 @@ for_each_index(ExecutionPolicy&& policy, IndexType size, UnaryFunction f)
 namespace detail
 {
 template <typename Iterator, typename T>
-class iota_functor
-{
-public:
-    iota_functor(Iterator begin, T value)
-      : _begin(begin)
-      , _value(value)
-    {
-    }
-
-    STDGPU_HOST_DEVICE void
-    operator()(const index_t i)
-    {
-        _begin[i] = _value + static_cast<T>(i);
-    }
-
-private:
-    Iterator _begin;
-    T _value;
-};
-} // namespace detail
-
-template <typename ExecutionPolicy, typename Iterator, typename T>
-void
-iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value)
-{
-    for_each_index(std::forward<ExecutionPolicy>(policy),
-                   static_cast<index_t>(end - begin),
-                   detail::iota_functor<Iterator, T>(begin, value));
-}
-
-namespace detail
-{
-template <typename Iterator, typename T>
 class fill_functor
 {
 public:

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -18,10 +18,10 @@
 
 #include <thrust/sequence.h>
 
-#include <stdgpu/algorithm.h>
 #include <stdgpu/contract.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
+#include <stdgpu/numeric.h>
 #include <stdgpu/utility.h>
 
 namespace stdgpu

--- a/src/stdgpu/impl/numeric_detail.h
+++ b/src/stdgpu/impl/numeric_detail.h
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2022 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_NUMERIC_DETAIL_H
+#define STDGPU_NUMERIC_DETAIL_H
+
+#include <stdgpu/algorithm.h>
+
+namespace stdgpu
+{
+
+namespace detail
+{
+template <typename Iterator, typename T>
+class iota_functor
+{
+public:
+    iota_functor(Iterator begin, T value)
+      : _begin(begin)
+      , _value(value)
+    {
+    }
+
+    STDGPU_HOST_DEVICE void
+    operator()(const index_t i)
+    {
+        _begin[i] = _value + static_cast<T>(i);
+    }
+
+private:
+    Iterator _begin;
+    T _value;
+};
+} // namespace detail
+
+template <typename ExecutionPolicy, typename Iterator, typename T>
+void
+iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value)
+{
+    for_each_index(std::forward<ExecutionPolicy>(policy),
+                   static_cast<index_t>(end - begin),
+                   detail::iota_functor<Iterator, T>(begin, value));
+}
+
+} // namespace stdgpu
+
+#endif // STDGPU_NUMERIC_DETAIL_H

--- a/src/stdgpu/numeric.h
+++ b/src/stdgpu/numeric.h
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2022 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_NUMERIC_H
+#define STDGPU_NUMERIC_H
+
+/**
+ * \addtogroup numeric numeric
+ * \ingroup utilities
+ * @{
+ */
+
+/**
+ * \file stdgpu/numeric.h
+ */
+
+namespace stdgpu
+{
+
+/**
+ * \ingroup numeric
+ * \brief Writes ascending values {values + i} to the i-th position of the given range
+ * \tparam ExecutionPolicy The type of the execution policy
+ * \tparam Iterator The type of the iterators
+ * \tparam T The type of the values
+ * \param[in] policy The execution policy, e.g. host or device
+ * \param[in] begin The iterator pointing to the first element
+ * \param[in] end The iterator pointing past to the last element
+ * \param[in] value The starting value that will be incremented
+ */
+template <typename ExecutionPolicy, typename Iterator, typename T>
+void
+iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value);
+
+} // namespace stdgpu
+
+/**
+ * @}
+ */
+
+#include <stdgpu/impl/numeric_detail.h>
+
+#endif // STDGPU_NUMERIC_H

--- a/test/stdgpu/CMakeLists.txt
+++ b/test/stdgpu/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(teststdgpu PRIVATE algorithm.cpp
                                   iterator.cpp
                                   limits.cpp
                                   memory.cpp
+                                  numeric.cpp
                                   ranges.cpp)
 
 target_sources(teststdgpu PRIVATE ../test_memory_utils.cpp)

--- a/test/stdgpu/algorithm.cpp
+++ b/test/stdgpu/algorithm.cpp
@@ -344,21 +344,6 @@ TEST_F(stdgpu_algorithm, for_each_index)
     }
 }
 
-TEST_F(stdgpu_algorithm, iota)
-{
-    const stdgpu::index_t N = 100000000;
-    std::vector<stdgpu::index_t> indices_vector(N);
-    stdgpu::index_t* indices = indices_vector.data();
-
-    stdgpu::index_t init = 42;
-    stdgpu::iota(thrust::host, indices_vector.begin(), indices_vector.end(), init);
-
-    for (stdgpu::index_t i = 0; i < N; ++i)
-    {
-        EXPECT_EQ(indices[i], i + init);
-    }
-}
-
 TEST_F(stdgpu_algorithm, fill)
 {
     using T = float;

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -23,6 +23,7 @@
 #include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
+#include <stdgpu/numeric.h>
 #include <test_memory_utils.h>
 #include <test_utils.h>
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -22,6 +22,7 @@
 #include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
+#include <stdgpu/numeric.h>
 #include <stdgpu/utility.h>
 #include <test_memory_utils.h>
 

--- a/test/stdgpu/numeric.cpp
+++ b/test/stdgpu/numeric.cpp
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2022 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include <stdgpu/numeric.h>
+
+class stdgpu_numeric : public ::testing::Test
+{
+protected:
+    // Called before each test
+    void
+    SetUp() override
+    {
+    }
+
+    // Called after each test
+    void
+    TearDown() override
+    {
+    }
+};
+
+TEST_F(stdgpu_numeric, iota)
+{
+    const stdgpu::index_t N = 100000000;
+    std::vector<stdgpu::index_t> indices_vector(N);
+    stdgpu::index_t* indices = indices_vector.data();
+
+    stdgpu::index_t init = 42;
+    stdgpu::iota(thrust::host, indices_vector.begin(), indices_vector.end(), init);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(indices[i], i + init);
+    }
+}

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -22,6 +22,7 @@
 #include <stdgpu/functional.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
+#include <stdgpu/numeric.h>
 #include <stdgpu/utility.h>
 #include <stdgpu/vector.cuh>
 #include <test_memory_utils.h>


### PR DESCRIPTION
The `iota` algorithm has been added in #283 in the `algorithm` header. However, the C++ standard library defines this function in the `numeric` header along with other functions such as `transform_reduce`. Move `iota` to a newly created `numeric` module and adapt the includes of all modules relying on that function.