### PR TITLE
cmake: Explicitly list and process headers

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -56,6 +56,11 @@ jobs:
         run: |
           bash scripts/run_tests.sh ${{ matrix.BuildType }}
 
+      - name: Verify headers
+        shell: bash
+        run: |
+          bash scripts/utils/verify_headers.sh
+
       - name: Install project
         shell: bash
         run: |
@@ -117,6 +122,11 @@ jobs:
         shell: bash
         run: |
           bash scripts/run_tests.sh ${{ matrix.BuildType }}
+
+      - name: Verify headers
+        shell: bash
+        run: |
+          bash scripts/utils/verify_headers.sh
 
       - name: Install project
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,6 +40,11 @@ jobs:
         run: |
           bash scripts/run_tests.sh ${{ matrix.BuildType }}
 
+      - name: Verify headers
+        shell: bash
+        run: |
+          bash scripts/utils/verify_headers.sh
+
       - name: Install project
         shell: bash
         run: |
@@ -85,6 +90,11 @@ jobs:
         shell: bash
         run: |
           bash scripts/run_tests.sh ${{ matrix.BuildType }}
+
+      - name: Verify headers
+        shell: bash
+        run: |
+          bash scripts/utils/verify_headers.sh
 
       - name: Install project
         shell: bash

--- a/cmake/config_summary.cmake
+++ b/cmake/config_summary.cmake
@@ -39,6 +39,13 @@ function(stdgpu_print_configuration_summary)
     message(STATUS "Tests:")
     message(STATUS "  STDGPU_BUILD_TESTS                        :   ${STDGPU_BUILD_TESTS}")
     message(STATUS "  STDGPU_BUILD_TEST_COVERAGE                :   ${STDGPU_BUILD_TEST_COVERAGE}")
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+        if(DEFINED CMAKE_VERIFY_INTERFACE_HEADER_SETS)
+            message(STATUS "  CMAKE_VERIFY_INTERFACE_HEADER_SETS        :   ${CMAKE_VERIFY_INTERFACE_HEADER_SETS}")
+        else()
+            message(STATUS "  CMAKE_VERIFY_INTERFACE_HEADER_SETS        :   <Not Defined> (-> OFF)")
+        endif()
+    endif()
 
     message(STATUS "")
 

--- a/scripts/ci/configure_cuda.sh
+++ b/scripts/ci/configure_cuda.sh
@@ -12,4 +12,4 @@ fi
 sh scripts/utils/create_empty_directory.sh build
 
 # Configure project
-sh scripts/utils/configure.sh $CONFIG -DSTDGPU_BACKEND=STDGPU_BACKEND_CUDA -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON $@
+sh scripts/utils/configure.sh $CONFIG -DSTDGPU_BACKEND=STDGPU_BACKEND_CUDA -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_VERIFY_INTERFACE_HEADER_SETS=ON $@

--- a/scripts/ci/configure_hip.sh
+++ b/scripts/ci/configure_hip.sh
@@ -12,4 +12,4 @@ fi
 sh scripts/utils/create_empty_directory.sh build
 
 # Configure project
-sh scripts/utils/configure.sh $CONFIG -DSTDGPU_BACKEND=STDGPU_BACKEND_HIP -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON $@
+sh scripts/utils/configure.sh $CONFIG -DSTDGPU_BACKEND=STDGPU_BACKEND_HIP -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_VERIFY_INTERFACE_HEADER_SETS=ON $@

--- a/scripts/ci/configure_openmp.sh
+++ b/scripts/ci/configure_openmp.sh
@@ -12,4 +12,4 @@ fi
 sh scripts/utils/create_empty_directory.sh build
 
 # Configure project
-sh scripts/utils/configure.sh $CONFIG -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/thrust $@
+sh scripts/utils/configure.sh $CONFIG -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/thrust -DCMAKE_VERIFY_INTERFACE_HEADER_SETS=ON $@

--- a/scripts/utils/verify_headers.sh
+++ b/scripts/utils/verify_headers.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# Verify headers
+cmake -E cmake_echo_color --blue ">>>>> Verify headers"
+cmake --build build --target stdgpu_verify_interface_header_sets

--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -37,10 +37,106 @@ target_sources(stdgpu PRIVATE impl/device.cpp
                               impl/memory.cpp
                               impl/limits.cpp)
 
