### PR TITLE
numeric: Add transform_reduce_index

### DIFF
--- a/src/stdgpu/impl/algorithm_detail.h
+++ b/src/stdgpu/impl/algorithm_detail.h
@@ -18,6 +18,7 @@
 
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <utility>
 
 #include <stdgpu/contract.h>
 

--- a/src/stdgpu/impl/numeric_detail.h
+++ b/src/stdgpu/impl/numeric_detail.h
@@ -16,6 +16,10 @@
 #ifndef STDGPU_NUMERIC_DETAIL_H
 #define STDGPU_NUMERIC_DETAIL_H
 
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/transform_reduce.h>
+#include <utility>
+
 #include <stdgpu/algorithm.h>
 
 namespace stdgpu
@@ -52,6 +56,18 @@ iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value)
     for_each_index(std::forward<ExecutionPolicy>(policy),
                    static_cast<index_t>(end - begin),
                    detail::iota_functor<Iterator, T>(begin, value));
+}
+
+template <typename IndexType, typename ExecutionPolicy, typename T, typename BinaryFunction, typename UnaryFunction>
+T
+transform_reduce_index(ExecutionPolicy&& policy, IndexType size, T init, BinaryFunction reduce, UnaryFunction f)
+{
+    return thrust::transform_reduce(std::forward<ExecutionPolicy>(policy),
+                                    thrust::counting_iterator<IndexType>(0),
+                                    thrust::counting_iterator<IndexType>(size),
+                                    f,
+                                    init,
+                                    reduce);
 }
 
 } // namespace stdgpu

--- a/src/stdgpu/numeric.h
+++ b/src/stdgpu/numeric.h
@@ -44,6 +44,24 @@ template <typename ExecutionPolicy, typename Iterator, typename T>
 void
 iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value);
 
+/**
+ * \ingroup numeric
+ * \brief Calls the given unary function with an index from the range [0, size) and performs a reduction afterwards
+ * \tparam IndexType The type of the index values
+ * \tparam ExecutionPolicy The type of the execution policy
+ * \tparam T The type of the reduced value \tparam BinaryFunction The type of the binary function for the reduction
+ * \tparam UnaryFunction The type of the unary function applied before reduction
+ * \param[in] policy The execution policy, e.g. host or device
+ * \param[in] size The number of indices, i.e. the upper bound of [0, size)
+ * \param[in] init The initial value which also participates in the reduction
+ * \param[in] reduce The binary function to reduce the values f(i)
+ * \param[in] f The unary function to call with an index i
+ * \return The result of the reduction of f(i) over the index range [0, size) along with the initial value
+ */
+template <typename IndexType, typename ExecutionPolicy, typename T, typename BinaryFunction, typename UnaryFunction>
+T
+transform_reduce_index(ExecutionPolicy&& policy, IndexType size, T init, BinaryFunction reduce, UnaryFunction f);
+
 } // namespace stdgpu
 
 /**


### PR DESCRIPTION
Another common pattern of the used algorithms is general reduction of set of value. These values could hypothetically be computed in a parallel manner using `for_each_index` over a range of indices [0, N). Therefore, add `transform_reduce_index` as the analogue of the indexed for loop which additionally reduces the computed values and port all away from `thrust`'s `transform_reduce`.

Partially addresses https://github.com/stotko/stdgpu/issues/279