### PR TITLE
execution: Add aliases for device and host policies

### DIFF
--- a/src/stdgpu/algorithm.h
+++ b/src/stdgpu/algorithm.h
@@ -26,8 +26,8 @@
  * \file stdgpu/algorithm.h
  */
 
-// For convenient calls of for_each_index() until there are abstractions for these
-#include <thrust/execution_policy.h>
+// For convenient calls of all policy-based algorithms
+#include <stdgpu/execution.h>
 
 #include <stdgpu/platform.h>
 

--- a/src/stdgpu/execution.h
+++ b/src/stdgpu/execution.h
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2022 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_EXECUTION_H
+#define STDGPU_EXECUTION_H
+
+/**
+ * \addtogroup execution execution
+ * \ingroup utilities
+ * @{
+ */
+
+/**
+ * \file stdgpu/execution.h
+ */
+
+#include <thrust/execution_policy.h>
+
+namespace stdgpu
+{
+namespace execution
+{
+
+/**
+ * \ingroup execution
+ * \brief The device execution policy
+ */
+constexpr decltype(thrust::device) device;
+
+/**
+ * \ingroup execution
+ * \brief The host execution policy
+ */
+constexpr decltype(thrust::host) host;
+
+} // namespace execution
+} // namespace stdgpu
+
+/**
+ * @}
+ */
+
+#endif // STDGPU_EXECUTION_H

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -471,18 +471,18 @@ deque<T, Allocator>::clear()
         // Full, i.e. one large block and begin == end
         if (full())
         {
-            detail::unoptimized_destroy(thrust::device, device_begin(_data), device_end(_data));
+            detail::unoptimized_destroy(execution::device, device_begin(_data), device_end(_data));
         }
         // One large block
         else if (begin <= end)
         {
-            detail::unoptimized_destroy(thrust::device, make_device(_data + begin), make_device(_data + end));
+            detail::unoptimized_destroy(execution::device, make_device(_data + begin), make_device(_data + end));
         }
         // Two disconnected blocks
         else
         {
-            detail::unoptimized_destroy(thrust::device, device_begin(_data), make_device(_data + end));
-            detail::unoptimized_destroy(thrust::device, make_device(_data + begin), device_end(_data));
+            detail::unoptimized_destroy(execution::device, device_begin(_data), make_device(_data + end));
+            detail::unoptimized_destroy(execution::device, make_device(_data + begin), device_end(_data));
         }
     }
 