-target_include_directories(stdgpu PUBLIC
-                                  $<BUILD_INTERFACE:${STDGPU_INCLUDE_LOCAL_DIR}>
-                                  $<BUILD_INTERFACE:${STDGPU_BUILD_INCLUDE_DIR}>
-                                  $<INSTALL_INTERFACE:${STDGPU_INCLUDE_INSTALL_DIR}>)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
+    target_sources(stdgpu PUBLIC FILE_SET stdgpu_headers
+                                 TYPE HEADERS
+                                 BASE_DIRS ${STDGPU_INCLUDE_LOCAL_DIR}
+                                 FILES algorithm.h
+                                       atomic.cuh
+                                       atomic_fwd
+                                       attribute.h
+                                       bit.h
+                                       bitset.cuh
+                                       bitset_fwd
+                                       cmath.h
+                                       compiler.h
+                                       contract.h
+                                       cstddef.h
+                                       deque.cuh
+                                       deque_fwd
+                                       device.h
+                                       execution.h
+                                       functional.h
+                                       iterator.h
+                                       limits.h
+                                       memory.h
+                                       mutex.cuh
+                                       mutex_fwd
+                                       numeric.h
+                                       platform.h
+                                       queue.cuh
+                                       queue_fwd
+                                       ranges.h
+                                       stack.cuh
+                                       stack_fwd
+                                       unordered_map.cuh
+                                       unordered_map_fwd
+                                       unordered_set.cuh
+                                       unordered_set_fwd
+                                       utility.h
+                                       vector.cuh
+                                       vector_fwd)
+
+    target_sources(stdgpu PUBLIC FILE_SET stdgpu_header_implementations
+                                 TYPE HEADERS
+                                 BASE_DIRS ${STDGPU_INCLUDE_LOCAL_DIR}
+                                 FILES impl/algorithm_detail.h
+                                       impl/atomic_detail.cuh
+                                       impl/bit_detail.h
+                                       impl/bitset_detail.cuh
+                                       impl/cmath_detail.h
+                                       impl/deque_detail.cuh
+                                       impl/functional_detail.h
+                                       impl/iterator_detail.h
+                                       impl/limits_detail.h
+                                       impl/memory_detail.h
+                                       impl/mutex_detail.cuh
+                                       impl/numeric_detail.h
+                                       impl/platform_check.h
+                                       impl/queue_detail.cuh
+                                       impl/ranges_detail.h
+                                       impl/stack_detail.cuh
+                                       impl/type_traits.h
+                                       impl/unordered_base.cuh
+                                       impl/unordered_base_detail.cuh
+                                       impl/unordered_map_detail.cuh
+                                       impl/unordered_set_detail.cuh
+                                       impl/utility_detail.h
+                                       impl/vector_detail.cuh)
+
+    target_sources(stdgpu PUBLIC FILE_SET stdgpu_config_header
+                                 TYPE HEADERS
+                                 BASE_DIRS ${STDGPU_BUILD_INCLUDE_DIR}
+                                 FILES "${STDGPU_BUILD_INCLUDE_DIR}/stdgpu/config.h")
+else()
+    target_include_directories(stdgpu PUBLIC
+                                      $<BUILD_INTERFACE:${STDGPU_INCLUDE_LOCAL_DIR}>
+                                      $<BUILD_INTERFACE:${STDGPU_BUILD_INCLUDE_DIR}>)
+endif()
+
+# Still required as the interface header file sets are *conditionally* enabled for clients based on *their* CMake version
+target_include_directories(stdgpu PUBLIC $<INSTALL_INTERFACE:${STDGPU_INCLUDE_INSTALL_DIR}>)
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+    set_target_properties(stdgpu PROPERTIES INTERFACE_HEADER_SETS_TO_VERIFY stdgpu_headers)
+
+    # Manually specify the correct compile language for all headers that must be compiled by the device compiler
+    set(STDGPU_DEVICE_HEADERS atomic.cuh
+                              bitset.cuh
+                              deque.cuh
+                              mutex.cuh
+                              queue.cuh
+                              stack.cuh
+                              unordered_map.cuh
+                              unordered_set.cuh
+                              vector.cuh)
+
+    if(STDGPU_BACKEND STREQUAL STDGPU_BACKEND_CUDA)
+        set_source_files_properties(${STDGPU_DEVICE_HEADERS} PROPERTIES LANGUAGE CUDA)
+    elseif(STDGPU_BACKEND STREQUAL STDGPU_BACKEND_HIP)
+        set_source_files_properties(${STDGPU_DEVICE_HEADERS} PROPERTIES LANGUAGE HIP)
+    endif()
+endif()
 
 target_compile_features(stdgpu PUBLIC cxx_std_17)
 
@@ -62,18 +158,31 @@ add_subdirectory(${STDGPU_BACKEND_DIRECTORY})
 
 
 # Export targets and install header files
-install(TARGETS stdgpu
-        EXPORT stdgpu-targets
-        DESTINATION "${STDGPU_LIB_INSTALL_DIR}"
-        COMPONENT stdgpu)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
+    install(TARGETS stdgpu
+            EXPORT stdgpu-targets
+            ARCHIVE DESTINATION "${STDGPU_LIB_INSTALL_DIR}"
+            LIBRARY DESTINATION "${STDGPU_LIB_INSTALL_DIR}"
+            FILE_SET stdgpu_headers DESTINATION "${STDGPU_INCLUDE_INSTALL_DIR}"
+            FILE_SET stdgpu_header_implementations DESTINATION "${STDGPU_INCLUDE_INSTALL_DIR}"
+            FILE_SET stdgpu_config_header DESTINATION "${STDGPU_INCLUDE_INSTALL_DIR}"
+            FILE_SET stdgpu_backend_headers DESTINATION "${STDGPU_INCLUDE_INSTALL_DIR}"
+            FILE_SET stdgpu_backend_header_implementations DESTINATION "${STDGPU_INCLUDE_INSTALL_DIR}"
+            COMPONENT stdgpu)
+else()
+    install(TARGETS stdgpu
+            EXPORT stdgpu-targets
+            DESTINATION "${STDGPU_LIB_INSTALL_DIR}"
+            COMPONENT stdgpu)
 
