### PR TITLE
General: Bump required standard to C++17

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@
 Language:        Cpp
 BasedOnStyle:  Mozilla
 # Only modifications deviating from the base style are specified
-Standard: c++14
+Standard: c++17
 AccessModifierOffset: -4
 AllowAllArgumentsOnNextLine: false
 AllowAllConstructorInitializersOnNextLine: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.23)
+cmake_minimum_required(VERSION 3.18...3.23)
 message(STATUS "Configuring with CMake ${CMAKE_VERSION}")
 
 

--- a/README.md
+++ b/README.md
@@ -177,18 +177,18 @@ Before building the library, please make sure that all required tools and depend
 
 <b>Required</b>
 
-- C++14 compiler
-    - GCC 7
-        - (Ubuntu 18.04/20.04) `sudo apt install g++ make`
-    - Clang 6
-        - (Ubuntu 18.04/20.04) `sudo apt install clang make`
+- C++17 compiler
+    - GCC 9
+        - (Ubuntu 20.04/22.04) `sudo apt install g++`
+    - Clang 10
+        - (Ubuntu 20.04/22.04) `sudo apt install clang`
     - MSVC 19.20
         - (Windows) Visual Studio 2019 https://visualstudio.microsoft.com/downloads/
-- CMake 3.15
-    - (Ubuntu 18.04) https://apt.kitware.com
-    - (Ubuntu 20.04) `sudo apt install cmake`
+- CMake 3.18
+    - (Ubuntu 20.04) https://apt.kitware.com
+    - (Ubuntu 22.04) `sudo apt install cmake`
     - (Windows) https://cmake.org/download
-- thrust 1.9.2
+- thrust 1.9.9
     - (Ubuntu/Windows) https://github.com/NVIDIA/thrust
     - May already be installed by backend dependencies
 
@@ -198,19 +198,18 @@ Before building the library, please make sure that all required tools and depend
     - NVCC
         - Already included in CUDA Toolkit
     - Clang 10
-        - (Ubuntu 18.04/20.04) `sudo apt install clang-10` or https://apt.llvm.org/
-        - Requires at least CMake 3.18
-- CUDA Toolkit 10.0
+        - (Ubuntu 20.04/22.04) `sudo apt install clang`
+- CUDA Toolkit 11.0
     - (Ubuntu/Windows) https://developer.nvidia.com/cuda-downloads
     - Includes thrust
 
 <b>Required for OpenMP backend</b>
 
 - OpenMP 2.0
-    - GCC 7
-        - (Ubuntu 18.04/20.04) Already installed
-    - Clang 6
-        - (Ubuntu 18.04/20.04) `sudo apt install libomp-dev`
+    - GCC 9
+        - (Ubuntu 20.04/22.04) Already installed
+    - Clang 10
+        - (Ubuntu 20.04/22.04) `sudo apt install libomp-dev`
     - MSVC 19.20
         - (Windows) Already installed
 
@@ -220,7 +219,8 @@ Before building the library, please make sure that all required tools and depend
     - (Ubuntu) https://github.com/RadeonOpenCompute/ROCm
     - Includes thrust
 - CMake 3.21.3
-    - (Ubuntu 18.04/20.04) https://apt.kitware.com
+    - (Ubuntu 20.04) https://apt.kitware.com
+    - (Ubuntu 22.04) `sudo apt install cmake`
     - (Windows) https://cmake.org/download
     - Required for first-class HIP language support
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -5,7 +5,7 @@ The following set of guidelines will help you to make your changes conformant wi
 
 ## Coding Style
 
-We use **C++14** throughout the project. Functionality from more recent C++ standards may break compatibility with some of the supported compilers and will be rejected.
+We use **C++17** throughout the project. Functionality from more recent C++ standards may break compatibility with some of the supported compilers and will be rejected.
 
 The source code is formatted according to a modified version of the Mozilla style guide that is specified in `.clang-format` and enforced by version **10** of `clang-format`. In order to automatically apply these rules to the source code, we provide the CMake targets `check_code_style` and `apply_code_style` as well as respective helper scripts:
 

--- a/doc/stdgpu/index.doxy
+++ b/doc/stdgpu/index.doxy
@@ -126,18 +126,18 @@ Before building the library, please make sure that all required tools and depend
 
 <b>Required</b>
 