@@ -520,18 +520,18 @@ deque<T, Allocator>::device_range()
     // Full, i.e. one large block and begin == end
     if (full())
     {
-        iota(thrust::device, device_begin(_range_indices), device_end(_range_indices), 0);
+        iota(execution::device, device_begin(_range_indices), device_end(_range_indices), 0);
     }
     // One large block, including empty block
     else if (begin <= end)
     {
-        iota(thrust::device, device_begin(_range_indices), device_begin(_range_indices) + (end - begin), begin);
+        iota(execution::device, device_begin(_range_indices), device_begin(_range_indices) + (end - begin), begin);
     }
     // Two disconnected blocks
     else
     {
-        iota(thrust::device, device_begin(_range_indices), device_begin(_range_indices) + end, 0);
-        iota(thrust::device,
+        iota(execution::device, device_begin(_range_indices), device_begin(_range_indices) + end, 0);
+        iota(execution::device,
              device_begin(_range_indices) + end,
              device_begin(_range_indices) + (end + capacity() - begin),
              begin);
@@ -550,18 +550,18 @@ deque<T, Allocator>::device_range() const
     // Full, i.e. one large block and begin == end
     if (full())
     {
-        iota(thrust::device, device_begin(_range_indices), device_end(_range_indices), 0);
+        iota(execution::device, device_begin(_range_indices), device_end(_range_indices), 0);
     }
     // One large block, including empty block
     else if (begin <= end)
     {
-        iota(thrust::device, device_begin(_range_indices), device_begin(_range_indices) + (end - begin), begin);
+        iota(execution::device, device_begin(_range_indices), device_begin(_range_indices) + (end - begin), begin);
     }
     // Two disconnected blocks
     else
     {
-        iota(thrust::device, device_begin(_range_indices), device_begin(_range_indices) + end, 0);
-        iota(thrust::device,
+        iota(execution::device, device_begin(_range_indices), device_begin(_range_indices) + end, 0);
+        iota(execution::device,
              device_begin(_range_indices) + end,
              device_begin(_range_indices) + (end + capacity() - begin),
              begin);

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -228,7 +228,7 @@ createDeviceArray(Allocator& device_allocator, const stdgpu::index64_t count, co
         return nullptr;
     }
 
-    stdgpu::uninitialized_fill(thrust::device,
+    stdgpu::uninitialized_fill(stdgpu::execution::device,
                                stdgpu::device_begin(device_array),
                                stdgpu::device_end(device_array),
                                default_value);
@@ -259,7 +259,7 @@ createHostArray(Allocator& host_allocator, const stdgpu::index64_t count, const 
         return nullptr;
     }
 
-    stdgpu::uninitialized_fill(thrust::host,
+    stdgpu::uninitialized_fill(stdgpu::execution::host,
                                stdgpu::host_begin(host_array),
                                stdgpu::host_end(host_array),
                                default_value);
@@ -296,7 +296,7 @@ createManagedArray(Allocator& managed_allocator,
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
         case Initialization::DEVICE:
         {
-            stdgpu::uninitialized_fill(thrust::device,
+            stdgpu::uninitialized_fill(stdgpu::execution::device,
                                        stdgpu::device_begin(managed_array),
                                        stdgpu::device_end(managed_array),
                                        default_value);
@@ -316,7 +316,7 @@ createManagedArray(Allocator& managed_allocator,
         {
             stdgpu::detail::workaround_synchronize_managed_memory();
 
-            stdgpu::uninitialized_fill(thrust::host,
+            stdgpu::uninitialized_fill(stdgpu::execution::host,
                                        stdgpu::host_begin(managed_array),
                                        stdgpu::host_end(managed_array),
                                        default_value);
@@ -359,7 +359,7 @@ template <typename T, typename Allocator>
 void
 destroyDeviceArray(Allocator& device_allocator, T*& device_array)
 {
-    stdgpu::destroy(thrust::device, stdgpu::device_begin(device_array), stdgpu::device_end(device_array));
+    stdgpu::destroy(stdgpu::execution::device, stdgpu::device_begin(device_array), stdgpu::device_end(device_array));
 
     stdgpu::detail::workaround_synchronize_device_thrust();
 
@@ -380,7 +380,7 @@ template <typename T, typename Allocator>
 void
 destroyHostArray(Allocator& host_allocator, T*& host_array)
 {
-    stdgpu::destroy(thrust::host, stdgpu::host_begin(host_array), stdgpu::host_end(host_array));
+    stdgpu::destroy(stdgpu::execution::host, stdgpu::host_begin(host_array), stdgpu::host_end(host_array));
 
     stdgpu::detail::destroyUninitializedHostArray<T, Allocator>(host_allocator, host_array);
 }
@@ -400,7 +400,7 @@ void
 destroyManagedArray(Allocator& managed_allocator, T*& managed_array)
 {
     // Call on host since the initialization place is not known
-    stdgpu::destroy(thrust::host, stdgpu::host_begin(managed_array), stdgpu::host_end(managed_array));
+    stdgpu::destroy(stdgpu::execution::host, stdgpu::host_begin(managed_array), stdgpu::host_end(managed_array));
 
     stdgpu::detail::destroyUninitializedManagedArray<T, Allocator>(managed_allocator, managed_array);
 }

--- a/src/stdgpu/impl/mutex_detail.cuh
+++ b/src/stdgpu/impl/mutex_detail.cuh
@@ -147,11 +147,11 @@ mutex_array<Block, Allocator>::valid() const
         return true;
     }
 
-    return stdgpu::transform_reduce_index(thrust::device,
-                                          size(),
-                                          true,
-                                          stdgpu::logical_and<>(),
-                                          detail::unlocked<Block, Allocator>(*this));
+    return transform_reduce_index(execution::device,
+                                  size(),
+                                  true,
+                                  logical_and<>(),
+                                  detail::unlocked<Block, Allocator>(*this));
 }
 
 namespace detail

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -317,7 +317,7 @@ template <typename T, typename Allocator>
 void
 vector_clear_iota(vector<T, Allocator>& v, const T& value)
 {
-    iota(thrust::device, device_begin(v.data()), device_end(v.data()), value);
+    iota(execution::device, device_begin(v.data()), device_end(v.data()), value);
     v._occupied.set();
     v._size.store(v.capacity());
 }
@@ -347,7 +347,9 @@ vector<T, Allocator>::insert(device_ptr<const T> position, ValueIterator begin, 
         return;
     }
 
-    for_each_index(thrust::device, N, detail::vector_insert<T, Allocator, ValueIterator, true>(*this, size(), begin));
+    for_each_index(execution::device,
+                   N,
+                   detail::vector_insert<T, Allocator, ValueIterator, true>(*this, size(), begin));
 
     _size.store(new_size);
 }
@@ -372,7 +374,7 @@ vector<T, Allocator>::erase(device_ptr<const T> begin, device_ptr<const T> end)
         return;
     }
 
-    for_each_index(thrust::device, N, detail::vector_erase<T, Allocator, true>(*this, new_size));
+    for_each_index(execution::device, N, detail::vector_erase<T, Allocator, true>(*this, new_size));
 
     _size.store(new_size);
 }
@@ -468,7 +470,7 @@ vector<T, Allocator>::clear()
     {
         const index_t current_size = size();
 
-        detail::unoptimized_destroy(thrust::device,
+        detail::unoptimized_destroy(execution::device,
                                     stdgpu::device_begin(_data),
                                     stdgpu::device_begin(_data) + current_size);
     }

--- a/src/stdgpu/iterator.h
+++ b/src/stdgpu/iterator.h
@@ -37,16 +37,16 @@ namespace stdgpu
 
 /**
  * \ingroup iterator
- * \brief A host pointer class allowing to call thrust algorithms without explicitly using the thrust::device execution
- * policy \note Considered equivalent to thrust::device_ptr but can be processed in plain C++
+ * \brief A host pointer class allowing to call thrust algorithms without explicitly using the respective execution
+ * policy policy \note Considered equivalent to thrust::device_ptr but can be processed in plain C++
  */
 template <typename T>
 using device_ptr = thrust::pointer<T, thrust::device_system_tag>;
 
 /**
  * \ingroup iterator
- * \brief A host pointer class allowing to call thrust algorithms without explicitly using the thrust::host execution
- * policy
+ * \brief A host pointer class allowing to call thrust algorithms without explicitly using the respective execution
+ * policy policy
  */
 template <typename T>
 using host_ptr = thrust::pointer<T, thrust::host_system_tag>;

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -29,6 +29,9 @@
 #include <memory>
 #include <type_traits>
 
+// For convenient calls of all policy-based algorithms
+#include <stdgpu/execution.h>
+
 #include <stdgpu/attribute.h>
 #include <stdgpu/config.h>
 #include <stdgpu/cstddef.h>

--- a/src/stdgpu/numeric.h
+++ b/src/stdgpu/numeric.h
@@ -26,6 +26,9 @@
  * \file stdgpu/numeric.h
  */
 
+// For convenient calls of all policy-based algorithms
+#include <stdgpu/execution.h>
+
 namespace stdgpu
 {
 

--- a/test/stdgpu/algorithm.cpp
+++ b/test/stdgpu/algorithm.cpp
@@ -336,7 +336,7 @@ TEST_F(stdgpu_algorithm, for_each_index)
     std::vector<stdgpu::index_t> indices_vector(static_cast<std::size_t>(N));
     stdgpu::index_t* indices = indices_vector.data();
 
-    stdgpu::for_each_index(thrust::host, N, store_indices(indices));
+    stdgpu::for_each_index(stdgpu::execution::host, N, store_indices(indices));
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -353,7 +353,7 @@ TEST_F(stdgpu_algorithm, fill)
     T* values = values_vector.data();
 
     T init(42.0F);
-    stdgpu::fill(thrust::host, values_vector.begin(), values_vector.end(), init);
+    stdgpu::fill(stdgpu::execution::host, values_vector.begin(), values_vector.end(), init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -370,7 +370,7 @@ TEST_F(stdgpu_algorithm, fill_n)
     T* values = values_vector.data();
 
     T init(42.0F);
-    stdgpu::fill_n(thrust::host, values_vector.begin(), N, init);
+    stdgpu::fill_n(stdgpu::execution::host, values_vector.begin(), N, init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -418,7 +418,7 @@ TEST_F(stdgpu_algorithm, copy)
     std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
-    stdgpu::copy(thrust::host, values_vector.begin(), values_vector.end(), values_copied_vector.begin());
+    stdgpu::copy(stdgpu::execution::host, values_vector.begin(), values_vector.end(), values_copied_vector.begin());
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -437,7 +437,7 @@ TEST_F(stdgpu_algorithm, copy_only_assignable)
     std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
-    stdgpu::copy(thrust::host, values_vector.begin(), values_vector.end(), values_copied_vector.begin());
+    stdgpu::copy(stdgpu::execution::host, values_vector.begin(), values_vector.end(), values_copied_vector.begin());
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -456,7 +456,7 @@ TEST_F(stdgpu_algorithm, copy_n)
     std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
-    stdgpu::copy_n(thrust::host, values_vector.begin(), N, values_copied_vector.begin());
+    stdgpu::copy_n(stdgpu::execution::host, values_vector.begin(), N, values_copied_vector.begin());
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -475,7 +475,7 @@ TEST_F(stdgpu_algorithm, copy_n_only_assignable)
     std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
-    stdgpu::copy_n(thrust::host, values_vector.begin(), N, values_copied_vector.begin());
+    stdgpu::copy_n(stdgpu::execution::host, values_vector.begin(), N, values_copied_vector.begin());
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -493,12 +493,12 @@ sequence_exchange()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N - 1);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
     value.store(N);
 
-    stdgpu::for_each_index(thrust::device, N - 1, Function<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N - 1, Function<T>(value, sequence));
 
     T* host_sequence = createHostArray<T>(N);
     copyDevice2HostArray<T>(sequence, N - 1, host_sequence);
@@ -667,11 +667,11 @@ sequence_compare_exchange_weak()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, Function<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, Function<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(N * (N + 1) / 2));
 
@@ -685,11 +685,11 @@ sequence_compare_exchange_strong()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, Function<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, Function<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(N * (N + 1) / 2));
 
@@ -847,11 +847,11 @@ sequence_fetch_add()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, Function<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, Function<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(N * (N + 1) / 2));
 
@@ -865,11 +865,11 @@ sequence_operator_add_equals()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, add_equals_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, add_equals_sequence<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(N * (N + 1) / 2));
 
@@ -1027,15 +1027,15 @@ sequence_fetch_sub()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, add_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, add_sequence<T>(value, sequence));
 
     ASSERT_EQ(value.load(), T(N * (N + 1) / 2));
 
-    stdgpu::for_each_index(thrust::device, N, Function<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, Function<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(0));
 
@@ -1049,15 +1049,15 @@ sequence_operator_sub_equals()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, add_equals_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, add_equals_sequence<T>(value, sequence));
 
     ASSERT_EQ(value.load(), T(N * (N + 1) / 2));
 
-    stdgpu::for_each_index(thrust::device, N, sub_equals_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, sub_equals_sequence<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(0));
 
@@ -1224,7 +1224,7 @@ sequence_fetch_or()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, Function<T>(value));
+    stdgpu::for_each_index(stdgpu::execution::device, N, Function<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1243,7 +1243,7 @@ sequence_operator_or_equals()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, or_equals_sequence<T>(value));
+    stdgpu::for_each_index(stdgpu::execution::device, N, or_equals_sequence<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1416,7 +1416,7 @@ sequence_fetch_and()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, or_sequence<T>(value));
+    stdgpu::for_each_index(stdgpu::execution::device, N, or_sequence<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1426,7 +1426,7 @@ sequence_fetch_and()
 
     T one_pattern = value.load(); // We previously filled this with 1's
 
-    stdgpu::for_each_index(thrust::device, N, Function<T>(value, one_pattern));
+    stdgpu::for_each_index(stdgpu::execution::device, N, Function<T>(value, one_pattern));
 
     value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1445,7 +1445,7 @@ sequence_operator_and_equals()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, or_equals_sequence<T>(value));
+    stdgpu::for_each_index(stdgpu::execution::device, N, or_equals_sequence<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1455,7 +1455,7 @@ sequence_operator_and_equals()
 
     T one_pattern = value.load(); // We previously filled this with 1's
 
-    stdgpu::for_each_index(thrust::device, N, and_equals_sequence<T>(value, one_pattern));
+    stdgpu::for_each_index(stdgpu::execution::device, N, and_equals_sequence<T>(value, one_pattern));
 
     value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1618,7 +1618,7 @@ sequence_fetch_xor()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, Function<T>(value));
+    stdgpu::for_each_index(stdgpu::execution::device, N, Function<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1637,7 +1637,7 @@ sequence_operator_xor_equals()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, xor_equals_sequence<T>(value));
+    stdgpu::for_each_index(stdgpu::execution::device, N, xor_equals_sequence<T>(value));
 
     T value_pattern = value.load();
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1735,12 +1735,12 @@ sequence_fetch_min()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
     value.store(std::numeric_limits<T>::max());
 
-    stdgpu::for_each_index(thrust::device, N, min_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, min_sequence<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(1));
 
@@ -1790,12 +1790,12 @@ sequence_fetch_max()
 {
     const stdgpu::index_t N = 40000;
     T* sequence = createDeviceArray<T>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
     value.store(std::numeric_limits<T>::lowest());
 
-    stdgpu::for_each_index(thrust::device, N, max_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, max_sequence<T>(value, sequence));
 
     EXPECT_EQ(value.load(), T(N));
 
@@ -1851,7 +1851,7 @@ sequence_fetch_inc_mod()
     const T new_value = static_cast<T>(42);
     value.store(new_value);
 
-    stdgpu::for_each_index(thrust::device, N, inc_mod_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, inc_mod_sequence<T>(value, sequence));
 
     EXPECT_EQ(value.load(), new_value);
 
@@ -1907,7 +1907,7 @@ sequence_fetch_dec_mod()
     const T new_value = static_cast<T>(42);
     value.store(new_value);
 
-    stdgpu::for_each_index(thrust::device, N, dec_mod_dequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, dec_mod_dequence<T>(value, sequence));
 
     EXPECT_EQ(value.load(), new_value);
 
@@ -1960,7 +1960,7 @@ sequence_pre_inc()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, pre_inc_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, pre_inc_sequence<T>(value, sequence));
 
     T* host_sequence = copyCreateDevice2HostArray<T>(sequence, N);
 
@@ -2021,7 +2021,7 @@ sequence_post_inc()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, post_inc_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, post_inc_sequence<T>(value, sequence));
 
     T* host_sequence = copyCreateDevice2HostArray<T>(sequence, N);
 
@@ -2082,11 +2082,11 @@ sequence_pre_dec()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, pre_inc_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, pre_inc_sequence<T>(value, sequence));
 
     ASSERT_EQ(value.load(), T(N));
 
-    stdgpu::for_each_index(thrust::device, N, pre_dec_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, pre_dec_sequence<T>(value, sequence));
 
     ASSERT_EQ(value.load(), T(0));
 
@@ -2149,11 +2149,11 @@ sequence_post_dec()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, post_inc_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, post_inc_sequence<T>(value, sequence));
 
     ASSERT_EQ(value.load(), T(N));
 
-    stdgpu::for_each_index(thrust::device, N, post_dec_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, post_dec_sequence<T>(value, sequence));
 
     ASSERT_EQ(value.load(), T(0));
 
@@ -2224,7 +2224,7 @@ sequence_fence()
 
     stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
 
-    stdgpu::for_each_index(thrust::device, N, fence_sequence<T>(value, sequence));
+    stdgpu::for_each_index(stdgpu::execution::device, N, fence_sequence<T>(value, sequence));
 
     ASSERT_EQ(value.load(), T(N));
 

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -169,7 +169,7 @@ TEST_F(stdgpu_bitset, set_all_bits_componentwise)
 {
     std::uint8_t* set = createDeviceArray<std::uint8_t>(bitset.size());
 
-    stdgpu::for_each_index(thrust::device, bitset.size(), set_all_bits(bitset, set));
+    stdgpu::for_each_index(stdgpu::execution::device, bitset.size(), set_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), bitset.size());
 
@@ -188,11 +188,11 @@ TEST_F(stdgpu_bitset, reset_all_bits_componentwise)
 {
     std::uint8_t* set = createDeviceArray<std::uint8_t>(bitset.size());
 
-    stdgpu::for_each_index(thrust::device, bitset.size(), set_all_bits(bitset, set));
+    stdgpu::for_each_index(stdgpu::execution::device, bitset.size(), set_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), bitset.size());
 
-    stdgpu::for_each_index(thrust::device, bitset.size(), reset_all_bits(bitset, set));
+    stdgpu::for_each_index(stdgpu::execution::device, bitset.size(), reset_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), 0);
 
@@ -211,7 +211,7 @@ TEST_F(stdgpu_bitset, set_and_reset_all_bits_componentwise)
 {
     std::uint8_t* set = createDeviceArray<std::uint8_t>(bitset.size());
 
-    stdgpu::for_each_index(thrust::device, bitset.size(), set_and_reset_all_bits(bitset, set));
+    stdgpu::for_each_index(stdgpu::execution::device, bitset.size(), set_and_reset_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), 0);
 
@@ -233,7 +233,7 @@ TEST_F(stdgpu_bitset, flip_all_bits_previously_reset_componentwise)
     // Previously reset
     bitset.reset();
 
-    stdgpu::for_each_index(thrust::device, bitset.size(), flip_all_bits(bitset, set));
+    stdgpu::for_each_index(stdgpu::execution::device, bitset.size(), flip_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), bitset.size());
 
@@ -255,7 +255,7 @@ TEST_F(stdgpu_bitset, flip_all_bits_previously_set_componentwise)
     // Previously set
     bitset.set();
 
-    stdgpu::for_each_index(thrust::device, bitset.size(), flip_all_bits(bitset, set));
+    stdgpu::for_each_index(stdgpu::execution::device, bitset.size(), flip_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), 0);
 
@@ -297,7 +297,7 @@ TEST_F(stdgpu_bitset, set_all_bits)
 
     bitset.set();
 
-    stdgpu::for_each_index(thrust::device, bitset.size(), read_all_bits(bitset, set));
+    stdgpu::for_each_index(stdgpu::execution::device, bitset.size(), read_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), bitset.size());
 
@@ -322,7 +322,7 @@ TEST_F(stdgpu_bitset, reset_all_bits)
 
     bitset.reset();
 
