### PR TITLE
mutex: Improve performance of valid function

### DIFF
--- a/src/stdgpu/impl/mutex_detail.cuh
+++ b/src/stdgpu/impl/mutex_detail.cuh
@@ -17,8 +17,6 @@
 #define STDGPU_MUTEX_DETAIL_H
 
 #include <stdgpu/contract.h>
-#include <stdgpu/functional.h>
-#include <stdgpu/numeric.h>
 
 namespace stdgpu
 {
@@ -114,44 +112,11 @@ mutex_array<Block, Allocator>::size() const
     return _lock_bits.size();
 }
 
-namespace detail
-{
-
-template <typename Block, typename Allocator>
-class unlocked
-{
-public:
-    inline explicit unlocked(const mutex_array<Block, Allocator>& lock_bits)
-      : _lock_bits(lock_bits)
-    {
-    }
-
-    inline STDGPU_DEVICE_ONLY bool
-    operator()(const index_t i) const
-    {
-        return !(_lock_bits[i].locked());
-    }
-
-private:
-    mutex_array<Block, Allocator> _lock_bits;
-};
-
-} // namespace detail
-
 template <typename Block, typename Allocator>
 inline bool
 mutex_array<Block, Allocator>::valid() const
 {
-    if (empty())
-    {
-        return true;
-    }
-
-    return transform_reduce_index(execution::device,
-                                  size(),
-                                  true,
-                                  logical_and<>(),
-                                  detail::unlocked<Block, Allocator>(*this));
+    return _lock_bits.count() == 0;
 }
 
 namespace detail


### PR DESCRIPTION
The `valid()` function of `mutex_array` tests each bit individually and performs a reduction to check if all mutexes are unlocked. Use the `count()` function of `bitset` instead to simplify the code. This also significantly improves the performance for large container sizes due to the more efficient reduction of the bits in `bitset`.

Before:
```
----------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations
----------------------------------------------------------------------
stdgpu_mutex_valid/1000          0.027 ms        0.027 ms        25450
stdgpu_mutex_valid/100000        0.051 ms        0.051 ms        12299
stdgpu_mutex_valid/10000000      0.695 ms        0.694 ms          991
```

After:
```
----------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations
----------------------------------------------------------------------
stdgpu_mutex_valid/1000          0.049 ms        0.049 ms        13793
stdgpu_mutex_valid/100000        0.050 ms        0.050 ms        13565
stdgpu_mutex_valid/10000000      0.302 ms        0.301 ms         2316
```