### PR TITLE
src,test: Port away from counting_iterator

### DIFF
--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -471,24 +471,18 @@ deque<T, Allocator>::clear()
         // Full, i.e. one large block and begin == end
         if (full())
         {
-            stdgpu::detail::unoptimized_destroy(thrust::device, stdgpu::device_begin(_data), stdgpu::device_end(_data));
+            detail::unoptimized_destroy(thrust::device, device_begin(_data), device_end(_data));
         }
         // One large block
         else if (begin <= end)
         {
-            stdgpu::detail::unoptimized_destroy(thrust::device,
-                                                stdgpu::make_device(_data + begin),
-                                                stdgpu::make_device(_data + end));
+            detail::unoptimized_destroy(thrust::device, make_device(_data + begin), make_device(_data + end));
         }
         // Two disconnected blocks
         else
         {
-            stdgpu::detail::unoptimized_destroy(thrust::device,
-                                                stdgpu::device_begin(_data),
-                                                stdgpu::make_device(_data + end));
-            stdgpu::detail::unoptimized_destroy(thrust::device,
-                                                stdgpu::make_device(_data + begin),
-                                                stdgpu::device_end(_data));
+            detail::unoptimized_destroy(thrust::device, device_begin(_data), make_device(_data + end));
+            detail::unoptimized_destroy(thrust::device, make_device(_data + begin), device_end(_data));
         }
     }
 
@@ -526,27 +520,21 @@ deque<T, Allocator>::device_range()
     // Full, i.e. one large block and begin == end
     if (full())
     {
-        stdgpu::iota(thrust::device, stdgpu::device_begin(_range_indices), stdgpu::device_end(_range_indices), 0);
+        iota(thrust::device, device_begin(_range_indices), device_end(_range_indices), 0);
     }
     // One large block, including empty block
     else if (begin <= end)
     {
-        stdgpu::iota(thrust::device,
-                     stdgpu::device_begin(_range_indices),
-                     stdgpu::device_begin(_range_indices) + (end - begin),
-                     begin);
+        iota(thrust::device, device_begin(_range_indices), device_begin(_range_indices) + (end - begin), begin);
     }
     // Two disconnected blocks
     else
     {
-        stdgpu::iota(thrust::device,
-                     stdgpu::device_begin(_range_indices),
-                     stdgpu::device_begin(_range_indices) + end,
-                     0);
-        stdgpu::iota(thrust::device,
-                     stdgpu::device_begin(_range_indices) + end,
-                     stdgpu::device_begin(_range_indices) + (end + capacity() - begin),
-                     begin);
+        iota(thrust::device, device_begin(_range_indices), device_begin(_range_indices) + end, 0);
+        iota(thrust::device,
+             device_begin(_range_indices) + end,
+             device_begin(_range_indices) + (end + capacity() - begin),
+             begin);
     }
 
     return device_indexed_range<value_type>(stdgpu::device_range<index_t>(_range_indices, size()), data());
@@ -562,27 +550,21 @@ deque<T, Allocator>::device_range() const
     // Full, i.e. one large block and begin == end
     if (full())
     {
-        stdgpu::iota(thrust::device, stdgpu::device_begin(_range_indices), stdgpu::device_end(_range_indices), 0);
+        iota(thrust::device, device_begin(_range_indices), device_end(_range_indices), 0);
     }
     // One large block, including empty block
     else if (begin <= end)
     {
-        stdgpu::iota(thrust::device,
-                     stdgpu::device_begin(_range_indices),
-                     stdgpu::device_begin(_range_indices) + (end - begin),
-                     begin);
+        iota(thrust::device, device_begin(_range_indices), device_begin(_range_indices) + (end - begin), begin);
     }
     // Two disconnected blocks
     else
     {
-        stdgpu::iota(thrust::device,
-                     stdgpu::device_begin(_range_indices),
-                     stdgpu::device_begin(_range_indices) + end,
-                     0);
-        stdgpu::iota(thrust::device,
-                     stdgpu::device_begin(_range_indices) + end,
-                     stdgpu::device_begin(_range_indices) + (end + capacity() - begin),
-                     begin);
+        iota(thrust::device, device_begin(_range_indices), device_begin(_range_indices) + end, 0);
+        iota(thrust::device,
+             device_begin(_range_indices) + end,
+             device_begin(_range_indices) + (end + capacity() - begin),
+             begin);
     }
 
     return device_indexed_range<const value_type>(stdgpu::device_range<index_t>(_range_indices, size()), data());

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -1081,9 +1081,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::clear()
 
     _occupied_count.store(0);
 
-    auto reset_excess_list_positions = detail::vector_clear_fill<index_t, index_allocator_type>(_excess_list_positions);
-    reset_excess_list_positions(thrust::counting_iterator<index_t>(bucket_count()),
-                                thrust::counting_iterator<index_t>(total_count()));
+    detail::vector_clear_iota<index_t, index_allocator_type>(_excess_list_positions, bucket_count());
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
@@ -1122,9 +1120,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::createDevic
     result._hash = hasher();
     result._key_equal = key_equal();
 