-    stdgpu::for_each_index(thrust::device, bitset.size(), read_all_bits(bitset, set));
+    stdgpu::for_each_index(stdgpu::execution::device, bitset.size(), read_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), 0);
 
@@ -346,7 +346,7 @@ TEST_F(stdgpu_bitset, flip_all_bits_previously_reset)
 
     bitset.flip();
 
-    stdgpu::for_each_index(thrust::device, bitset.size(), read_all_bits(bitset, set));
+    stdgpu::for_each_index(stdgpu::execution::device, bitset.size(), read_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), bitset.size());
 
@@ -512,7 +512,7 @@ TEST_F(stdgpu_bitset, set_random_bits)
     stdgpu::index_t* host_random_sequence = generate_shuffled_sequence(bitset.size());
     stdgpu::index_t* random_sequence = copyCreateHost2DeviceArray<stdgpu::index_t>(host_random_sequence, bitset.size());
 
-    stdgpu::for_each_index(thrust::device, N, set_bits(bitset, random_sequence, set));
+    stdgpu::for_each_index(stdgpu::execution::device, N, set_bits(bitset, random_sequence, set));
 
     ASSERT_EQ(bitset.count(), N);
 
@@ -546,11 +546,11 @@ TEST_F(stdgpu_bitset, reset_random_bits)
     stdgpu::index_t* host_random_sequence = generate_shuffled_sequence(bitset.size());
     stdgpu::index_t* random_sequence = copyCreateHost2DeviceArray<stdgpu::index_t>(host_random_sequence, bitset.size());
 
-    stdgpu::for_each_index(thrust::device, N, set_bits(bitset, random_sequence, set));
+    stdgpu::for_each_index(stdgpu::execution::device, N, set_bits(bitset, random_sequence, set));
 
     ASSERT_EQ(bitset.count(), N);
 
-    stdgpu::for_each_index(thrust::device, N, reset_bits(bitset, random_sequence, set));
+    stdgpu::for_each_index(stdgpu::execution::device, N, reset_bits(bitset, random_sequence, set));
 
     ASSERT_EQ(bitset.count(), 0);
 
@@ -576,7 +576,7 @@ TEST_F(stdgpu_bitset, set_and_reset_random_bits)
     stdgpu::index_t* host_random_sequence = generate_shuffled_sequence(bitset.size());
     stdgpu::index_t* random_sequence = copyCreateHost2DeviceArray<stdgpu::index_t>(host_random_sequence, bitset.size());
 
-    stdgpu::for_each_index(thrust::device, N, set_and_reset_bits(bitset, random_sequence, set));
+    stdgpu::for_each_index(stdgpu::execution::device, N, set_and_reset_bits(bitset, random_sequence, set));
 
     ASSERT_EQ(bitset.count(), 0);
 
@@ -607,7 +607,7 @@ TEST_F(stdgpu_bitset, flip_random_bits_previously_reset)
     stdgpu::index_t* host_random_sequence = generate_shuffled_sequence(bitset.size());
     stdgpu::index_t* random_sequence = copyCreateHost2DeviceArray<stdgpu::index_t>(host_random_sequence, bitset.size());
 
-    stdgpu::for_each_index(thrust::device, N, flip_bits(bitset, random_sequence, set));
+    stdgpu::for_each_index(stdgpu::execution::device, N, flip_bits(bitset, random_sequence, set));
 
     ASSERT_EQ(bitset.count(), N);
 
@@ -646,7 +646,7 @@ TEST_F(stdgpu_bitset, flip_random_bits_previously_set)
     stdgpu::index_t* host_random_sequence = generate_shuffled_sequence(bitset.size());
     stdgpu::index_t* random_sequence = copyCreateHost2DeviceArray<stdgpu::index_t>(host_random_sequence, bitset.size());
 
-    stdgpu::for_each_index(thrust::device, N, flip_bits(bitset, random_sequence, set));
+    stdgpu::for_each_index(stdgpu::execution::device, N, flip_bits(bitset, random_sequence, set));
 
     ASSERT_EQ(bitset.count(), bitset.size() - N);
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -208,9 +208,9 @@ fill_deque(stdgpu::deque<int>& pool, const stdgpu::index_t N)
     ASSERT_LE(N, pool.capacity());
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, push_back_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_deque<int>(pool, values));
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -282,7 +282,7 @@ TEST_F(stdgpu_deque, pop_back_some)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), N_remaining);
     ASSERT_FALSE(pool.empty());
@@ -308,7 +308,7 @@ TEST_F(stdgpu_deque, pop_back_all)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -327,7 +327,7 @@ TEST_F(stdgpu_deque, pop_back_too_many)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -346,17 +346,17 @@ TEST_F(stdgpu_deque, pop_back_const_type)
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
     const float part_second = 2.0F;
-    stdgpu::for_each_index(thrust::device, N, push_back_deque_const_type<T>(pool, values, part_second));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_deque_const_type<T>(pool, values, part_second));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    stdgpu::for_each_index(thrust::device, N, pop_back_deque_const_type<T>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N, pop_back_deque_const_type<T>(pool));
 
     EXPECT_EQ(pool.size(), 0);
     EXPECT_TRUE(pool.empty());
@@ -374,16 +374,16 @@ TEST_F(stdgpu_deque, pop_back_nondefault_type)
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    stdgpu::for_each_index(thrust::device, N, pop_back_deque<nondefault_int_deque>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N, pop_back_deque<nondefault_int_deque>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -405,12 +405,12 @@ TEST_F(stdgpu_deque, push_back_some)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
 
-    stdgpu::for_each_index(thrust::device, N_push, push_back_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, push_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -440,12 +440,12 @@ TEST_F(stdgpu_deque, push_back_all)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, push_back_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, push_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -475,12 +475,12 @@ TEST_F(stdgpu_deque, push_back_too_many)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, push_back_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, push_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -509,10 +509,10 @@ TEST_F(stdgpu_deque, push_back_const_type)
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
     const float part_second = 2.0F;
-    stdgpu::for_each_index(thrust::device, N, push_back_deque_const_type<T>(pool, values, part_second));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_deque_const_type<T>(pool, values, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -530,9 +530,9 @@ TEST_F(stdgpu_deque, push_back_nondefault_type)
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -554,12 +554,12 @@ TEST_F(stdgpu_deque, emplace_back_some)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
 
-    stdgpu::for_each_index(thrust::device, N_push, emplace_back_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, emplace_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -589,12 +589,12 @@ TEST_F(stdgpu_deque, emplace_back_all)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, emplace_back_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, emplace_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -624,12 +624,12 @@ TEST_F(stdgpu_deque, emplace_back_too_many)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, emplace_back_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, emplace_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -658,10 +658,10 @@ TEST_F(stdgpu_deque, emplace_back_const_type)
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
     const float part_second = 2.0F;
-    stdgpu::for_each_index(thrust::device, N, emplace_back_deque_const_type<T>(pool, values, part_second));
+    stdgpu::for_each_index(stdgpu::execution::device, N, emplace_back_deque_const_type<T>(pool, values, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -679,9 +679,9 @@ TEST_F(stdgpu_deque, emplace_back_nondefault_type)
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, emplace_back_deque<nondefault_int_deque, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, emplace_back_deque<nondefault_int_deque, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -832,7 +832,7 @@ TEST_F(stdgpu_deque, pop_front_some)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_front_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), N_remaining);
     ASSERT_FALSE(pool.empty());
@@ -858,7 +858,7 @@ TEST_F(stdgpu_deque, pop_front_all)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_front_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -877,7 +877,7 @@ TEST_F(stdgpu_deque, pop_front_too_many)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_front_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -896,17 +896,17 @@ TEST_F(stdgpu_deque, pop_front_const_type)
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
     const float part_second = 2.0F;
-    stdgpu::for_each_index(thrust::device, N, push_back_deque_const_type<T>(pool, values, part_second));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_deque_const_type<T>(pool, values, part_second));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    stdgpu::for_each_index(thrust::device, N, pop_front_deque_const_type<T>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N, pop_front_deque_const_type<T>(pool));
 
     EXPECT_EQ(pool.size(), 0);
     EXPECT_TRUE(pool.empty());
@@ -924,16 +924,16 @@ TEST_F(stdgpu_deque, pop_front_nondefault_type)
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    stdgpu::for_each_index(thrust::device, N, pop_front_deque<nondefault_int_deque>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N, pop_front_deque<nondefault_int_deque>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -954,12 +954,12 @@ TEST_F(stdgpu_deque, push_front_some)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_front_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, push_front_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, push_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -989,12 +989,12 @@ TEST_F(stdgpu_deque, push_front_all)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_front_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, push_front_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, push_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1024,12 +1024,12 @@ TEST_F(stdgpu_deque, push_front_too_many)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_front_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, push_front_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, push_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1058,10 +1058,10 @@ TEST_F(stdgpu_deque, push_front_const_type)
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
     const float part_second = 2.0F;
-    stdgpu::for_each_index(thrust::device, N, push_front_deque_const_type<T>(pool, values, part_second));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_front_deque_const_type<T>(pool, values, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -1079,9 +1079,9 @@ TEST_F(stdgpu_deque, push_front_nondefault_type)
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, push_front_deque<nondefault_int_deque, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_front_deque<nondefault_int_deque, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1102,12 +1102,12 @@ TEST_F(stdgpu_deque, emplace_front_some)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_front_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, emplace_front_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, emplace_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1137,12 +1137,12 @@ TEST_F(stdgpu_deque, emplace_front_all)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_front_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, emplace_front_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, emplace_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1172,12 +1172,12 @@ TEST_F(stdgpu_deque, emplace_front_too_many)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_front_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, emplace_front_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, emplace_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1206,10 +1206,10 @@ TEST_F(stdgpu_deque, emplace_front_const_type)
     stdgpu::deque<T> pool = stdgpu::deque<T>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
     const float part_second = 2.0F;
-    stdgpu::for_each_index(thrust::device, N, emplace_front_deque_const_type<T>(pool, values, part_second));
+    stdgpu::for_each_index(stdgpu::execution::device, N, emplace_front_deque_const_type<T>(pool, values, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -1227,9 +1227,9 @@ TEST_F(stdgpu_deque, emplace_front_nondefault_type)
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, emplace_front_deque<nondefault_int_deque, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, emplace_front_deque<nondefault_int_deque, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1250,14 +1250,14 @@ TEST_F(stdgpu_deque, push_back_circular)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_front_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), N - N_pop + 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), N - N_pop + 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, push_back_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, push_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1287,14 +1287,14 @@ TEST_F(stdgpu_deque, push_front_circular)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_front_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), N - N_pop + 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), N - N_pop + 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, push_front_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, push_front_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -1358,12 +1358,12 @@ TEST_F(stdgpu_deque, clear_circular)
     stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N + 1);
 
     fill_deque(pool, N);
-    stdgpu::for_each_index(thrust::device, N_offset, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_offset, pop_front_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_offset);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_offset, push_back_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_offset, push_back_deque<int>(pool, values));
 
     pool.clear();
 
@@ -1383,9 +1383,9 @@ TEST_F(stdgpu_deque, clear_nondefault_type)
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N + 1);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
 
     pool.clear();
 
@@ -1405,9 +1405,9 @@ TEST_F(stdgpu_deque, clear_nondefault_type_full)
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
 
     pool.clear();
 