-install(DIRECTORY "${STDGPU_INCLUDE_LOCAL_DIR}/" "${STDGPU_BUILD_INCLUDE_DIR}/"
-        DESTINATION "${STDGPU_INCLUDE_INSTALL_DIR}"
-        COMPONENT stdgpu
-        FILES_MATCHING
-        PATTERN "*.h"
-        PATTERN "*.cuh"
-        PATTERN "*_fwd")
+    install(DIRECTORY "${STDGPU_INCLUDE_LOCAL_DIR}/" "${STDGPU_BUILD_INCLUDE_DIR}/"
+            DESTINATION "${STDGPU_INCLUDE_INSTALL_DIR}"
+            COMPONENT stdgpu
+            FILES_MATCHING
+            PATTERN "*.h"
+            PATTERN "*.cuh"
+            PATTERN "*_fwd")
+endif()
 
 # Install dependencies file and custom thrust module
 configure_file("${stdgpu_SOURCE_DIR}/cmake/stdgpu-dependencies.cmake.in"

--- a/src/stdgpu/cuda/CMakeLists.txt
+++ b/src/stdgpu/cuda/CMakeLists.txt
@@ -8,6 +8,22 @@ find_dependency(CUDAToolkit 11.0 REQUIRED MODULE)
 target_sources(stdgpu PRIVATE impl/device.cpp
                               impl/memory.cpp)
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
+    target_sources(stdgpu PUBLIC FILE_SET stdgpu_backend_headers
+                                 TYPE HEADERS
+                                 BASE_DIRS ${STDGPU_INCLUDE_LOCAL_DIR}
+                                 FILES atomic.cuh
+                                       device.h
+                                       memory.h
+                                       platform.h
+                                       platform_check.h)
+
+    target_sources(stdgpu PUBLIC FILE_SET stdgpu_backend_header_implementations
+                                 TYPE HEADERS
+                                 BASE_DIRS ${STDGPU_INCLUDE_LOCAL_DIR}
+                                 FILES impl/atomic_detail.cuh)
+endif()
+
 target_compile_features(stdgpu PUBLIC cuda_std_17)
 
 target_compile_definitions(stdgpu PUBLIC THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA)

--- a/src/stdgpu/hip/CMakeLists.txt
+++ b/src/stdgpu/hip/CMakeLists.txt
@@ -18,6 +18,22 @@ find_dependency(hip 5.1 REQUIRED)
 target_sources(stdgpu PRIVATE impl/device.cpp
                               impl/memory.cpp)
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
+    target_sources(stdgpu PUBLIC FILE_SET stdgpu_backend_headers
+                                 TYPE HEADERS
+                                 BASE_DIRS ${STDGPU_INCLUDE_LOCAL_DIR}
+                                 FILES atomic.h
+                                       device.h
+                                       memory.h
+                                       platform.h
+                                       platform_check.h)
+
+    target_sources(stdgpu PUBLIC FILE_SET stdgpu_backend_header_implementations
+                                 TYPE HEADERS
+                                 BASE_DIRS ${STDGPU_INCLUDE_LOCAL_DIR}
+                                 FILES impl/atomic_detail.h)
+endif()
+
 target_compile_features(stdgpu PUBLIC hip_std_17)
 
 target_compile_definitions(stdgpu PUBLIC THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP)

--- a/src/stdgpu/openmp/CMakeLists.txt
+++ b/src/stdgpu/openmp/CMakeLists.txt
@@ -8,6 +8,22 @@ find_dependency(OpenMP 2.0 REQUIRED)
 target_sources(stdgpu PRIVATE impl/device.cpp
                               impl/memory.cpp)
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
+    target_sources(stdgpu PUBLIC FILE_SET stdgpu_backend_headers
+                                 TYPE HEADERS
+                                 BASE_DIRS ${STDGPU_INCLUDE_LOCAL_DIR}
+                                 FILES atomic.h
+                                       device.h
+                                       memory.h
+                                       platform.h
+                                       platform_check.h)
+
+    target_sources(stdgpu PUBLIC FILE_SET stdgpu_backend_header_implementations
+                                 TYPE HEADERS
+                                 BASE_DIRS ${STDGPU_INCLUDE_LOCAL_DIR}
+                                 FILES impl/atomic_detail.h)
+endif()
+
 target_compile_definitions(stdgpu PUBLIC THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_OMP)
 
 target_link_libraries(stdgpu PUBLIC OpenMP::OpenMP_CXX)


### PR DESCRIPTION
CMake 3.23 and 3.24 introduce functionality to properly handle header files and also perform automatic `#include` checks. Use this new approach - if available - and extend the CI checks to also cover header verification.

Note that this slightly changes the set of installed header to only include the **currently used**  backend rather than all header files. Since this single backend will only be functional anyways (due to the compiled sources), the new approach is in fact more consistent.