-- C++14 compiler
-    - GCC 7
-        - (Ubuntu 18.04/20.04) `sudo apt install g++ make`
-    - Clang 6
-        - (Ubuntu 18.04/20.04) `sudo apt install clang make`
+- C++17 compiler
+    - GCC 9
+        - (Ubuntu 20.04/22.04) `sudo apt install g++`
+    - Clang 10
+        - (Ubuntu 20.04/22.04) `sudo apt install clang`
     - MSVC 19.20
         - (Windows) Visual Studio 2019 https://visualstudio.microsoft.com/downloads/
-- CMake 3.15
-    - (Ubuntu 18.04) https://apt.kitware.com
-    - (Ubuntu 20.04) `sudo apt install cmake`
+- CMake 3.18
+    - (Ubuntu 20.04) https://apt.kitware.com
+    - (Ubuntu 22.04) `sudo apt install cmake`
     - (Windows) https://cmake.org/download
-- thrust 1.9.2
+- thrust 1.9.9
     - (Ubuntu/Windows) https://github.com/NVIDIA/thrust
     - May already be installed by backend dependencies
 
@@ -147,19 +147,18 @@ Before building the library, please make sure that all required tools and depend
     - NVCC
         - Already included in CUDA Toolkit
     - Clang 10
-        - (Ubuntu 18.04/20.04) `sudo apt install clang-10` or https://apt.llvm.org/
-        - Requires at least CMake 3.18
-- CUDA Toolkit 10.0
+        - (Ubuntu 20.04/22.04) `sudo apt install clang`
+- CUDA Toolkit 11.0
     - (Ubuntu/Windows) https://developer.nvidia.com/cuda-downloads
     - Includes thrust
 
 <b>Required for OpenMP backend</b>
 
 - OpenMP 2.0
-    - GCC 7
-        - (Ubuntu 18.04/20.04) Already installed
-    - Clang 6
-        - (Ubuntu 18.04/20.04) `sudo apt install libomp-dev`
+    - GCC 9
+        - (Ubuntu 20.04/22.04) Already installed
+    - Clang 10
+        - (Ubuntu 20.04/22.04) `sudo apt install libomp-dev`
     - MSVC 19.20
         - (Windows) Already installed
 
@@ -169,7 +168,8 @@ Before building the library, please make sure that all required tools and depend
     - (Ubuntu) https://github.com/RadeonOpenCompute/ROCm
     - Includes thrust
 - CMake 3.21.3
-    - (Ubuntu 18.04/20.04) https://apt.kitware.com
+    - (Ubuntu 20.04) https://apt.kitware.com
+    - (Ubuntu 22.04) `sudo apt install cmake`
     - (Windows) https://cmake.org/download
     - Required for first-class HIP language support
 

--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(stdgpu PUBLIC
                                   $<BUILD_INTERFACE:${STDGPU_BUILD_INCLUDE_DIR}>
                                   $<INSTALL_INTERFACE:${STDGPU_INCLUDE_INSTALL_DIR}>)
 
-target_compile_features(stdgpu PUBLIC cxx_std_14)
+target_compile_features(stdgpu PUBLIC cxx_std_17)
 
 target_compile_options(stdgpu PRIVATE ${STDGPU_DEVICE_FLAGS}
                                       ${STDGPU_HOST_FLAGS})

--- a/src/stdgpu/cuda/CMakeLists.txt
+++ b/src/stdgpu/cuda/CMakeLists.txt
@@ -9,7 +9,7 @@ target_sources(stdgpu PRIVATE impl/device.cpp
                               impl/memory.cpp)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-    target_compile_features(stdgpu PUBLIC cuda_std_14)
+    target_compile_features(stdgpu PUBLIC cuda_std_17)
 endif()
 
 target_compile_definitions(stdgpu PUBLIC THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA)

--- a/src/stdgpu/hip/CMakeLists.txt
+++ b/src/stdgpu/hip/CMakeLists.txt
@@ -18,7 +18,7 @@ find_dependency(hip 5.1 REQUIRED)
 target_sources(stdgpu PRIVATE impl/device.cpp
                               impl/memory.cpp)
 
-target_compile_features(stdgpu PUBLIC hip_std_14)
+target_compile_features(stdgpu PUBLIC hip_std_17)
 
 target_compile_definitions(stdgpu PUBLIC THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP)
 


### PR DESCRIPTION
C++17 has been out for quite a long time and support in all relevant compilers has matured sufficiently until now. Thus, bump the requirements of building stdgpu from C++14 to C++17. This unblocks several features and cleanups.

Issue: #314 