### PR TITLE
src,test: Enable and fix more clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,22 @@
 Checks: "-*,\
 bugprone-*,\
 -bugprone-easily-swappable-parameters,\
+cert-*,\
+-cert-dcl21-cpp,\
+-cert-err58-cpp,\
+concurrency-*,\
+cppcoreguidelines-*,\
+-cppcoreguidelines-avoid-c-arrays,\
+-cppcoreguidelines-avoid-magic-numbers,\
+-cppcoreguidelines-avoid-non-const-global-variables,\
+-cppcoreguidelines-init-variables,\
+-cppcoreguidelines-macro-usage,\
+-cppcoreguidelines-owning-memory,\
+-cppcoreguidelines-pro-bounds-pointer-arithmetic,\
+-cppcoreguidelines-pro-type-const-cast,\
+-cppcoreguidelines-pro-type-reinterpret-cast,\
+-cppcoreguidelines-pro-type-vararg,\
+-cppcoreguidelines-special-member-functions,\
 hicpp-*,\
 -hicpp-avoid-c-arrays,\
 -hicpp-vararg,\
@@ -16,6 +32,7 @@ modernize-*,\
 -modernize-pass-by-value,\
 -modernize-use-trailing-return-type,\
 performance-*,\
+portability-*,\
 readability-*,\
 -readability-avoid-const-params-in-decls,\
 -readability-const-return-type,\

--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -171,7 +171,7 @@ public:
      * \param[in] desired The value to store to the atomic object
      * \return The desired value
      */
-    STDGPU_HOST_DEVICE T // NOLINT(misc-unconventional-assign-operator)
+    STDGPU_HOST_DEVICE T // NOLINT(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
     operator=(const T desired);
 
     /**
@@ -459,7 +459,7 @@ public:
      * \return The desired value
      * \note Equivalent to store()
      */
-    STDGPU_HOST_DEVICE T // NOLINT(misc-unconventional-assign-operator)
+    STDGPU_HOST_DEVICE T // NOLINT(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
     operator=(const T desired);
 
     /**

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -85,7 +85,7 @@ public:
          * \param[in] x A bit value to assign
          * \return The old value of the bit
          */
-        STDGPU_DEVICE_ONLY bool // NOLINT(misc-unconventional-assign-operator)
+        STDGPU_DEVICE_ONLY bool // NOLINT(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
         operator=(bool x);
 
         /**
@@ -93,7 +93,7 @@ public:
          * \param[in] x The reference object to assign
          * \return The old value of the bit
          */