-    result._excess_list_positions.insert(result._excess_list_positions.device_end(),
-                                         thrust::counting_iterator<index_t>(bucket_count),
-                                         thrust::counting_iterator<index_t>(bucket_count + excess_count));
+    detail::vector_clear_iota<index_t, index_allocator_type>(result._excess_list_positions, bucket_count);
 
     STDGPU_ENSURES(result._excess_list_positions.full());
 

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -59,7 +59,8 @@ template <typename T, typename Allocator, bool>
 class vector_erase;
 
 template <typename T, typename Allocator>
-class vector_clear_fill;
+void
+vector_clear_iota(vector<T, Allocator>& v, const T& value);
 
 } // namespace detail
 
@@ -365,8 +366,8 @@ private:
     template <typename T2, typename Allocator2, bool>
     friend class detail::vector_erase;
 
-    template <typename T2, typename Allocator2>
-    friend class detail::vector_clear_fill;
+    friend void
+    detail::vector_clear_iota<T, Allocator>(vector<T, Allocator>& v, const T& value);
 
     STDGPU_DEVICE_ONLY bool
     occupied(const index_t n) const;

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -2311,10 +2311,10 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, custom_allocator)
 
     // Account for potential but not guaranteed copy-ellision
     EXPECT_EQ(test_utils::get_allocator_statistics().default_constructions, 1);
-    EXPECT_GE(test_utils::get_allocator_statistics().copy_constructions, 62);
-    EXPECT_LE(test_utils::get_allocator_statistics().copy_constructions, 95);
-    EXPECT_GE(test_utils::get_allocator_statistics().destructions, 63);
-    EXPECT_LE(test_utils::get_allocator_statistics().destructions, 96);
+    EXPECT_GE(test_utils::get_allocator_statistics().copy_constructions, 42);
+    EXPECT_LE(test_utils::get_allocator_statistics().copy_constructions, 101);
+    EXPECT_GE(test_utils::get_allocator_statistics().destructions, 43);
+    EXPECT_LE(test_utils::get_allocator_statistics().destructions, 102);
 
     test_utils::get_allocator_statistics().reset();
 }

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -16,7 +16,6 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <thrust/iterator/counting_iterator.h>
 
 #include <stdgpu/algorithm.h>
 #include <stdgpu/functional.h>
@@ -701,9 +700,10 @@ TEST_F(stdgpu_vector, insert)
 
     fill_vector(pool, N_init);
 
-    pool.insert(pool.device_end(),
-                thrust::counting_iterator<int>(N_init + 1),
-                thrust::counting_iterator<int>(N_init + 1 + N_insert));
+    int* values = createDeviceArray<int>(N_insert);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), N_init + 1);
+
+    pool.insert(pool.device_end(), stdgpu::device_begin(values), stdgpu::device_end(values));
 
     ASSERT_EQ(pool.size(), N_init + N_insert);
     ASSERT_FALSE(pool.empty());
@@ -718,6 +718,7 @@ TEST_F(stdgpu_vector, insert)
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
     destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, insert_non_end)
@@ -730,9 +731,10 @@ TEST_F(stdgpu_vector, insert_non_end)
 
     fill_vector(pool, N_init);
 
-    pool.insert(pool.device_end() - 1,
-                thrust::counting_iterator<int>(N_init + 1),
-                thrust::counting_iterator<int>(N_init + 1 + N_insert));
+    int* values = createDeviceArray<int>(N_insert);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), N_init + 1);
+
+    pool.insert(pool.device_end() - 1, stdgpu::device_begin(values), stdgpu::device_end(values));
 
     ASSERT_EQ(pool.size(), N_init);
     ASSERT_FALSE(pool.empty());
@@ -740,6 +742,7 @@ TEST_F(stdgpu_vector, insert_non_end)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, insert_too_many)
@@ -752,9 +755,10 @@ TEST_F(stdgpu_vector, insert_too_many)
 
     fill_vector(pool, N_init);
 
-    pool.insert(pool.device_end(),
-                thrust::counting_iterator<int>(N_init + 1),
-                thrust::counting_iterator<int>(N_init + 1 + N_insert));
+    int* values = createDeviceArray<int>(N_insert);
+    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), N_init + 1);
+
+    pool.insert(pool.device_end(), stdgpu::device_begin(values), stdgpu::device_end(values));
 
     ASSERT_EQ(pool.size(), N_init);
     ASSERT_FALSE(pool.empty());
@@ -762,6 +766,7 @@ TEST_F(stdgpu_vector, insert_too_many)
     ASSERT_TRUE(pool.valid());
 
     stdgpu::vector<int>::destroyDeviceObject(pool);
+    destroyDeviceArray<int>(values);
 }
 
 TEST_F(stdgpu_vector, erase)


### PR DESCRIPTION
After the introduction of `for_each_index` and `transform_reduce_index` there are only a few occurrences of `counting_iterator` left. Port these remaining use cases to `iota` and clean up some qualifications.

Partially addresses #279