### PR TITLE
memory: Drop thrust synchronization workaround

### DIFF
--- a/src/stdgpu/cuda/impl/memory.cpp
+++ b/src/stdgpu/cuda/impl/memory.cpp
@@ -18,7 +18,6 @@
 #include <cstdio>
 #include <cuda_runtime_api.h> // Include after thrust to avoid redefinition warning for __host__ and __device__ in .cpp files
 #include <exception>
-#include <thrust/version.h>
 
 namespace stdgpu
 {
@@ -154,15 +153,6 @@ dispatch_memcpy(void* destination,
     }
 
     STDGPU_CUDA_SAFE_CALL(cudaMemcpy(destination, source, static_cast<std::size_t>(bytes), kind));
-}
-
-void
-workaround_synchronize_device_thrust()
-{
-// We need to synchronize the device before exiting the calling function
-#if THRUST_VERSION <= 100903 // CUDA 10.0 and below
-    STDGPU_CUDA_SAFE_CALL(cudaDeviceSynchronize());
-#endif
 }
 
 void

--- a/src/stdgpu/cuda/memory.h
+++ b/src/stdgpu/cuda/memory.h
@@ -57,12 +57,6 @@ dispatch_memcpy(void* destination,
                 dynamic_memory_type source_type);
 
 /**
- * \brief Workarounds a synchronization issue with older versions of thrust
- */
-void
-workaround_synchronize_device_thrust();
-
-/**
  * \brief Workarounds a synchronization issue with older GPUs
  */
 void

--- a/src/stdgpu/hip/impl/memory.cpp
+++ b/src/stdgpu/hip/impl/memory.cpp
@@ -18,7 +18,6 @@
 #include <cstdio>
 #include <exception>
 #include <hip/hip_runtime_api.h>
-#include <thrust/version.h>
 
 namespace stdgpu
 {
@@ -154,15 +153,6 @@ dispatch_memcpy(void* destination,
     }
 
     STDGPU_HIP_SAFE_CALL(hipMemcpy(destination, source, static_cast<std::size_t>(bytes), kind));
-}
-
-void
-workaround_synchronize_device_thrust()
-{
-// We need to synchronize the device before exiting the calling function
-#if THRUST_VERSION <= 100903
-    STDGPU_HIP_SAFE_CALL(hipDeviceSynchronize());
-#endif
 }
 
 void

--- a/src/stdgpu/hip/memory.h
+++ b/src/stdgpu/hip/memory.h
@@ -57,12 +57,6 @@ dispatch_memcpy(void* destination,
                 dynamic_memory_type source_type);
 
 /**
- * \brief Workarounds a synchronization issue with older versions of thrust
- */
-void
-workaround_synchronize_device_thrust();
-
-/**
  * \brief Workarounds a synchronization issue with older GPUs
  */
 void

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -287,12 +287,6 @@ dispatch_memcpy(void* destination,
 }
 
 void
-workaround_synchronize_device_thrust()
-{
-    stdgpu::STDGPU_BACKEND_NAMESPACE::workaround_synchronize_device_thrust();
-}
-
-void
 workaround_synchronize_managed_memory()
 {
     stdgpu::STDGPU_BACKEND_NAMESPACE::workaround_synchronize_managed_memory();

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -140,9 +140,6 @@ unoptimized_destroy(ExecutionPolicy&& policy, Iterator first, Iterator last)
 }
 
 void
-workaround_synchronize_device_thrust();
-
-void
 workaround_synchronize_managed_memory();
 
 template <typename T, typename Allocator>
@@ -232,8 +229,6 @@ createDeviceArray(Allocator& device_allocator, const stdgpu::index64_t count, co
                                stdgpu::device_end(device_array),
                                default_value);
 
-    stdgpu::detail::workaround_synchronize_device_thrust();
-
     return device_array;
 }
 
@@ -299,8 +294,6 @@ createManagedArray(Allocator& managed_allocator,
                                        stdgpu::device_begin(managed_array),
                                        stdgpu::device_end(managed_array),
                                        default_value);
-
-            stdgpu::detail::workaround_synchronize_device_thrust();
         }
         break;
 #else
@@ -359,8 +352,6 @@ void
 destroyDeviceArray(Allocator& device_allocator, T*& device_array)
 {
     stdgpu::destroy(stdgpu::execution::device, stdgpu::device_begin(device_array), stdgpu::device_end(device_array));
-
-    stdgpu::detail::workaround_synchronize_device_thrust();
 
     stdgpu::detail::destroyUninitializedDeviceArray<T, Allocator>(device_allocator, device_array);
 }

--- a/src/stdgpu/openmp/impl/memory.cpp
+++ b/src/stdgpu/openmp/impl/memory.cpp
@@ -85,12 +85,6 @@ dispatch_memcpy(void* destination,
 }
 
 void
-workaround_synchronize_device_thrust()
-{
-    // No synchronization workaround required for OpenMP backend
-}
-
-void
 workaround_synchronize_managed_memory()
 {
     // No synchronization workaround required for OpenMP backend

--- a/src/stdgpu/openmp/memory.h
+++ b/src/stdgpu/openmp/memory.h
@@ -57,12 +57,6 @@ dispatch_memcpy(void* destination,
                 dynamic_memory_type source_type);
 
 /**
- * \brief Workarounds a synchronization issue with older versions of thrust
- */
-void
-workaround_synchronize_device_thrust();
-
-/**
  * \brief Workarounds a synchronization issue with older GPUs
  */
 void


### PR DESCRIPTION
Since we no require at least thrust 1.9.9, drop the manual workaround for synchronizing the device in the `memory` module. This also simplifies the interface of the backends.

Partially addresses #314 