### PR TITLE
test: Reduce array sizes to speed up CI

### DIFF
--- a/test/stdgpu/algorithm.cpp
+++ b/test/stdgpu/algorithm.cpp
@@ -332,8 +332,8 @@ private:
 
 TEST_F(stdgpu_algorithm, for_each_index)
 {
-    const stdgpu::index_t N = 100000000;
-    std::vector<stdgpu::index_t> indices_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<stdgpu::index_t> indices_vector(static_cast<std::size_t>(N));
     stdgpu::index_t* indices = indices_vector.data();
 
     stdgpu::for_each_index(thrust::host, N, store_indices(indices));
@@ -348,8 +348,8 @@ TEST_F(stdgpu_algorithm, fill)
 {
     using T = float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
     T init(42.0F);
@@ -365,8 +365,8 @@ TEST_F(stdgpu_algorithm, fill_n)
 {
     using T = float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
     T init(42.0F);
@@ -411,11 +411,11 @@ TEST_F(stdgpu_algorithm, copy)
 {
     using T = float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    std::vector<T> values_copied_vector(N);
+    std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
     stdgpu::copy(thrust::host, values_vector.begin(), values_vector.end(), values_copied_vector.begin());
@@ -430,11 +430,11 @@ TEST_F(stdgpu_algorithm, copy_only_assignable)
 {
     using T = assignable_float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    std::vector<T> values_copied_vector(N);
+    std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
     stdgpu::copy(thrust::host, values_vector.begin(), values_vector.end(), values_copied_vector.begin());
@@ -449,11 +449,11 @@ TEST_F(stdgpu_algorithm, copy_n)
 {
     using T = float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    std::vector<T> values_copied_vector(N);
+    std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
     stdgpu::copy_n(thrust::host, values_vector.begin(), N, values_copied_vector.begin());
@@ -468,11 +468,11 @@ TEST_F(stdgpu_algorithm, copy_n_only_assignable)
 {
     using T = assignable_float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    std::vector<T> values_copied_vector(N);
+    std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
     stdgpu::copy_n(thrust::host, values_vector.begin(), N, values_copied_vector.begin());

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -1761,8 +1761,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill)
 {
     using T = float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
     T init(42.0F);
@@ -1778,8 +1778,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill_only_copyable)
 {
     using T = copyable_float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
     T init(42.0F);
@@ -1795,8 +1795,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill_n)
 {
     using T = float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
     T init(42.0F);
@@ -1812,8 +1812,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill_n_only_copyable)
 {
     using T = copyable_float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
     T init(42.0F);
@@ -1829,11 +1829,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy)
 {
     using T = float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    std::vector<T> values_copied_vector(N);
+    std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
     stdgpu::uninitialized_copy(thrust::host, stdgpu::make_host(values), stdgpu::make_host(values + N), values_copied);
@@ -1848,11 +1848,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy_only_copyable)
 {
     using T = copyable_float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    std::vector<T> values_copied_vector(N);
+    std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
     stdgpu::uninitialized_copy(thrust::host, stdgpu::make_host(values), stdgpu::make_host(values + N), values_copied);
@@ -1867,11 +1867,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy_n)
 {
     using T = float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    std::vector<T> values_copied_vector(N);
+    std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
     stdgpu::uninitialized_copy_n(thrust::host, stdgpu::make_host(values), N, values_copied);
@@ -1886,11 +1886,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy_n_only_copyable)
 {
     using T = copyable_float;
 
-    const stdgpu::index_t N = 100000000;
-    std::vector<T> values_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    std::vector<T> values_copied_vector(N);
+    std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
     stdgpu::uninitialized_copy_n(thrust::host, stdgpu::make_host(values), N, values_copied);

--- a/test/stdgpu/numeric.cpp
+++ b/test/stdgpu/numeric.cpp
@@ -39,8 +39,8 @@ protected:
 
 TEST_F(stdgpu_numeric, iota)
 {
-    const stdgpu::index_t N = 100000000;
-    std::vector<stdgpu::index_t> indices_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<stdgpu::index_t> indices_vector(static_cast<std::size_t>(N));
     stdgpu::index_t* indices = indices_vector.data();
 
     stdgpu::index_t init = 42;
@@ -72,8 +72,8 @@ private:
 
 TEST_F(stdgpu_numeric, transform_reduce_index)
 {
-    const stdgpu::index_t N = 100000000;
-    std::vector<std::int64_t> numbers_vector(N);
+    const stdgpu::index_t N = static_cast<stdgpu::index_t>(pow(2, 22));
+    std::vector<std::int64_t> numbers_vector(static_cast<std::size_t>(N));
     std::int64_t* numbers = numbers_vector.data();
 
     std::int64_t init = 42;


### PR DESCRIPTION
After the large refactoring of the `algorithm` module and the related functions, the time to run the tests significantly increased. Reduce the array sizes of the affected tests to speed up the CI and restore a similar runtime performance as before the changes.