@@ -1428,13 +1428,15 @@ TEST_F(stdgpu_deque, clear_nondefault_type_circular)
     stdgpu::deque<nondefault_int_deque> pool = stdgpu::deque<nondefault_int_deque>::createDeviceObject(N + 1);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_deque<nondefault_int_deque, int>(pool, values));
 
-    stdgpu::for_each_index(thrust::device, N_offset, pop_front_deque<nondefault_int_deque>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_offset, pop_front_deque<nondefault_int_deque>(pool));
 
-    stdgpu::for_each_index(thrust::device, N_offset, push_back_deque<nondefault_int_deque, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device,
+                           N_offset,
+                           push_back_deque<nondefault_int_deque, int>(pool, values));
 
     pool.clear();
 
@@ -1487,9 +1489,9 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_back)
     stdgpu::deque<int> pool_validation = stdgpu::deque<int>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device,
+    stdgpu::for_each_index(stdgpu::execution::device,
                            N,
                            simultaneous_push_back_and_pop_back_deque<int>(pool, pool_validation, values));
 
@@ -1557,9 +1559,9 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_front)
     stdgpu::deque<int> pool_validation = stdgpu::deque<int>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device,
+    stdgpu::for_each_index(stdgpu::execution::device,
                            N,
                            simultaneous_push_front_and_pop_front_deque<int>(pool, pool_validation, values));
 
@@ -1627,9 +1629,9 @@ TEST_F(stdgpu_deque, simultaneous_push_front_and_pop_back)
     stdgpu::deque<int> pool_validation = stdgpu::deque<int>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device,
+    stdgpu::for_each_index(stdgpu::execution::device,
                            N,
                            simultaneous_push_front_and_pop_back_deque<int>(pool, pool_validation, values));
 
@@ -1697,9 +1699,9 @@ TEST_F(stdgpu_deque, simultaneous_push_back_and_pop_front)
     stdgpu::deque<int> pool_validation = stdgpu::deque<int>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device,
+    stdgpu::for_each_index(stdgpu::execution::device,
                            N,
                            simultaneous_push_back_and_pop_front_deque<int>(pool, pool_validation, values));
 