-        STDGPU_DEVICE_ONLY bool // NOLINT(misc-unconventional-assign-operator)
+        STDGPU_DEVICE_ONLY bool // NOLINT(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
         operator=(const reference& x);
 
         /**

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -193,8 +193,10 @@ atomic<T, Allocator>::store(const T desired, const memory_order order)
     _value_ref.store(desired, order);
 }
 
-template <typename T, typename Allocator> // NOLINT(misc-unconventional-assign-operator)
-inline STDGPU_HOST_DEVICE T               // NOLINT(misc-unconventional-assign-operator)
+// NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
+template <typename T, typename Allocator>
+// NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
+inline STDGPU_HOST_DEVICE T
 atomic<T, Allocator>::operator=(const T desired)
 {
     return _value_ref.operator=(desired);
@@ -368,15 +370,15 @@ atomic<T, Allocator>::operator^=(const T arg)
 template <typename T>
 inline STDGPU_HOST_DEVICE
 atomic_ref<T>::atomic_ref(T& obj)
+  : _value(&obj)
 {
-    _value = &obj;
 }
 
 template <typename T>
 inline STDGPU_HOST_DEVICE
 atomic_ref<T>::atomic_ref(T* value)
+  : _value(value)
 {
-    _value = value;
 }
 
 template <typename T>
@@ -435,8 +437,10 @@ atomic_ref<T>::store(const T desired, [[maybe_unused]] const memory_order order)
 #endif
 }
 
-template <typename T>       // NOLINT(misc-unconventional-assign-operator)
-inline STDGPU_HOST_DEVICE T // NOLINT(misc-unconventional-assign-operator)
+// NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
+template <typename T>
+// NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
+inline STDGPU_HOST_DEVICE T
 atomic_ref<T>::operator=(const T desired)
 {
     store(desired);

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -41,8 +41,10 @@ bitset<Block, Allocator>::reference::reference(bitset<Block, Allocator>::referen
     STDGPU_EXPECTS(bit_n < _bits_per_block);
 }
 
-template <typename Block, typename Allocator> // NOLINT(misc-unconventional-assign-operator)
-inline STDGPU_DEVICE_ONLY bool                // NOLINT(misc-unconventional-assign-operator)
+// NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
+template <typename Block, typename Allocator>
+// NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
+inline STDGPU_DEVICE_ONLY bool
 bitset<Block, Allocator>::reference::operator=(bool x)
 {
     block_type set_pattern = static_cast<block_type>(1) << static_cast<block_type>(_bit_n);
@@ -62,9 +64,12 @@ bitset<Block, Allocator>::reference::operator=(bool x)
     return bit(old, _bit_n);
 }
 
-template <typename Block, typename Allocator>                      // NOLINT(misc-unconventional-assign-operator)
-inline STDGPU_DEVICE_ONLY bool                                     // NOLINT(misc-unconventional-assign-operator)
-bitset<Block, Allocator>::reference::operator=(const reference& x) // NOLINT(bugprone-unhandled-self-assignment)
+// NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
+template <typename Block, typename Allocator>
+// NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
+inline STDGPU_DEVICE_ONLY bool
+// NOLINTNEXTLINE(bugprone-unhandled-self-assignment,cert-oop54-cpp)
+bitset<Block, Allocator>::reference::operator=(const reference& x)
 {
     return operator=(static_cast<bool>(x));
 }

--- a/src/stdgpu/openmp/impl/memory.cpp
+++ b/src/stdgpu/openmp/impl/memory.cpp
@@ -33,7 +33,8 @@ dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes)
         case dynamic_memory_type::host:
         case dynamic_memory_type::managed:
         {
-            *array = std::malloc(static_cast<std::size_t>(bytes)); // NOLINT(hicpp-no-malloc)
+            *array =
+                    std::malloc(static_cast<std::size_t>(bytes)); // NOLINT(hicpp-no-malloc,cppcoreguidelines-no-malloc)
         }
         break;
 
@@ -55,7 +56,7 @@ dispatch_free(const dynamic_memory_type type, void* array)
         case dynamic_memory_type::host:
         case dynamic_memory_type::managed:
         {
-            std::free(array); // NOLINT(hicpp-no-malloc)
+            std::free(array); // NOLINT(hicpp-no-malloc,cppcoreguidelines-no-malloc)
         }
         break;
 

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -44,8 +44,10 @@ protected:
         stdgpu::bitset<>::destroyDeviceObject(bitset);
     }
 
-    const stdgpu::index_t bitset_size = 1048576; // NOLINT(misc-non-private-member-variables-in-classes)
-    stdgpu::bitset<> bitset = {};                // NOLINT(misc-non-private-member-variables-in-classes)
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes,cppcoreguidelines-non-private-member-variables-in-classes)
+    const stdgpu::index_t bitset_size = 1048576;
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes,cppcoreguidelines-non-private-member-variables-in-classes)
+    stdgpu::bitset<> bitset = {};
 };
 
 TEST_F(stdgpu_bitset, empty_container)

--- a/test/stdgpu/contract.cpp
+++ b/test/stdgpu/contract.cpp
@@ -64,9 +64,9 @@ TEST_F(stdgpu_contract, expects_host_expression)
 TEST_F(stdgpu_contract, expects_host_comma_expression)
 {
 #if STDGPU_ENABLE_CONTRACT_CHECKS
-    STDGPU_EXPECTS(std::is_same<int, int>::value); // NOLINT(hicpp-static-assert,misc-static-assert)
+    STDGPU_EXPECTS(std::is_same<int, int>::value); // NOLINT(hicpp-static-assert,misc-static-assert,cert-dcl03-c)
 
-    // NOLINTNEXTLINE(hicpp-no-array-decay,hicpp-avoid-goto,hicpp-static-assert,misc-static-assert)
+    // NOLINTNEXTLINE(hicpp-no-array-decay,hicpp-avoid-goto,hicpp-static-assert,misc-static-assert,cert-dcl03-c)
     EXPECT_DEATH(STDGPU_EXPECTS(std::is_same<int, float>::value), "");
 #endif
 }
@@ -99,9 +99,9 @@ TEST_F(stdgpu_contract, ensures_host_expression)
 TEST_F(stdgpu_contract, ensures_host_comma_expression)
 {
 #if STDGPU_ENABLE_CONTRACT_CHECKS
-    STDGPU_ENSURES(std::is_same<int, int>::value); // NOLINT(hicpp-static-assert,misc-static-assert)
+    STDGPU_ENSURES(std::is_same<int, int>::value); // NOLINT(hicpp-static-assert,misc-static-assert,cert-dcl03-c)
 
-    // NOLINTNEXTLINE(hicpp-no-array-decay,hicpp-avoid-goto,hicpp-static-assert,misc-static-assert)
+    // NOLINTNEXTLINE(hicpp-no-array-decay,hicpp-avoid-goto,hicpp-static-assert,misc-static-assert,cert-dcl03-c)
     EXPECT_DEATH(STDGPU_ENSURES(std::is_same<int, float>::value), "");
 #endif
 }
@@ -134,9 +134,9 @@ TEST_F(stdgpu_contract, assert_host_expression)
 TEST_F(stdgpu_contract, assert_host_comma_expression)
 {
 #if STDGPU_ENABLE_CONTRACT_CHECKS
-    STDGPU_ASSERT(std::is_same<int, int>::value); // NOLINT(hicpp-static-assert,misc-static-assert)
+    STDGPU_ASSERT(std::is_same<int, int>::value); // NOLINT(hicpp-static-assert,misc-static-assert,cert-dcl03-c)
 
-    // NOLINTNEXTLINE(hicpp-no-array-decay,hicpp-avoid-goto,hicpp-static-assert,misc-static-assert)
+    // NOLINTNEXTLINE(hicpp-no-array-decay,hicpp-avoid-goto,hicpp-static-assert,misc-static-assert,cert-dcl03-c)
     EXPECT_DEATH(STDGPU_ASSERT(std::is_same<int, float>::value), "");
 #endif
 }

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -40,8 +40,10 @@ protected:
         stdgpu::mutex_array<>::destroyDeviceObject(locks);
     }
 
-    const stdgpu::index_t locks_size = 100000; // NOLINT(misc-non-private-member-variables-in-classes)
-    stdgpu::mutex_array<> locks = {};          // NOLINT(misc-non-private-member-variables-in-classes)
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes,cppcoreguidelines-non-private-member-variables-in-classes)
+    const stdgpu::index_t locks_size = 100000;
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes,cppcoreguidelines-non-private-member-variables-in-classes)
+    stdgpu::mutex_array<> locks = {};
 };
 
 TEST_F(stdgpu_mutex, empty_container)

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -63,8 +63,10 @@ protected:
         test_unordered_datastructure::destroyDeviceObject(hash_datastructure);
     }
 
-    const stdgpu::index_t hash_datastructure_size = 100000; // NOLINT(misc-non-private-member-variables-in-classes)
-    test_unordered_datastructure hash_datastructure = {};   // NOLINT(misc-non-private-member-variables-in-classes)
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes,cppcoreguidelines-non-private-member-variables-in-classes)
+    const stdgpu::index_t hash_datastructure_size = 100000;
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes,cppcoreguidelines-non-private-member-variables-in-classes)
+    test_unordered_datastructure hash_datastructure = {};
 };
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, empty_container)


### PR DESCRIPTION
Recent versions of clang-tidy introduced further checks to improve the code quality. Although our coverage is already quite good, increase the number of checks and suppress the aliases to existing checks.

In the future, we may even maximize the coverage by unconditionally enabling all checks and providing a single list of ignored warnings.