@@ -1754,7 +1756,7 @@ TEST_F(stdgpu_deque, at_non_const)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N, at_non_const_deque(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N, at_non_const_deque(pool));
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1793,7 +1795,7 @@ TEST_F(stdgpu_deque, access_operator_non_const)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N, access_operator_non_const_deque(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N, access_operator_non_const_deque(pool));
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1855,7 +1857,7 @@ TEST_F(stdgpu_deque, shrink_to_fit)
 
     fill_deque(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
     ASSERT_EQ(pool.size(), N_remaining);
     ASSERT_EQ(pool.capacity(), N);
@@ -1920,7 +1922,7 @@ non_const_front(const stdgpu::deque<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, non_const_front_functor<T>(pool, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_front_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1936,7 +1938,7 @@ const_front(const stdgpu::deque<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, const_front_functor<T>(pool, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, const_front_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -2006,7 +2008,7 @@ non_const_back(const stdgpu::deque<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, non_const_back_functor<T>(pool, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_back_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -2022,7 +2024,7 @@ const_back(const stdgpu::deque<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, const_back_functor<T>(pool, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, const_back_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -2096,7 +2098,7 @@ non_const_operator_access(const stdgpu::deque<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, non_const_operator_access_functor<T>(pool, i, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_operator_access_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -2112,7 +2114,7 @@ const_operator_access(const stdgpu::deque<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, const_operator_access_functor<T>(pool, i, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, const_operator_access_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -2186,7 +2188,7 @@ non_const_at(const stdgpu::deque<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, non_const_at_functor<T>(pool, i, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_at_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -2202,7 +2204,7 @@ const_at(const stdgpu::deque<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, const_at_functor<T>(pool, i, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, const_at_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -2334,7 +2336,7 @@ TEST_F(stdgpu_deque, non_const_device_range)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = pool.device_range();
-    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(stdgpu::execution::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -2364,7 +2366,7 @@ TEST_F(stdgpu_deque, non_const_device_range_full)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = pool.device_range();
-    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(stdgpu::execution::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -2388,12 +2390,12 @@ TEST_F(stdgpu_deque, non_const_device_range_circular)
 
     fill_deque(pool, N);
 
-    stdgpu::for_each_index(thrust::device, N_offset, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_offset, pop_front_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_offset);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_offset, push_back_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_offset, push_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_EQ(pool.capacity(), N + 1);
@@ -2402,7 +2404,7 @@ TEST_F(stdgpu_deque, non_const_device_range_circular)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = pool.device_range();
-    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(stdgpu::execution::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -2433,7 +2435,7 @@ TEST_F(stdgpu_deque, const_device_range)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range();
-    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(stdgpu::execution::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -2463,7 +2465,7 @@ TEST_F(stdgpu_deque, const_device_range_full)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range();
-    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(stdgpu::execution::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -2487,12 +2489,12 @@ TEST_F(stdgpu_deque, const_device_range_circular)
 
     fill_deque(pool, N);
 
-    stdgpu::for_each_index(thrust::device, N_offset, pop_front_deque<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_offset, pop_front_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_offset);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_offset, push_back_deque<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_offset, push_back_deque<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_EQ(pool.capacity(), N + 1);
@@ -2501,7 +2503,7 @@ TEST_F(stdgpu_deque, const_device_range_circular)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range();
-    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(stdgpu::execution::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());

--- a/test/stdgpu/iterator.cpp
+++ b/test/stdgpu/iterator.cpp
@@ -398,7 +398,10 @@ TEST_F(stdgpu_iterator, back_inserter)
     std::iota(stdgpu::host_begin(array), stdgpu::host_end(array), 1);
 
     back_insert_interface ci(numbers);
-    stdgpu::copy(thrust::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), stdgpu::back_inserter(ci));
+    stdgpu::copy(stdgpu::execution::host,
+                 stdgpu::host_cbegin(array),
+                 stdgpu::host_cend(array),
+                 stdgpu::back_inserter(ci));
 
     int* array_result = copyCreateHost2HostArray<int>(numbers.data(), N, MemoryCopy::NO_CHECK);
 
@@ -423,7 +426,10 @@ TEST_F(stdgpu_iterator, front_inserter)
     std::iota(stdgpu::host_begin(array), stdgpu::host_end(array), 1);
 
     front_insert_interface ci(numbers);
-    stdgpu::copy(thrust::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), stdgpu::front_inserter(ci));
+    stdgpu::copy(stdgpu::execution::host,
+                 stdgpu::host_cbegin(array),
+                 stdgpu::host_cend(array),
+                 stdgpu::front_inserter(ci));
 
     int* array_result = copyCreateHost2HostArray<int>(numbers.data(), N, MemoryCopy::NO_CHECK);
 
@@ -448,7 +454,7 @@ TEST_F(stdgpu_iterator, inserter)
     std::iota(stdgpu::host_begin(array), stdgpu::host_end(array), 1);
 
     insert_interface ci(numbers);
-    stdgpu::copy(thrust::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), stdgpu::inserter(ci));
+    stdgpu::copy(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), stdgpu::inserter(ci));
 
     int* array_result = copyCreateHost2HostArray<int>(numbers.data(), N, MemoryCopy::NO_CHECK);
 

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -398,7 +398,7 @@ createAndDestroyDeviceFunction(const stdgpu::index_t iterations)
         int* array_device = createDeviceArray<int>(size, default_value);
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
-        EXPECT_TRUE(equal_value(thrust::device,
+        EXPECT_TRUE(equal_value(stdgpu::execution::device,
                                 stdgpu::device_cbegin(array_device),
                                 stdgpu::device_cend(array_device),
                                 default_value));
@@ -414,7 +414,7 @@ createAndDestroyDeviceFunction(const stdgpu::index_t iterations)
 
         int* array_device_2 = createDeviceArray<int, Allocator>(a, size, default_value);
 
-        EXPECT_TRUE(equal_value(thrust::device,
+        EXPECT_TRUE(equal_value(stdgpu::execution::device,
                                 stdgpu::device_cbegin(array_device_2),
                                 stdgpu::device_cend(array_device_2),
                                 default_value));
@@ -440,11 +440,11 @@ createAndDestroyHostFunction(const stdgpu::index_t iterations)
         int* array_host = createHostArray<int>(size, default_value);
         int* array_host_2 = createHostArray<int, Allocator>(a, size, default_value);
 
-        EXPECT_TRUE(equal_value(thrust::host,
+        EXPECT_TRUE(equal_value(stdgpu::execution::host,
                                 stdgpu::host_cbegin(array_host),
                                 stdgpu::host_cend(array_host),
                                 default_value));
-        EXPECT_TRUE(equal_value(thrust::host,
+        EXPECT_TRUE(equal_value(stdgpu::execution::host,
                                 stdgpu::host_cbegin(array_host_2),
                                 stdgpu::host_cend(array_host_2),
                                 default_value));
@@ -473,16 +473,16 @@ createAndDestroyManagedFunction(const stdgpu::index_t iterations)
         int* array_managed_host_2 = createManagedArray<int, Allocator>(a, size, default_value, Initialization::HOST);
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
-        EXPECT_TRUE(equal_value(thrust::device,
+        EXPECT_TRUE(equal_value(stdgpu::execution::device,
                                 stdgpu::device_cbegin(array_managed_device),
                                 stdgpu::device_cend(array_managed_device),
                                 default_value));
 #endif
-        EXPECT_TRUE(equal_value(thrust::host,
+        EXPECT_TRUE(equal_value(stdgpu::execution::host,
                                 stdgpu::host_cbegin(array_managed_host),
                                 stdgpu::host_cend(array_managed_host),
                                 default_value));
-        EXPECT_TRUE(equal_value(thrust::host,
+        EXPECT_TRUE(equal_value(stdgpu::execution::host,
                                 stdgpu::host_cbegin(array_managed_host_2),
                                 stdgpu::host_cend(array_managed_host_2),
                                 default_value));
@@ -634,7 +634,7 @@ copyCreateDevice2DeviceFunction(const stdgpu::index_t iterations)
         int* array_copy = copyCreateDevice2DeviceArray<int>(array, size);
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
-        EXPECT_TRUE(equal_range(thrust::device,
+        EXPECT_TRUE(equal_range(stdgpu::execution::device,
                                 stdgpu::device_begin(array),
                                 stdgpu::device_end(array),
                                 stdgpu::device_begin(array_copy)));
@@ -646,7 +646,7 @@ copyCreateDevice2DeviceFunction(const stdgpu::index_t iterations)
 
         int* array_copy_2 = copyCreateDevice2DeviceArray<int, Allocator>(a, array, size);
 
-        EXPECT_TRUE(equal_range(thrust::device,
+        EXPECT_TRUE(equal_range(stdgpu::execution::device,
                                 stdgpu::device_begin(array),
                                 stdgpu::device_end(array),
                                 stdgpu::device_begin(array_copy_2)));
@@ -692,7 +692,7 @@ copyCreateHost2DeviceFunction(const stdgpu::index_t iterations)
         int* array_copy = copyCreateHost2DeviceArray<int>(array_host, size);
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
-        EXPECT_TRUE(equal_range(thrust::device,
+        EXPECT_TRUE(equal_range(stdgpu::execution::device,
                                 stdgpu::device_cbegin(array),
                                 stdgpu::device_cend(array),
                                 stdgpu::device_cbegin(array_copy)));
@@ -704,7 +704,7 @@ copyCreateHost2DeviceFunction(const stdgpu::index_t iterations)
 
         int* array_copy_2 = copyCreateHost2DeviceArray<int, Allocator>(a, array_host, size);
 
-        EXPECT_TRUE(equal_range(thrust::device,
+        EXPECT_TRUE(equal_range(stdgpu::execution::device,
                                 stdgpu::device_begin(array),
                                 stdgpu::device_end(array),
                                 stdgpu::device_begin(array_copy_2)));
@@ -751,7 +751,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2DeviceArray_no_check)
     int* array_copy = copyCreateHost2DeviceArray<int>(array_host, size, MemoryCopy::NO_CHECK);
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
-    EXPECT_TRUE(equal_range(thrust::device,
+    EXPECT_TRUE(equal_range(stdgpu::execution::device,
                             stdgpu::device_cbegin(array),
                             stdgpu::device_cend(array),
                             stdgpu::device_cbegin(array_copy)));
@@ -780,11 +780,11 @@ copyCreateDevice2HostFunction(const stdgpu::index_t iterations)
         int* array_copy = copyCreateDevice2HostArray<int>(array, size);
         int* array_copy_2 = copyCreateDevice2HostArray<int, Allocator>(a, array, size);
 
-        EXPECT_TRUE(equal_range(thrust::host,
+        EXPECT_TRUE(equal_range(stdgpu::execution::host,
                                 stdgpu::host_cbegin(array_host),
                                 stdgpu::host_cend(array_host),
                                 stdgpu::host_cbegin(array_copy)));
-        EXPECT_TRUE(equal_range(thrust::host,
+        EXPECT_TRUE(equal_range(stdgpu::execution::host,
                                 stdgpu::host_cbegin(array_host),
                                 stdgpu::host_cend(array_host),
                                 stdgpu::host_cbegin(array_copy_2)));
@@ -831,11 +831,11 @@ copyCreateHost2HostFunction(const stdgpu::index_t iterations)
         int* array_copy = copyCreateHost2HostArray<int>(array_host, size);
         int* array_copy_2 = copyCreateHost2HostArray<int, Allocator>(a, array_host, size);
 
-        EXPECT_TRUE(equal_range(thrust::host,
+        EXPECT_TRUE(equal_range(stdgpu::execution::host,
                                 stdgpu::host_cbegin(array_host),
                                 stdgpu::host_cend(array_host),
                                 stdgpu::host_cbegin(array_copy)));
-        EXPECT_TRUE(equal_range(thrust::host,
+        EXPECT_TRUE(equal_range(stdgpu::execution::host,
                                 stdgpu::host_cbegin(array_host),
                                 stdgpu::host_cend(array_host),
                                 stdgpu::host_cbegin(array_copy_2)));
@@ -875,7 +875,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyCreateHost2HostArray_no_check)
     }
     int* array_copy = copyCreateHost2HostArray<int>(array_host, size, MemoryCopy::NO_CHECK);
 
-    EXPECT_TRUE(equal_range(thrust::host, array_host, array_host + size, stdgpu::host_cbegin(array_copy)));
+    EXPECT_TRUE(equal_range(stdgpu::execution::host, array_host, array_host + size, stdgpu::host_cbegin(array_copy)));
 
     delete[] array_host;
     destroyHostArray<int>(array_copy);
@@ -943,7 +943,7 @@ copyDevice2DeviceFunction(const stdgpu::index_t iterations)
         copyDevice2DeviceArray<int>(array, size, array_copy);
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
-        EXPECT_TRUE(equal_range(thrust::device,
+        EXPECT_TRUE(equal_range(stdgpu::execution::device,
                                 stdgpu::device_cbegin(array),
                                 stdgpu::device_cend(array),
                                 stdgpu::device_cbegin(array_copy)));
@@ -977,7 +977,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2DeviceArray_self)
     copyDevice2DeviceArray<int>(array, size, array_copy);
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
-    EXPECT_TRUE(equal_range(thrust::device,
+    EXPECT_TRUE(equal_range(stdgpu::execution::device,
                             stdgpu::device_cbegin(array),
                             stdgpu::device_cend(array),
                             stdgpu::device_cbegin(array_copy)));
@@ -1002,7 +1002,7 @@ copyHost2DeviceFunction(const stdgpu::index_t iterations)
         copyHost2DeviceArray<int>(array_host, size, array_copy);
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
-        EXPECT_TRUE(equal_range(thrust::device,
+        EXPECT_TRUE(equal_range(stdgpu::execution::device,
                                 stdgpu::device_cbegin(array),
                                 stdgpu::device_cend(array),
                                 stdgpu::device_cbegin(array_copy)));
@@ -1042,7 +1042,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2DeviceArray_no_check)
     copyHost2DeviceArray<int>(array_host, size, array_copy, MemoryCopy::NO_CHECK);
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
-    EXPECT_TRUE(equal_range(thrust::device,
+    EXPECT_TRUE(equal_range(stdgpu::execution::device,
                             stdgpu::device_cbegin(array),
                             stdgpu::device_cend(array),
                             stdgpu::device_cbegin(array_copy)));
@@ -1068,7 +1068,7 @@ copyDevice2HostFunction(const stdgpu::index_t iterations)
         int* array_copy = createHostArray<int>(size, 0);
         copyDevice2HostArray<int>(array, size, array_copy);
 
-        EXPECT_TRUE(equal_range(thrust::host,
+        EXPECT_TRUE(equal_range(stdgpu::execution::host,
                                 stdgpu::host_cbegin(array_host),
                                 stdgpu::host_cend(array_host),
                                 stdgpu::host_cbegin(array_copy)));
@@ -1102,7 +1102,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2HostArray_no_check)
     int* array_copy = new int[static_cast<std::size_t>(size)];
     copyDevice2HostArray<int>(array, size, array_copy, MemoryCopy::NO_CHECK);
 
-    EXPECT_TRUE(equal_range(thrust::host, stdgpu::host_cbegin(array_host), stdgpu::host_cend(array_host), array_copy));
+    EXPECT_TRUE(equal_range(stdgpu::execution::host,
+                            stdgpu::host_cbegin(array_host),
+                            stdgpu::host_cend(array_host),
+                            array_copy));
 
     destroyDeviceArray<int>(array);
     destroyHostArray<int>(array_host);
@@ -1123,7 +1126,7 @@ copyHost2HostFunction(const stdgpu::index_t iterations)
         int* array_copy = createHostArray<int>(size, 0);
         copyHost2HostArray<int>(array_host, size, array_copy);
 
-        EXPECT_TRUE(equal_range(thrust::host,
+        EXPECT_TRUE(equal_range(stdgpu::execution::host,
                                 stdgpu::host_cbegin(array_host),
                                 stdgpu::host_cend(array_host),
                                 stdgpu::host_cbegin(array_copy)));
@@ -1159,7 +1162,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_no_check)
     int* array_copy = new int[static_cast<std::size_t>(size)];
     copyHost2HostArray<int>(array_host, size, array_copy, MemoryCopy::NO_CHECK);
 
-    EXPECT_TRUE(equal_range(thrust::host, array_host, array_host + size, array_copy));
+    EXPECT_TRUE(equal_range(stdgpu::execution::host, array_host, array_host + size, array_copy));
 
     delete[] array_host;
     delete[] array_copy;
@@ -1174,7 +1177,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_self)
     int* array_copy = array_host;
     copyHost2HostArray<int>(array_host, size, array_copy);
 
-    EXPECT_TRUE(equal_range(thrust::host,
+    EXPECT_TRUE(equal_range(stdgpu::execution::host,
                             stdgpu::host_cbegin(array_host),
                             stdgpu::host_cend(array_host),
                             stdgpu::host_cbegin(array_copy)));
@@ -1195,7 +1198,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_self_no_check)
     int* array_copy = array_host;
     copyHost2HostArray<int>(array_host, size, array_copy, MemoryCopy::NO_CHECK);
 
-    EXPECT_TRUE(equal_range(thrust::host, array_host, array_host + size, array_copy));
+    EXPECT_TRUE(equal_range(stdgpu::execution::host, array_host, array_host + size, array_copy));
 
     delete[] array_host;
 }
@@ -1292,9 +1295,12 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_device_allocator)
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
     const int default_value = 10;
-    stdgpu::fill(thrust::device, stdgpu::device_begin(array), stdgpu::device_end(array), default_value);
+    stdgpu::fill(stdgpu::execution::device, stdgpu::device_begin(array), stdgpu::device_end(array), default_value);
 
-    EXPECT_TRUE(equal_value(thrust::device, stdgpu::device_cbegin(array), stdgpu::device_cend(array), default_value));
+    EXPECT_TRUE(equal_value(stdgpu::execution::device,
+                            stdgpu::device_cbegin(array),
+                            stdgpu::device_cend(array),
+                            default_value));
 #endif
 
     a.deallocate(array, size);
@@ -1308,9 +1314,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_host_allocator)
     int* array = a.allocate(size);
 
     const int default_value = 10;
-    stdgpu::fill(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
 
-    EXPECT_TRUE(equal_value(thrust::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
+    EXPECT_TRUE(
+            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
 
     a.deallocate(array, size);
 }
@@ -1323,9 +1330,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_managed_allocator)
     int* array = a.allocate(size);
 
     const int default_value = 10;
-    stdgpu::fill(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
 
-    EXPECT_TRUE(equal_value(thrust::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
+    EXPECT_TRUE(
+            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
 
     a.deallocate(array, size);
 }
@@ -1340,9 +1348,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_deallocate)
     int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
 
     const int default_value = 10;
-    stdgpu::fill(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
 
-    EXPECT_TRUE(equal_value(thrust::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
+    EXPECT_TRUE(
+            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
 
     stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
 }
@@ -1358,9 +1367,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_hint_deallocate)
     int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size, array_hint);
 
     const int default_value = 10;
-    stdgpu::fill(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
 
-    EXPECT_TRUE(equal_value(thrust::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
+    EXPECT_TRUE(
+            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
 
     stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
     stdgpu::allocator_traits<Allocator>::deallocate(a, array_hint, size);
@@ -1380,9 +1390,12 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_device)
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
     const int default_value = 10;
-    stdgpu::fill(thrust::device, stdgpu::device_begin(array), stdgpu::device_end(array), default_value);
+    stdgpu::fill(stdgpu::execution::device, stdgpu::device_begin(array), stdgpu::device_end(array), default_value);
 
-    EXPECT_TRUE(equal_value(thrust::device, stdgpu::device_cbegin(array), stdgpu::device_cend(array), default_value));
+    EXPECT_TRUE(equal_value(stdgpu::execution::device,
+                            stdgpu::device_cbegin(array),
+                            stdgpu::device_cend(array),
+                            default_value));
 #endif
 
     stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
@@ -1401,9 +1414,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_host)
     int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
 
     const int default_value = 10;
-    stdgpu::fill(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
 
-    EXPECT_TRUE(equal_value(thrust::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
+    EXPECT_TRUE(
+            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
 
     stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
 }
@@ -1421,9 +1435,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_managed)
     int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
 
     const int default_value = 10;
-    stdgpu::fill(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
 
-    EXPECT_TRUE(equal_value(thrust::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
+    EXPECT_TRUE(
+            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
 
     stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
 }
@@ -1653,7 +1668,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroy)
     ASSERT_EQ(constructor_calls, 0);
     ASSERT_EQ(destructor_calls, 0);
 
-    stdgpu::destroy(thrust::host, stdgpu::host_begin(array), stdgpu::host_end(array));
+    stdgpu::destroy(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array));
 
     EXPECT_EQ(constructor_calls, 0);
     EXPECT_EQ(destructor_calls, size);
@@ -1683,7 +1698,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, destroy_n)
     ASSERT_EQ(constructor_calls, 0);
     ASSERT_EQ(destructor_calls, 0);
 
-    stdgpu::destroy_n(thrust::host, stdgpu::host_begin(array), size);
+    stdgpu::destroy_n(stdgpu::execution::host, stdgpu::host_begin(array), size);
 
     EXPECT_EQ(constructor_calls, 0);
     EXPECT_EQ(destructor_calls, size);
@@ -1766,7 +1781,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill)
     T* values = values_vector.data();
 
     T init(42.0F);
-    stdgpu::uninitialized_fill(thrust::host, stdgpu::make_host(values), stdgpu::make_host(values + N), init);
+    stdgpu::uninitialized_fill(stdgpu::execution::host, stdgpu::make_host(values), stdgpu::make_host(values + N), init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -1783,7 +1798,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill_only_copyable)
     T* values = values_vector.data();
 
     T init(42.0F);
-    stdgpu::uninitialized_fill(thrust::host, stdgpu::make_host(values), stdgpu::make_host(values + N), init);
+    stdgpu::uninitialized_fill(stdgpu::execution::host, stdgpu::make_host(values), stdgpu::make_host(values + N), init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -1800,7 +1815,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill_n)
     T* values = values_vector.data();
 
     T init(42.0F);
-    stdgpu::uninitialized_fill_n(thrust::host, stdgpu::make_host(values), N, init);
+    stdgpu::uninitialized_fill_n(stdgpu::execution::host, stdgpu::make_host(values), N, init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -1817,7 +1832,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill_n_only_copyable)
     T* values = values_vector.data();
 
     T init(42.0F);
-    stdgpu::uninitialized_fill_n(thrust::host, stdgpu::make_host(values), N, init);
+    stdgpu::uninitialized_fill_n(stdgpu::execution::host, stdgpu::make_host(values), N, init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -1836,7 +1851,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy)
     std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
-    stdgpu::uninitialized_copy(thrust::host, stdgpu::make_host(values), stdgpu::make_host(values + N), values_copied);
+    stdgpu::uninitialized_copy(stdgpu::execution::host,
+                               stdgpu::make_host(values),
+                               stdgpu::make_host(values + N),
+                               values_copied);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -1855,7 +1873,10 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy_only_copyable)
     std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
-    stdgpu::uninitialized_copy(thrust::host, stdgpu::make_host(values), stdgpu::make_host(values + N), values_copied);
+    stdgpu::uninitialized_copy(stdgpu::execution::host,
+                               stdgpu::make_host(values),
+                               stdgpu::make_host(values + N),
+                               values_copied);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -1874,7 +1895,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy_n)
     std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
-    stdgpu::uninitialized_copy_n(thrust::host, stdgpu::make_host(values), N, values_copied);
+    stdgpu::uninitialized_copy_n(stdgpu::execution::host, stdgpu::make_host(values), N, values_copied);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -1893,7 +1914,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy_n_only_copyable)
     std::vector<T> values_copied_vector(static_cast<std::size_t>(N));
     T* values_copied = values_copied_vector.data();
 
-    stdgpu::uninitialized_copy_n(thrust::host, stdgpu::make_host(values), N, values_copied);
+    stdgpu::uninitialized_copy_n(stdgpu::execution::host, stdgpu::make_host(values), N, values_copied);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -102,7 +102,7 @@ private:
 
 TEST_F(stdgpu_mutex, parallel_lock_and_unlock)
 {
-    stdgpu::for_each_index(thrust::device, locks.size(), lock_and_unlock(locks));
+    stdgpu::for_each_index(stdgpu::execution::device, locks.size(), lock_and_unlock(locks));
 
     EXPECT_TRUE(locks.valid());
 }
@@ -157,9 +157,9 @@ equal(const stdgpu::mutex_array<>& locks_1, const stdgpu::mutex_array<>& locks_2
 
     std::uint8_t* equality_flags = createDeviceArray<std::uint8_t>(locks_1.size());
 
-    stdgpu::for_each_index(thrust::device, locks_1.size(), same_state(locks_1, locks_2, equality_flags));
+    stdgpu::for_each_index(stdgpu::execution::device, locks_1.size(), same_state(locks_1, locks_2, equality_flags));
 
-    bool result = stdgpu::transform_reduce_index(thrust::device,
+    bool result = stdgpu::transform_reduce_index(stdgpu::execution::device,
                                                  locks_1.size(),
                                                  true,
                                                  stdgpu::logical_and<>(),
@@ -197,7 +197,7 @@ lock_single(const stdgpu::mutex_array<>& locks, const stdgpu::index_t n)
 {
     std::uint8_t* result = createDeviceArray<std::uint8_t>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, lock_single_functor(locks, n, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, lock_single_functor(locks, n, result));
 
     std::uint8_t host_result;
     copyDevice2HostArray<std::uint8_t>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -258,7 +258,7 @@ lock_multiple(const stdgpu::mutex_array<>& locks, const stdgpu::index_t n_0, con
 {
     int* result = createDeviceArray<int>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, lock_multiple_functor(locks, n_0, n_1, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, lock_multiple_functor(locks, n_0, n_1, result));
 
     int host_result;
     copyDevice2HostArray<int>(result, 1, &host_result, MemoryCopy::NO_CHECK);

--- a/test/stdgpu/numeric.cpp
+++ b/test/stdgpu/numeric.cpp
@@ -44,7 +44,7 @@ TEST_F(stdgpu_numeric, iota)
     stdgpu::index_t* indices = indices_vector.data();
 
     stdgpu::index_t init = 42;
-    stdgpu::iota(thrust::host, indices_vector.begin(), indices_vector.end(), init);
+    stdgpu::iota(stdgpu::execution::host, indices_vector.begin(), indices_vector.end(), init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
     {
@@ -77,11 +77,14 @@ TEST_F(stdgpu_numeric, transform_reduce_index)
     std::int64_t* numbers = numbers_vector.data();
 
     std::int64_t init = 42;
-    stdgpu::iota(thrust::host, numbers_vector.begin(), numbers_vector.end(), init);
+    stdgpu::iota(stdgpu::execution::host, numbers_vector.begin(), numbers_vector.end(), init);
 
     std::int64_t shift = 21;
-    std::int64_t shifted_sum =
-            stdgpu::transform_reduce_index(thrust::host, N, shift, stdgpu::plus<>(), number_sequence(numbers));
+    std::int64_t shifted_sum = stdgpu::transform_reduce_index(stdgpu::execution::host,
+                                                              N,
+                                                              shift,
+                                                              stdgpu::plus<>(),
+                                                              number_sequence(numbers));
 
     auto sum_closed_form = [](const std::int64_t n) { return n * (n + 1) / 2; };
 

--- a/test/stdgpu/ranges.cpp
+++ b/test/stdgpu/ranges.cpp
@@ -285,7 +285,7 @@ TEST_F(stdgpu_ranges, transform_range_with_range)
     std::iota(array_range.begin(), array_range.end(), 0);
 
     // Execute transformation and write into array_result
-    stdgpu::copy(thrust::host, square_range.begin(), square_range.end(), stdgpu::host_begin(array_result));
+    stdgpu::copy(stdgpu::execution::host, square_range.begin(), square_range.end(), stdgpu::host_begin(array_result));
 
     for (stdgpu::index_t i = 0; i < size; ++i)
     {
@@ -310,7 +310,7 @@ TEST_F(stdgpu_ranges, transform_range_with_range_and_function)
     std::iota(array_range.begin(), array_range.end(), 0);
 
     // Execute transformation and write into array_result
-    stdgpu::copy(thrust::host, square_range.begin(), square_range.end(), stdgpu::host_begin(array_result));
+    stdgpu::copy(stdgpu::execution::host, square_range.begin(), square_range.end(), stdgpu::host_begin(array_result));
 
     for (stdgpu::index_t i = 0; i < size; ++i)
     {

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -169,7 +169,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_hits)
     test_unordered_datastructure::key_type* keys =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_keys, N);
 
-    stdgpu::for_each_index(thrust::device, N, count_buckets_hits(hash_datastructure, bucket_hits, keys));
+    stdgpu::for_each_index(stdgpu::execution::device, N, count_buckets_hits(hash_datastructure, bucket_hits, keys));
 
     int* host_bucket_hits = copyCreateDevice2HostArray<int>(bucket_hits, hash_datastructure.bucket_count());
 
@@ -219,7 +219,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_collisions)
     test_unordered_datastructure::key_type* keys =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_keys, N);
 
-    stdgpu::for_each_index(thrust::device, N, count_buckets_hits(hash_datastructure, bucket_hits, keys));
+    stdgpu::for_each_index(stdgpu::execution::device, N, count_buckets_hits(hash_datastructure, bucket_hits, keys));
 
     int* host_bucket_hits = copyCreateDevice2HostArray<int>(bucket_hits, hash_datastructure.bucket_count());
 
@@ -300,7 +300,9 @@ insert_key(HashDataStructure& hash_datastructure, const typename HashDataStructu
 {
     stdgpu::index_t* inserted = createDeviceArray<stdgpu::index_t>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, insert_single<HashDataStructure>(hash_datastructure, key, inserted));
+    stdgpu::for_each_index(stdgpu::execution::device,
+                           1,
+                           insert_single<HashDataStructure>(hash_datastructure, key, inserted));
 
     stdgpu::index_t host_inserted;
     copyDevice2HostArray<stdgpu::index_t>(inserted, 1, &host_inserted, MemoryCopy::NO_CHECK);
@@ -339,7 +341,7 @@ erase_key(test_unordered_datastructure& hash_datastructure, const test_unordered
 {
     stdgpu::index_t* erased = createDeviceArray<stdgpu::index_t>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, erase_single(hash_datastructure, key, erased));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, erase_single(hash_datastructure, key, erased));
 
     stdgpu::index_t host_erased;
     copyDevice2HostArray<stdgpu::index_t>(erased, 1, &host_erased, MemoryCopy::NO_CHECK);
@@ -403,7 +405,7 @@ regular_contains_key(const test_unordered_datastructure& hash_datastructure,
 {
     stdgpu::index_t* contained = createDeviceArray<stdgpu::index_t>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, contains_key_functor(hash_datastructure, key, contained));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, contains_key_functor(hash_datastructure, key, contained));
 
     stdgpu::index_t host_contained;
     copyDevice2HostArray<stdgpu::index_t>(contained, 1, &host_contained, MemoryCopy::NO_CHECK);
@@ -419,7 +421,9 @@ transparent_contains_key(const test_unordered_datastructure& hash_datastructure,
 {
     stdgpu::index_t* contained = createDeviceArray<stdgpu::index_t>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, transparent_contains_key_functor(hash_datastructure, key, contained));
+    stdgpu::for_each_index(stdgpu::execution::device,
+                           1,
+                           transparent_contains_key_functor(hash_datastructure, key, contained));
 
     stdgpu::index_t host_contained;
     copyDevice2HostArray<stdgpu::index_t>(contained, 1, &host_contained, MemoryCopy::NO_CHECK);
@@ -542,7 +546,7 @@ non_const_find_key(const test_unordered_datastructure& hash_datastructure,
 {
     test_unordered_datastructure::iterator* result = createDeviceArray<test_unordered_datastructure::iterator>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, non_const_find_key_functor(hash_datastructure, key, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_find_key_functor(hash_datastructure, key, result));
 
     test_unordered_datastructure::iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -559,7 +563,7 @@ const_find_key(const test_unordered_datastructure& hash_datastructure,
     test_unordered_datastructure::const_iterator* result =
             createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, const_find_key_functor(hash_datastructure, key, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, const_find_key_functor(hash_datastructure, key, result));
 
     test_unordered_datastructure::const_iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -575,7 +579,9 @@ transparent_non_const_find_key(const test_unordered_datastructure& hash_datastru
 {
     test_unordered_datastructure::iterator* result = createDeviceArray<test_unordered_datastructure::iterator>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, transparent_non_const_find_key_functor(hash_datastructure, key, result));
+    stdgpu::for_each_index(stdgpu::execution::device,
+                           1,
+                           transparent_non_const_find_key_functor(hash_datastructure, key, result));
 
     test_unordered_datastructure::iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -592,7 +598,9 @@ transparent_const_find_key(const test_unordered_datastructure& hash_datastructur
     test_unordered_datastructure::const_iterator* result =
             createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, transparent_const_find_key_functor(hash_datastructure, key, result));
+    stdgpu::for_each_index(stdgpu::execution::device,
+                           1,
+                           transparent_const_find_key_functor(hash_datastructure, key, result));
 
     test_unordered_datastructure::const_iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -688,7 +696,7 @@ non_const_begin_iterator(const test_unordered_datastructure& hash_datastructure)
 {
     test_unordered_datastructure::iterator* result = createDeviceArray<test_unordered_datastructure::iterator>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, non_const_begin_iterator_functor(hash_datastructure, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_begin_iterator_functor(hash_datastructure, result));
 
     test_unordered_datastructure::iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -704,7 +712,7 @@ const_begin_iterator(const test_unordered_datastructure& hash_datastructure)
     test_unordered_datastructure::const_iterator* result =
             createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, const_begin_iterator_functor(hash_datastructure, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, const_begin_iterator_functor(hash_datastructure, result));
 
     test_unordered_datastructure::const_iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -720,7 +728,7 @@ cbegin_iterator(const test_unordered_datastructure& hash_datastructure)
     test_unordered_datastructure::const_iterator* result =
             createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, cbegin_iterator_functor(hash_datastructure, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, cbegin_iterator_functor(hash_datastructure, result));
 
     test_unordered_datastructure::const_iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -811,7 +819,7 @@ non_const_end_iterator(const test_unordered_datastructure& hash_datastructure)
 {
     test_unordered_datastructure::iterator* result = createDeviceArray<test_unordered_datastructure::iterator>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, non_const_end_iterator_functor(hash_datastructure, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_end_iterator_functor(hash_datastructure, result));
 
     test_unordered_datastructure::iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -827,7 +835,7 @@ const_end_iterator(const test_unordered_datastructure& hash_datastructure)
     test_unordered_datastructure::const_iterator* result =
             createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, const_end_iterator_functor(hash_datastructure, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, const_end_iterator_functor(hash_datastructure, result));
 
     test_unordered_datastructure::const_iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -843,7 +851,7 @@ cend_iterator(const test_unordered_datastructure& hash_datastructure)
     test_unordered_datastructure::const_iterator* result =
             createDeviceArray<test_unordered_datastructure::const_iterator>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, cend_iterator_functor(hash_datastructure, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, cend_iterator_functor(hash_datastructure, result));
 
     test_unordered_datastructure::const_iterator host_result;
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1205,7 +1213,7 @@ insert_key_multiple(test_unordered_datastructure& hash_datastructure, const test
     const stdgpu::index_t N = 100000;
     stdgpu::index_t* inserted = createDeviceArray<stdgpu::index_t>(N);
 
-    stdgpu::for_each_index(thrust::device, N, insert_multiple(hash_datastructure, key, inserted));
+    stdgpu::for_each_index(stdgpu::execution::device, N, insert_multiple(hash_datastructure, key, inserted));
 
     stdgpu::index_t* host_inserted = copyCreateDevice2HostArray<stdgpu::index_t>(inserted, N);
 
@@ -1228,7 +1236,7 @@ erase_key_multiple(test_unordered_datastructure& hash_datastructure, const test_
     const stdgpu::index_t N = 100000;
     stdgpu::index_t* erased = createDeviceArray<stdgpu::index_t>(N);
 
-    stdgpu::for_each_index(thrust::device, N, erase_multiple(hash_datastructure, key, erased));
+    stdgpu::for_each_index(stdgpu::execution::device, N, erase_multiple(hash_datastructure, key, erased));
 
     stdgpu::index_t* host_erased = copyCreateDevice2HostArray<stdgpu::index_t>(erased, N);
 
@@ -1396,7 +1404,9 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_multiple_while_full)
     const stdgpu::index_t N = 100000;
     stdgpu::index_t* inserted = createDeviceArray<stdgpu::index_t>(N);
 
-    stdgpu::for_each_index(thrust::device, N, insert_multiple(tiny_hash_datastructure, position_3, inserted));
+    stdgpu::for_each_index(stdgpu::execution::device,
+                           N,
+                           insert_multiple(tiny_hash_datastructure, position_3, inserted));
 
     stdgpu::index_t* host_inserted = copyCreateDevice2HostArray<stdgpu::index_t>(inserted, N);
     stdgpu::index_t number_inserted =
@@ -1555,7 +1565,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_one_free
     test_unordered_datastructure::key_type* positions =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-    stdgpu::for_each_index(thrust::device, N, insert_keys(tiny_hash_datastructure, positions, inserted));
+    stdgpu::for_each_index(stdgpu::execution::device, N, insert_keys(tiny_hash_datastructure, positions, inserted));
 
     stdgpu::index_t* host_inserted = copyCreateDevice2HostArray<stdgpu::index_t>(inserted, N);
     stdgpu::index_t number_inserted =
@@ -1596,7 +1606,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_excess_e
     test_unordered_datastructure::key_type* positions =
             createDeviceArray<test_unordered_datastructure::key_type>(N, position_3);
 
-    stdgpu::for_each_index(thrust::device, N, insert_keys(tiny_hash_datastructure, positions, inserted));
+    stdgpu::for_each_index(stdgpu::execution::device, N, insert_keys(tiny_hash_datastructure, positions, inserted));
 
     stdgpu::index_t* host_inserted = copyCreateDevice2HostArray<stdgpu::index_t>(inserted, N);
     stdgpu::index_t number_inserted =
@@ -1649,7 +1659,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, emplace_parallel_while_one_fre
     test_unordered_datastructure::key_type* positions =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-    stdgpu::for_each_index(thrust::device, N, emplace_keys(tiny_hash_datastructure, positions, inserted));
+    stdgpu::for_each_index(stdgpu::execution::device, N, emplace_keys(tiny_hash_datastructure, positions, inserted));
 
     stdgpu::index_t* host_inserted = copyCreateDevice2HostArray<stdgpu::index_t>(inserted, N);
     stdgpu::index_t number_inserted =
@@ -1690,7 +1700,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, emplace_parallel_while_excess_
     test_unordered_datastructure::key_type* positions =
             createDeviceArray<test_unordered_datastructure::key_type>(N, position_3);
 
-    stdgpu::for_each_index(thrust::device, N, emplace_keys(tiny_hash_datastructure, positions, inserted));
+    stdgpu::for_each_index(stdgpu::execution::device, N, emplace_keys(tiny_hash_datastructure, positions, inserted));
 
     stdgpu::index_t* host_inserted = copyCreateDevice2HostArray<stdgpu::index_t>(inserted, N);
     stdgpu::index_t number_inserted =
@@ -1745,7 +1755,7 @@ insert_unique_parallel(test_unordered_datastructure& hash_datastructure, const s
     test_unordered_datastructure::key_type* positions =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-    stdgpu::for_each_index(thrust::device, N, insert_keys(hash_datastructure, positions, inserted));
+    stdgpu::for_each_index(stdgpu::execution::device, N, insert_keys(hash_datastructure, positions, inserted));
 
     stdgpu::index_t* host_inserted = copyCreateDevice2HostArray<stdgpu::index_t>(inserted, N);
     stdgpu::index_t number_inserted =
@@ -1772,7 +1782,7 @@ emplace_unique_parallel(test_unordered_datastructure& hash_datastructure, const 
     test_unordered_datastructure::key_type* positions =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-    stdgpu::for_each_index(thrust::device, N, emplace_keys(hash_datastructure, positions, inserted));
+    stdgpu::for_each_index(stdgpu::execution::device, N, emplace_keys(hash_datastructure, positions, inserted));
 
     stdgpu::index_t* host_inserted = copyCreateDevice2HostArray<stdgpu::index_t>(inserted, N);
     stdgpu::index_t number_inserted =
@@ -1799,7 +1809,7 @@ erase_unique_parallel(test_unordered_datastructure& hash_datastructure,
     test_unordered_datastructure::key_type* positions =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-    stdgpu::for_each_index(thrust::device, N, erase_keys(hash_datastructure, positions, erased));
+    stdgpu::for_each_index(stdgpu::execution::device, N, erase_keys(hash_datastructure, positions, erased));
 
     stdgpu::index_t* host_erased = copyCreateDevice2HostArray<stdgpu::index_t>(erased, N);
     stdgpu::index_t number_erased =
@@ -1881,7 +1891,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_range_unique_parallel)
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
     test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
 
-    stdgpu::for_each_index(thrust::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
 
     stdgpu::device_ptr<test_unordered_datastructure::value_type> values_begin = stdgpu::device_begin(values);
     stdgpu::device_ptr<test_unordered_datastructure::value_type> values_end = stdgpu::device_end(values);
@@ -1905,7 +1915,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_const_range_unique_para
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
     test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
 
-    stdgpu::for_each_index(thrust::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
 
     stdgpu::device_ptr<const test_unordered_datastructure::value_type> values_begin = stdgpu::device_cbegin(values);
     stdgpu::device_ptr<const test_unordered_datastructure::value_type> values_end = stdgpu::device_cend(values);
@@ -1929,7 +1939,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_range_unique_parallel)
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
     test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
 
-    stdgpu::for_each_index(thrust::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
 
     stdgpu::device_ptr<test_unordered_datastructure::value_type> values_begin = stdgpu::device_begin(values);
     stdgpu::device_ptr<test_unordered_datastructure::value_type> values_end = stdgpu::device_end(values);
@@ -1961,7 +1971,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_const_range_unique_paral
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
     test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
 
-    stdgpu::for_each_index(thrust::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
 
     stdgpu::device_ptr<const test_unordered_datastructure::value_type> values_begin = stdgpu::device_cbegin(values);
     stdgpu::device_ptr<const test_unordered_datastructure::value_type> values_end = stdgpu::device_cend(values);
@@ -2032,7 +2042,9 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_and_erase_unique_parall
     test_unordered_datastructure::key_type* positions =
             copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
 
-    stdgpu::for_each_index(thrust::device, N, insert_and_erase_keys(hash_datastructure, positions, inserted, erased));
+    stdgpu::for_each_index(stdgpu::execution::device,
+                           N,
+                           insert_and_erase_keys(hash_datastructure, positions, inserted, erased));
 
     stdgpu::index_t* host_inserted = copyCreateDevice2HostArray<stdgpu::index_t>(inserted, N);
     stdgpu::index_t number_inserted =
@@ -2138,7 +2150,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_size_sum)
 
     stdgpu::index_t* bucket_sizes = createDeviceArray<stdgpu::index_t>(hash_datastructure.bucket_count());
 
-    stdgpu::for_each_index(thrust::device,
+    stdgpu::for_each_index(stdgpu::execution::device,
                            hash_datastructure.bucket_count(),
                            store_bucket_sizes(hash_datastructure, bucket_sizes));
 
@@ -2170,9 +2182,9 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, count_sum)
     stdgpu::index_t* counts = createDeviceArray<stdgpu::index_t>(N);
     stdgpu::index_t* transparent_counts = createDeviceArray<stdgpu::index_t>(N);
 
-    stdgpu::for_each_index(thrust::device, N, store_counts(hash_datastructure, positions, counts));
+    stdgpu::for_each_index(stdgpu::execution::device, N, store_counts(hash_datastructure, positions, counts));
 
-    stdgpu::for_each_index(thrust::device,
+    stdgpu::for_each_index(stdgpu::execution::device,
                            N,
                            transparent_store_counts(hash_datastructure, positions, transparent_counts));
 
@@ -2208,7 +2220,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_keys_same)
 
     auto range = hash_datastructure.device_range();
     // unordered_map's value_type cannot be copied using copy(), so use uninitialized_copy() instead
-    stdgpu::uninitialized_copy(thrust::device, range.begin(), range.end(), values);
+    stdgpu::uninitialized_copy(stdgpu::execution::device, range.begin(), range.end(), values);
 
     test_unordered_datastructure::value_type* host_values =
             copyCreateDevice2HostArray<test_unordered_datastructure::value_type>(values, N);

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -206,9 +206,9 @@ fill_vector(stdgpu::vector<int>& pool, const stdgpu::index_t N)
     ASSERT_LE(N, pool.capacity());
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, push_back_vector<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_vector<int>(pool, values));
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -280,7 +280,7 @@ TEST_F(stdgpu_vector, pop_back_some)
 
     fill_vector(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_vector<int>(pool));
 
     ASSERT_EQ(pool.size(), N_remaining);
     ASSERT_FALSE(pool.empty());
@@ -306,7 +306,7 @@ TEST_F(stdgpu_vector, pop_back_all)
 
     fill_vector(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_vector<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -325,7 +325,7 @@ TEST_F(stdgpu_vector, pop_back_too_many)
 
     fill_vector(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_vector<int>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -344,17 +344,17 @@ TEST_F(stdgpu_vector, pop_back_const_type)
     stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
     const float part_second = 2.0F;
-    stdgpu::for_each_index(thrust::device, N, push_back_vector_const_type<T>(pool, values, part_second));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_vector_const_type<T>(pool, values, part_second));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    stdgpu::for_each_index(thrust::device, N, pop_back_vector_const_type<T>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N, pop_back_vector_const_type<T>(pool));
 
     EXPECT_EQ(pool.size(), 0);
     EXPECT_TRUE(pool.empty());
@@ -372,16 +372,16 @@ TEST_F(stdgpu_vector, pop_back_nondefault_type)
     stdgpu::vector<nondefault_int_vector> pool = stdgpu::vector<nondefault_int_vector>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, push_back_vector<nondefault_int_vector, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_vector<nondefault_int_vector, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
     ASSERT_TRUE(pool.full());
     ASSERT_TRUE(pool.valid());
 
-    stdgpu::for_each_index(thrust::device, N, pop_back_vector<nondefault_int_vector>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N, pop_back_vector<nondefault_int_vector>(pool));
 
     ASSERT_EQ(pool.size(), 0);
     ASSERT_TRUE(pool.empty());
@@ -403,12 +403,12 @@ TEST_F(stdgpu_vector, push_back_some)
 
     fill_vector(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_vector<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
 
-    stdgpu::for_each_index(thrust::device, N_push, push_back_vector<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, push_back_vector<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -438,12 +438,12 @@ TEST_F(stdgpu_vector, push_back_all)
 
     fill_vector(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_vector<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, push_back_vector<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, push_back_vector<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -473,12 +473,12 @@ TEST_F(stdgpu_vector, push_back_too_many)
 
     fill_vector(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_vector<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, push_back_vector<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, push_back_vector<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -507,10 +507,10 @@ TEST_F(stdgpu_vector, push_back_const_type)
     stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
     const float part_second = 2.0F;
-    stdgpu::for_each_index(thrust::device, N, push_back_vector_const_type<T>(pool, values, part_second));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_vector_const_type<T>(pool, values, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -528,9 +528,9 @@ TEST_F(stdgpu_vector, push_back_nondefault_type)
     stdgpu::vector<nondefault_int_vector> pool = stdgpu::vector<nondefault_int_vector>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, push_back_vector<nondefault_int_vector, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_vector<nondefault_int_vector, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -552,12 +552,12 @@ TEST_F(stdgpu_vector, emplace_back_some)
 
     fill_vector(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_vector<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
 
-    stdgpu::for_each_index(thrust::device, N_push, push_back_vector<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, push_back_vector<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -587,12 +587,12 @@ TEST_F(stdgpu_vector, emplace_back_all)
 
     fill_vector(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_vector<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, emplace_back_vector<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, emplace_back_vector<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -622,12 +622,12 @@ TEST_F(stdgpu_vector, emplace_back_too_many)
 
     fill_vector(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_vector<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N_push, emplace_back_vector<int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N_push, emplace_back_vector<int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -656,10 +656,10 @@ TEST_F(stdgpu_vector, emplace_back_const_type)
     stdgpu::vector<T> pool = stdgpu::vector<T>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
     const float part_second = 2.0F;
-    stdgpu::for_each_index(thrust::device, N, emplace_back_vector_const_type<T>(pool, values, part_second));
+    stdgpu::for_each_index(stdgpu::execution::device, N, emplace_back_vector_const_type<T>(pool, values, part_second));
 
     EXPECT_EQ(pool.size(), N);
     EXPECT_FALSE(pool.empty());
@@ -677,9 +677,9 @@ TEST_F(stdgpu_vector, emplace_back_nondefault_type)
     stdgpu::vector<nondefault_int_vector> pool = stdgpu::vector<nondefault_int_vector>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, emplace_back_vector<nondefault_int_vector, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, emplace_back_vector<nondefault_int_vector, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -701,7 +701,7 @@ TEST_F(stdgpu_vector, insert)
     fill_vector(pool, N_init);
 
     int* values = createDeviceArray<int>(N_insert);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), N_init + 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), N_init + 1);
 
     pool.insert(pool.device_end(), stdgpu::device_begin(values), stdgpu::device_end(values));
 
@@ -732,7 +732,7 @@ TEST_F(stdgpu_vector, insert_non_end)
     fill_vector(pool, N_init);
 
     int* values = createDeviceArray<int>(N_insert);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), N_init + 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), N_init + 1);
 
     pool.insert(pool.device_end() - 1, stdgpu::device_begin(values), stdgpu::device_end(values));
 
@@ -756,7 +756,7 @@ TEST_F(stdgpu_vector, insert_too_many)
     fill_vector(pool, N_init);
 
     int* values = createDeviceArray<int>(N_insert);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), N_init + 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), N_init + 1);
 
     pool.insert(pool.device_end(), stdgpu::device_begin(values), stdgpu::device_end(values));
 
@@ -861,9 +861,9 @@ TEST_F(stdgpu_vector, clear_nondefault_type)
     stdgpu::vector<nondefault_int_vector> pool = stdgpu::vector<nondefault_int_vector>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device, N, push_back_vector<nondefault_int_vector, int>(pool, values));
+    stdgpu::for_each_index(stdgpu::execution::device, N, push_back_vector<nondefault_int_vector, int>(pool, values));
 
     ASSERT_EQ(pool.size(), N);
     ASSERT_FALSE(pool.empty());
@@ -921,9 +921,9 @@ TEST_F(stdgpu_vector, simultaneous_push_back_and_pop_back)
     stdgpu::vector<int> pool_validation = stdgpu::vector<int>::createDeviceObject(N);
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(thrust::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1);
 
-    stdgpu::for_each_index(thrust::device,
+    stdgpu::for_each_index(stdgpu::execution::device,
                            N,
                            simultaneous_push_back_and_pop_back_vector<int>(pool, pool_validation, values));
 
@@ -978,7 +978,7 @@ TEST_F(stdgpu_vector, at_non_const)
 
     fill_vector(pool);
 
-    stdgpu::for_each_index(thrust::device, N, at_non_const_vector(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N, at_non_const_vector(pool));
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1017,7 +1017,7 @@ TEST_F(stdgpu_vector, access_operator_non_const)
 
     fill_vector(pool);
 
-    stdgpu::for_each_index(thrust::device, N, access_operator_non_const_vector(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N, access_operator_non_const_vector(pool));
 
     int* host_numbers = copyCreateDevice2HostArray(pool.data(), N);
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1079,7 +1079,7 @@ TEST_F(stdgpu_vector, shrink_to_fit)
 
     fill_vector(pool);
 
-    stdgpu::for_each_index(thrust::device, N_pop, pop_back_vector<int>(pool));
+    stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_vector<int>(pool));
 
     ASSERT_EQ(pool.size(), N_remaining);
     ASSERT_EQ(pool.capacity(), N);
@@ -1144,7 +1144,7 @@ non_const_front(const stdgpu::vector<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, non_const_front_functor<T>(pool, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_front_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1160,7 +1160,7 @@ const_front(const stdgpu::vector<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, const_front_functor<T>(pool, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, const_front_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1230,7 +1230,7 @@ non_const_back(const stdgpu::vector<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, non_const_back_functor<T>(pool, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_back_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1246,7 +1246,7 @@ const_back(const stdgpu::vector<T>& pool)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, const_back_functor<T>(pool, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, const_back_functor<T>(pool, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1320,7 +1320,7 @@ non_const_operator_access(const stdgpu::vector<T>& pool, const stdgpu::index_t i
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, non_const_operator_access_functor<T>(pool, i, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_operator_access_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1336,7 +1336,7 @@ const_operator_access(const stdgpu::vector<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, const_operator_access_functor<T>(pool, i, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, const_operator_access_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1410,7 +1410,7 @@ non_const_at(const stdgpu::vector<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, non_const_at_functor<T>(pool, i, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_at_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1426,7 +1426,7 @@ const_at(const stdgpu::vector<T>& pool, const stdgpu::index_t i)
 {
     T* result = createDeviceArray<T>(1);
 
-    stdgpu::for_each_index(thrust::device, 1, const_at_functor<T>(pool, i, result));
+    stdgpu::for_each_index(stdgpu::execution::device, 1, const_at_functor<T>(pool, i, result));
 
     T host_result;
     copyDevice2HostArray<T>(result, 1, &host_result, MemoryCopy::NO_CHECK);
@@ -1602,7 +1602,7 @@ TEST_F(stdgpu_vector, non_const_device_range)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = pool.device_range();
-    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(stdgpu::execution::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
@@ -1632,7 +1632,7 @@ TEST_F(stdgpu_vector, const_device_range)
     int* numbers = createDeviceArray<int>(N);
 
     auto range = static_cast<const stdgpu::vector<int>&>(pool).device_range();
-    stdgpu::copy(thrust::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
+    stdgpu::copy(stdgpu::execution::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());


### PR DESCRIPTION
After all algorithms have been ported to the two basic building blocks `for_each_index` and `transform_reduce_index` which all now require execution policies, the only remaining widespread `thrust` functionality are the policies themselves. Add aliases for the `device` and `host` policies in the new `execution` header following the C++ standard as close as possible. In the future, a more powerful abstraction with more fine-grained control around these centralized objects could be investigated.

Partially addresses #279