### PR TITLE
examples,src,test: Fix various clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,28 +8,21 @@ cert-*,\
 concurrency-*,\
 cppcoreguidelines-*,\
 -cppcoreguidelines-avoid-c-arrays,\
--cppcoreguidelines-avoid-magic-numbers,\
 -cppcoreguidelines-avoid-non-const-global-variables,\
--cppcoreguidelines-init-variables,\
 -cppcoreguidelines-macro-usage,\
 -cppcoreguidelines-owning-memory,\
 -cppcoreguidelines-pro-bounds-pointer-arithmetic,\
 -cppcoreguidelines-pro-type-const-cast,\
--cppcoreguidelines-pro-type-reinterpret-cast,\
 -cppcoreguidelines-pro-type-vararg,\
--cppcoreguidelines-special-member-functions,\
 hicpp-*,\
 -hicpp-avoid-c-arrays,\
 -hicpp-vararg,\
 -hicpp-use-auto,\
--hicpp-special-member-functions,\
 misc-*,\
 modernize-*,\
 -modernize-avoid-c-arrays,\
--modernize-concat-nested-namespaces,\
 -modernize-use-auto,\
 -modernize-use-nodiscard,\
--modernize-pass-by-value,\
 -modernize-use-trailing-return-type,\
 performance-*,\
 portability-*,\
@@ -38,8 +31,6 @@ readability-*,\
 -readability-const-return-type,\
 -readability-function-cognitive-complexity,\
 -readability-identifier-length,\
--readability-magic-numbers,\
--readability-redundant-declaration,\
 "
 HeaderFilterRegex: 'src|benchmark/stdgpu|test/stdgpu'
 ...

--- a/examples/cuda/bitset.cu
+++ b/examples/cuda/bitset.cu
@@ -57,7 +57,7 @@ main()
     // This example shows how every second bit of stdgpu::bitset can be set concurrently in a GPU kernel.
     //
 
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n / 2);

--- a/examples/cuda/deque.cu
+++ b/examples/cuda/deque.cu
@@ -68,7 +68,7 @@ main()
     // Furthermore, even numbers are put into the front, whereas odd number are put into the back.
     //
 
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     stdgpu::deque<int> deq = stdgpu::deque<int>::createDeviceObject(3 * n);

--- a/examples/cuda/iterator.cu
+++ b/examples/cuda/iterator.cu
@@ -41,7 +41,7 @@ main()
     // In this example, stdgpu::back_inserter is used to push all odd numbers of a sequence into a stdgpu::vector.
     //
 
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     stdgpu::vector<int> vec = stdgpu::vector<int>::createDeviceObject(n);

--- a/examples/cuda/mutex_array.cu
+++ b/examples/cuda/mutex_array.cu
@@ -46,7 +46,8 @@ try_partial_sum(const int* d_input, const stdgpu::index_t n, stdgpu::mutex_array
     // While loops might hang due to internal driver scheduling, so use a fixed number of trials.
     // Do not loop over try_lock(). Instead, loop over the whole sequential part to avoid deadlocks.
     bool finished = false;
-    for (stdgpu::index_t k = 0; k < 5; ++k)
+    const stdgpu::index_t number_trials = 5;
+    for (stdgpu::index_t k = 0; k < number_trials; ++k)
     {
         // --- SEQUENTIAL PART ---
         if (!finished && locks[j].try_lock())
@@ -74,8 +75,8 @@ main()
     // deadlock-free looping.
     //
 
-    stdgpu::index_t n = 100;
-    stdgpu::index_t m = 10;
+    const stdgpu::index_t n = 100;
+    const stdgpu::index_t m = 10;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(m);

--- a/examples/cuda/unordered_map.cu
+++ b/examples/cuda/unordered_map.cu
@@ -76,7 +76,7 @@ main()
     // This example demonstrates how stdgpu::unordered_map is used to compute a duplicate-free set of numbers.
     //
 
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n / 2);

--- a/examples/cuda/unordered_set.cu
+++ b/examples/cuda/unordered_set.cu
@@ -58,7 +58,7 @@ main()
     // This example demonstrates how stdgpu::unordered_set is used to compute a duplicate-free set of numbers.
     //
 
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n / 2);

--- a/examples/cuda/vector.cu
+++ b/examples/cuda/vector.cu
@@ -50,7 +50,7 @@ main()
     // Every number is contained 3 times, except for the first and last one which is contained only 2 times.
     //
 
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     stdgpu::vector<int> vec = stdgpu::vector<int>::createDeviceObject(3 * n);

--- a/examples/openmp/bitset.cpp
+++ b/examples/openmp/bitset.cpp
@@ -56,7 +56,7 @@ main()
     // This example shows how every second bit of stdgpu::bitset can be set concurrently in a GPU kernel.
     //
 
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n / 2);

--- a/examples/openmp/deque.cpp
+++ b/examples/openmp/deque.cpp
@@ -67,7 +67,7 @@ main()
     // Furthermore, even numbers are put into the front, whereas odd number are put into the back.
     //
 
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     stdgpu::deque<int> deq = stdgpu::deque<int>::createDeviceObject(3 * n);

--- a/examples/openmp/iterator.cpp
+++ b/examples/openmp/iterator.cpp
@@ -41,7 +41,7 @@ main()
     // In this example, stdgpu::back_inserter is used to push all odd numbers of a sequence into a stdgpu::vector.
     //
 
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     stdgpu::vector<int> vec = stdgpu::vector<int>::createDeviceObject(n);

--- a/examples/openmp/mutex_array.cpp
+++ b/examples/openmp/mutex_array.cpp
@@ -44,7 +44,8 @@ try_partial_sum(const int* d_input, const stdgpu::index_t n, stdgpu::mutex_array
         // While loops might hang due to internal driver scheduling, so use a fixed number of trials.
         // Do not loop over try_lock(). Instead, loop over the whole sequential part to avoid deadlocks.
         bool finished = false;
-        for (stdgpu::index_t k = 0; k < 5; ++k)
+        const stdgpu::index_t number_trials = 5;
+        for (stdgpu::index_t k = 0; k < number_trials; ++k)
         {
             // --- SEQUENTIAL PART ---
             if (!finished && locks[j].try_lock())
@@ -73,8 +74,8 @@ main()
     // deadlock-free looping.
     //
 
-    stdgpu::index_t n = 100;
-    stdgpu::index_t m = 10;
+    const stdgpu::index_t n = 100;
+    const stdgpu::index_t m = 10;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(m);

--- a/examples/openmp/unordered_map.cpp
+++ b/examples/openmp/unordered_map.cpp
@@ -75,7 +75,7 @@ main()
     // This example demonstrates how stdgpu::unordered_map is used to compute a duplicate-free set of numbers.
     //
 
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n / 2);

--- a/examples/openmp/unordered_set.cpp
+++ b/examples/openmp/unordered_set.cpp
@@ -57,7 +57,7 @@ main()
     // This example demonstrates how stdgpu::unordered_set is used to compute a duplicate-free set of numbers.
     //
 
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     int* d_result = createDeviceArray<int>(n / 2);

--- a/examples/openmp/vector.cpp
+++ b/examples/openmp/vector.cpp
@@ -49,7 +49,7 @@ main()
     // Every number is contained 3 times, except for the first and last one which is contained only 2 times.
     //
 
-    stdgpu::index_t n = 100;
+    const stdgpu::index_t n = 100;
 
     int* d_input = createDeviceArray<int>(n);
     stdgpu::vector<int> vec = stdgpu::vector<int>::createDeviceObject(3 * n);

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -74,6 +74,11 @@ public:
         reference() = delete;
 
         /**
+         * \brief Default destructor
+         */
+        ~reference() = default;
+
+        /**
          * \brief Default copy constructor
          * \param[in] x The reference object to copy
          */
@@ -95,6 +100,17 @@ public:
          */
         STDGPU_DEVICE_ONLY bool // NOLINT(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
         operator=(const reference& x);
+
+        /**
+         * \brief Deleted move constructor
+         */
+        reference(reference&&) = delete;
+
+        /**
+         * \brief Deleted move assignment operator
+         */
+        reference&
+        operator=(reference&&) = delete;
 
         /**
          * \brief Returns the value of the bit

--- a/src/stdgpu/cuda/atomic.cuh
+++ b/src/stdgpu/cuda/atomic.cuh
@@ -20,10 +20,7 @@
 
 #include <stdgpu/impl/type_traits.h>
 
-namespace stdgpu
-{
-
-namespace cuda
+namespace stdgpu::cuda
 {
 
 /**
@@ -181,9 +178,7 @@ template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::v
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address, const T arg);
 
-} // namespace cuda
-
-} // namespace stdgpu
+} // namespace stdgpu::cuda
 
 #include <stdgpu/cuda/impl/atomic_detail.cuh>
 

--- a/src/stdgpu/cuda/device.h
+++ b/src/stdgpu/cuda/device.h
@@ -16,10 +16,7 @@
 #ifndef STDGPU_CUDA_DEVICE_H
 #define STDGPU_CUDA_DEVICE_H
 
-namespace stdgpu
-{
-
-namespace cuda
+namespace stdgpu::cuda
 {
 
 /**
@@ -28,8 +25,6 @@ namespace cuda
 void
 print_device_information();
 
-} // namespace cuda
-
-} // namespace stdgpu
+} // namespace stdgpu::cuda
 
 #endif // STDGPU_CUDA_DEVICE_H

--- a/src/stdgpu/cuda/impl/atomic_detail.cuh
+++ b/src/stdgpu/cuda/impl/atomic_detail.cuh
@@ -66,10 +66,7 @@ atomicMax(float* address, const float value)
     return __int_as_float(old);
 }
 
-namespace stdgpu
-{
-
-namespace cuda
+namespace stdgpu::cuda
 {
 
 inline STDGPU_HOST_DEVICE bool
@@ -185,8 +182,6 @@ atomic_fetch_dec_mod(T* address, const T arg)
     return atomicDec(address, arg);
 }
 
-} // namespace cuda
-
-} // namespace stdgpu
+} // namespace stdgpu::cuda
 
 #endif // STDGPU_CUDA_ATOMIC_DETAIL_H

--- a/src/stdgpu/cuda/impl/device.cpp
+++ b/src/stdgpu/cuda/impl/device.cpp
@@ -42,10 +42,7 @@ byte_to_gibi_byte(const float byte)
 }
 } // namespace detail
 
-namespace stdgpu
-{
-
-namespace cuda
+namespace stdgpu::cuda
 {
 
 void
@@ -97,6 +94,4 @@ print_device_information()
     printf("+---------------------------------------------------------+\n\n");
 }
 
-} // namespace cuda
-
-} // namespace stdgpu
+} // namespace stdgpu::cuda

--- a/src/stdgpu/cuda/impl/memory.cpp
+++ b/src/stdgpu/cuda/impl/memory.cpp
@@ -19,9 +19,7 @@
 #include <cuda_runtime_api.h> // Include after thrust to avoid redefinition warning for __host__ and __device__ in .cpp files
 #include <exception>
 
-namespace stdgpu
-{
-namespace cuda
+namespace stdgpu::cuda
 {
 
 /**
@@ -173,6 +171,4 @@ workaround_synchronize_managed_memory()
     }
 }
 
-} // namespace cuda
-
-} // namespace stdgpu
+} // namespace stdgpu::cuda

--- a/src/stdgpu/cuda/memory.h
+++ b/src/stdgpu/cuda/memory.h
@@ -19,9 +19,7 @@
 #include <stdgpu/cstddef.h>
 #include <stdgpu/memory.h>
 
-namespace stdgpu
-{
-namespace cuda
+namespace stdgpu::cuda
 {
 
 /**
@@ -62,8 +60,6 @@ dispatch_memcpy(void* destination,
 void
 workaround_synchronize_managed_memory();
 
-} // namespace cuda
-
-} // namespace stdgpu
+} // namespace stdgpu::cuda
 
 #endif // STDGPU_CUDA_MEMORY_H

--- a/src/stdgpu/cuda/platform.h
+++ b/src/stdgpu/cuda/platform.h
@@ -18,9 +18,7 @@
 
 #include <stdgpu/compiler.h>
 
-namespace stdgpu
-{
-namespace cuda
+namespace stdgpu::cuda
 {
 
 /**
@@ -73,8 +71,6 @@ namespace cuda
     #define STDGPU_CUDA_IS_DEVICE_COMPILED 0
 #endif
 
-} // namespace cuda
-
-} // namespace stdgpu
+} // namespace stdgpu::cuda
 
 #endif // STDGPU_CUDA_PLATFORM_H

--- a/src/stdgpu/cuda/platform_check.h
+++ b/src/stdgpu/cuda/platform_check.h
@@ -18,9 +18,7 @@
 
 #include <stdgpu/compiler.h>
 
-namespace stdgpu
-{
-namespace cuda
+namespace stdgpu::cuda
 {
 
 #if STDGPU_DEVICE_COMPILER != STDGPU_DEVICE_COMPILER_NVCC && STDGPU_DEVICE_COMPILER != STDGPU_DEVICE_COMPILER_CUDACLANG
@@ -28,8 +26,6 @@ namespace cuda
     #include <stdgpu/this_include_error_is_intended/take_a_look_at_the_error_above> // Helper to stop compilation as early as possible
 #endif
 
-} // namespace cuda
-
-} // namespace stdgpu
+} // namespace stdgpu::cuda
 
 #endif // STDGPU_CUDA_PLATFORM_CHECK_H

--- a/src/stdgpu/execution.h
+++ b/src/stdgpu/execution.h
@@ -28,9 +28,7 @@
 
 #include <thrust/execution_policy.h>
 
-namespace stdgpu
-{
-namespace execution
+namespace stdgpu::execution
 {
 
 /**
@@ -45,8 +43,7 @@ constexpr decltype(thrust::device) device;
  */
 constexpr decltype(thrust::host) host;
 
-} // namespace execution
-} // namespace stdgpu
+} // namespace stdgpu::execution
 
 /**
  * @}

--- a/src/stdgpu/hip/atomic.h
+++ b/src/stdgpu/hip/atomic.h
@@ -20,10 +20,7 @@
 
 #include <stdgpu/impl/type_traits.h>
 
-namespace stdgpu
-{
-
-namespace hip
+namespace stdgpu::hip
 {
 
 /**
@@ -181,9 +178,7 @@ template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::v
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address, const T arg);
 
-} // namespace hip
-
-} // namespace stdgpu
+} // namespace stdgpu::hip
 
 #include <stdgpu/hip/impl/atomic_detail.h>
 

--- a/src/stdgpu/hip/device.h
+++ b/src/stdgpu/hip/device.h
@@ -16,10 +16,7 @@
 #ifndef STDGPU_HIP_DEVICE_H
 #define STDGPU_HIP_DEVICE_H
 
-namespace stdgpu
-{
-
-namespace hip
+namespace stdgpu::hip
 {
 
 /**
@@ -28,8 +25,6 @@ namespace hip
 void
 print_device_information();
 
-} // namespace hip
-
-} // namespace stdgpu
+} // namespace stdgpu::hip
 
 #endif // STDGPU_HIP_DEVICE_H

--- a/src/stdgpu/hip/impl/atomic_detail.h
+++ b/src/stdgpu/hip/impl/atomic_detail.h
@@ -20,10 +20,7 @@
 #include <stdgpu/limits.h>
 #include <stdgpu/platform.h>
 
-namespace stdgpu
-{
-
-namespace hip
+namespace stdgpu::hip
 {
 
 inline STDGPU_HOST_DEVICE bool
@@ -139,8 +136,6 @@ atomic_fetch_dec_mod(T* address, const T arg)
     return atomicDec(address, arg);
 }
 
-} // namespace hip
-
-} // namespace stdgpu
+} // namespace stdgpu::hip
 
 #endif // STDGPU_HIP_ATOMIC_DETAIL_H

--- a/src/stdgpu/hip/impl/device.cpp
+++ b/src/stdgpu/hip/impl/device.cpp
@@ -42,10 +42,7 @@ byte_to_gibi_byte(const float byte)
 }
 } // namespace detail
 
-namespace stdgpu
-{
-
-namespace hip
+namespace stdgpu::hip
 {
 
 void
@@ -99,6 +96,4 @@ print_device_information()
     printf("+---------------------------------------------------------+\n\n");
 }
 
-} // namespace hip
-
-} // namespace stdgpu
+} // namespace stdgpu::hip

--- a/src/stdgpu/hip/impl/memory.cpp
+++ b/src/stdgpu/hip/impl/memory.cpp
@@ -19,9 +19,7 @@
 #include <exception>
 #include <hip/hip_runtime_api.h>
 
-namespace stdgpu
-{
-namespace hip
+namespace stdgpu::hip
 {
 
 /**
@@ -174,6 +172,4 @@ workaround_synchronize_managed_memory()
     }
 }
 
-} // namespace hip
-
-} // namespace stdgpu
+} // namespace stdgpu::hip

--- a/src/stdgpu/hip/memory.h
+++ b/src/stdgpu/hip/memory.h
@@ -19,9 +19,7 @@
 #include <stdgpu/cstddef.h>
 #include <stdgpu/memory.h>
 
-namespace stdgpu
-{
-namespace hip
+namespace stdgpu::hip
 {
 
 /**
@@ -62,8 +60,6 @@ dispatch_memcpy(void* destination,
 void
 workaround_synchronize_managed_memory();
 
-} // namespace hip
-
-} // namespace stdgpu
+} // namespace stdgpu::hip
 
 #endif // STDGPU_HIP_MEMORY_H

--- a/src/stdgpu/hip/platform.h
+++ b/src/stdgpu/hip/platform.h
@@ -18,9 +18,7 @@
 
 #include <stdgpu/compiler.h>
 
-namespace stdgpu
-{
-namespace hip
+namespace stdgpu::hip
 {
 
 /**
@@ -73,8 +71,6 @@ namespace hip
     #define STDGPU_HIP_IS_DEVICE_COMPILED 0
 #endif
 
-} // namespace hip
-
-} // namespace stdgpu
+} // namespace stdgpu::hip
 
 #endif // STDGPU_HIP_PLATFORM_H

--- a/src/stdgpu/hip/platform_check.h
+++ b/src/stdgpu/hip/platform_check.h
@@ -18,9 +18,7 @@
 
 #include <stdgpu/compiler.h>
 
-namespace stdgpu
-{
-namespace hip
+namespace stdgpu::hip
 {
 
 #if STDGPU_DEVICE_COMPILER != STDGPU_DEVICE_COMPILER_HIPCLANG
@@ -28,8 +26,6 @@ namespace hip
     #include <stdgpu/this_include_error_is_intended/take_a_look_at_the_error_above> // Helper to stop compilation as early as possible
 #endif
 
-} // namespace hip
-
-} // namespace stdgpu
+} // namespace stdgpu::hip
 
 #endif // STDGPU_HIP_PLATFORM_CHECK_H

--- a/src/stdgpu/impl/algorithm_detail.h
+++ b/src/stdgpu/impl/algorithm_detail.h
@@ -64,7 +64,7 @@ template <typename Iterator, typename T>
 class fill_functor
 {
 public:
-    fill_functor(Iterator begin, T value)
+    fill_functor(Iterator begin, const T& value) // NOLINT(modernize-pass-by-value)
       : _begin(begin)
       , _value(value)
     {
@@ -103,7 +103,7 @@ template <typename InputIt, typename OutputIt>
 class copy_functor
 {
 public:
-    copy_functor(InputIt begin, OutputIt output_begin)
+    copy_functor(InputIt begin, OutputIt output_begin) // NOLINT(modernize-pass-by-value)
       : _begin(begin)
       , _output_begin(output_begin)
     {

--- a/src/stdgpu/impl/bit_detail.h
+++ b/src/stdgpu/impl/bit_detail.h
@@ -112,9 +112,9 @@ template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::
 STDGPU_HOST_DEVICE int
 popcount(const T number)
 {
-    int result;
+    int result = 0;
     T cleared_number = number;
-    for (result = 0; cleared_number; ++result)
+    for (; cleared_number; ++result)
     {
         // Clear the least significant bit set
         cleared_number &= cleared_number - static_cast<T>(1);
@@ -135,7 +135,10 @@ bit_cast(const From& object)
 {
     To result;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     auto* result_bytes = reinterpret_cast<unsigned char*>(&result);
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     const auto* object_bytes = reinterpret_cast<const unsigned char*>(&object);
 
     for (unsigned int i = 0; i < sizeof(To); ++i)

--- a/src/stdgpu/impl/iterator_detail.h
+++ b/src/stdgpu/impl/iterator_detail.h
@@ -387,9 +387,7 @@ inserter(Container& c)
 
 } // namespace stdgpu
 
-namespace thrust
-{
-namespace detail
+namespace thrust::detail
 {
 
 template <typename Container>
@@ -407,7 +405,6 @@ struct is_proxy_reference<stdgpu::detail::insert_iterator_proxy<Container>> : pu
 {
 };
 
-} // namespace detail
-} // namespace thrust
+} // namespace thrust::detail
 
 #endif // STDGPU_ITERATORDETAIL_H

--- a/src/stdgpu/impl/limits_detail.h
+++ b/src/stdgpu/impl/limits_detail.h
@@ -635,7 +635,7 @@ numeric_limits<float>::epsilon() noexcept
 constexpr STDGPU_HOST_DEVICE float
 numeric_limits<float>::round_error() noexcept
 {
-    return 0.5F; // NOLINT(readability-magic-numbers)
+    return 0.5F; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 }
 
 constexpr STDGPU_HOST_DEVICE float
@@ -671,7 +671,7 @@ numeric_limits<double>::epsilon() noexcept
 constexpr STDGPU_HOST_DEVICE double
 numeric_limits<double>::round_error() noexcept
 {
-    return 0.5; // NOLINT(readability-magic-numbers)
+    return 0.5; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 }
 
 constexpr STDGPU_HOST_DEVICE double
@@ -707,7 +707,7 @@ numeric_limits<long double>::epsilon() noexcept
 constexpr STDGPU_HOST_DEVICE long double
 numeric_limits<long double>::round_error() noexcept
 {
-    return 0.5L; // NOLINT(readability-magic-numbers)
+    return 0.5L; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 }
 
 constexpr STDGPU_HOST_DEVICE long double

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -36,16 +36,6 @@ class memory_manager
 {
 public:
     /**
-     * \brief Constructor
-     */
-    memory_manager() = default;
-
-    /**
-     * \brief Destructor
-     */
-    ~memory_manager() = default;
-
-    /**
      * \brief Registers the allocated memory block
      * \param[in] pointer A pointer to the start of the memory block
      * \param[in] size The size of the memory blocks in bytes

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -18,6 +18,7 @@
 
 #include <cstdio>
 #include <type_traits>
+#include <utility>
 
 #include <stdgpu/algorithm.h>
 #include <stdgpu/cstddef.h>
@@ -27,10 +28,7 @@
 #include <stdgpu/platform.h>
 #include <stdgpu/utility.h>
 
-namespace stdgpu
-{
-
-namespace detail
+namespace stdgpu::detail
 {
 
 template <typename T>
@@ -71,7 +69,7 @@ template <typename Iterator, typename T>
 class uninitialized_fill_functor
 {
 public:
-    uninitialized_fill_functor(Iterator begin, T value)
+    uninitialized_fill_functor(Iterator begin, const T& value) // NOLINT(modernize-pass-by-value)
       : _begin(begin)
       , _value(value)
     {
@@ -187,9 +185,7 @@ destroyUninitializedManagedArray(Allocator& managed_allocator, T*& managed_array
     managed_array = nullptr;
 }
 
-} // namespace detail
-
-} // namespace stdgpu
+} // namespace stdgpu::detail
 
 template <typename T>
 T*
@@ -577,7 +573,7 @@ namespace stdgpu
 
 template <typename T>
 template <typename U>
-safe_device_allocator<T>::safe_device_allocator([[maybe_unused]] const safe_device_allocator<U>& other)
+safe_device_allocator<T>::safe_device_allocator([[maybe_unused]] const safe_device_allocator<U>& other) noexcept
 {
 }
 
@@ -603,7 +599,7 @@ safe_device_allocator<T>::deallocate(T* p, index64_t n)
 
 template <typename T>
 template <typename U>
-safe_host_allocator<T>::safe_host_allocator([[maybe_unused]] const safe_host_allocator<U>& other)
+safe_host_allocator<T>::safe_host_allocator([[maybe_unused]] const safe_host_allocator<U>& other) noexcept
 {
 }
 
@@ -629,7 +625,7 @@ safe_host_allocator<T>::deallocate(T* p, index64_t n)
 
 template <typename T>
 template <typename U>
-safe_managed_allocator<T>::safe_managed_allocator([[maybe_unused]] const safe_managed_allocator<U>& other)
+safe_managed_allocator<T>::safe_managed_allocator([[maybe_unused]] const safe_managed_allocator<U>& other) noexcept
 {
 }
 

--- a/src/stdgpu/impl/type_traits.h
+++ b/src/stdgpu/impl/type_traits.h
@@ -19,10 +19,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace stdgpu
-{
-
-namespace detail
+namespace stdgpu::detail
 {
 
 /**
@@ -78,8 +75,6 @@ STDGPU_DETAIL_DEFINE_TRAIT(has_arrow_operator,
                                             .
                                             operator->()))
 
-} // namespace detail
-
-} // namespace stdgpu
+} // namespace stdgpu::detail
 
 #endif // STDGPU_TYPE_TRAITS_H

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -29,10 +29,7 @@
 #include <stdgpu/utility.h>
 #include <stdgpu/vector.cuh>
 
-namespace stdgpu
-{
-
-namespace detail
+namespace stdgpu::detail
 {
 
 /**
@@ -454,9 +451,7 @@ public:
     bucket_impl(const KeyLike& key) const;
 };
 
-} // namespace detail
-
-} // namespace stdgpu
+} // namespace stdgpu::detail
 
 #include <stdgpu/impl/unordered_base_detail.cuh>
 

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -27,10 +27,7 @@
 #include <stdgpu/memory.h>
 #include <stdgpu/utility.h>
 
-namespace stdgpu
-{
-
-namespace detail
+namespace stdgpu::detail
 {
 
 inline index_t
@@ -41,6 +38,7 @@ expected_collisions(const index_t bucket_count, const index_t capacity)
 
     long double k = static_cast<long double>(bucket_count);
     long double n = static_cast<long double>(capacity);
+    // NOLINTNEXTLINE(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
     index_t result = static_cast<index_t>(n * (1.0L - std::pow(1.0L - (1.0L / k), n - 1.0L)));
 
     STDGPU_ENSURES(result >= 0);
@@ -1165,8 +1163,6 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::unordered_b
 {
 }
 
-} // namespace detail
-
-} // namespace stdgpu
+} // namespace stdgpu::detail
 
 #endif // STDGPU_UNORDERED_BASE_DETAIL_H

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -16,6 +16,8 @@
 #ifndef STDGPU_UNORDERED_MAP_DETAIL_H
 #define STDGPU_UNORDERED_MAP_DETAIL_H
 
+#include <utility>
+
 #include <stdgpu/bit.h>
 #include <stdgpu/contract.h>
 #include <stdgpu/utility.h>
@@ -314,8 +316,8 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::destroyDeviceObject(
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
-unordered_map<Key, T, Hash, KeyEqual, Allocator>::unordered_map(const base_type& base)
-  : _base(base)
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::unordered_map(base_type&& base)
+  : _base(std::move(base))
 {
 }
 

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -16,6 +16,8 @@
 #ifndef STDGPU_UNORDERED_SET_DETAIL_H
 #define STDGPU_UNORDERED_SET_DETAIL_H
 
+#include <utility>
+
 #include <stdgpu/bit.h>
 #include <stdgpu/contract.h>
 #include <stdgpu/utility.h>
@@ -297,8 +299,8 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::destroyDeviceObject(
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
-unordered_set<Key, Hash, KeyEqual, Allocator>::unordered_set(const base_type& base)
-  : _base(base)
+unordered_set<Key, Hash, KeyEqual, Allocator>::unordered_set(base_type&& base)
+  : _base(std::move(base))
 {
 }
 

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -465,12 +465,17 @@ struct safe_device_allocator
     /**
      * \brief Default constructor
      */
-    safe_device_allocator() = default;
+    safe_device_allocator() noexcept = default;
+
+    /**
+     * \brief Default destructor
+     */
+    ~safe_device_allocator() noexcept = default;
 
     /**
      * \brief Copy constructor
      */
-    safe_device_allocator(const safe_device_allocator&) = default;
+    safe_device_allocator(const safe_device_allocator&) noexcept = default;
 
     /**
      * \brief Copy constructor
@@ -478,14 +483,26 @@ struct safe_device_allocator
      * \param[in] other The allocator to be copied from
      */
     template <typename U>
-    explicit safe_device_allocator(const safe_device_allocator<U>& other);
+    explicit safe_device_allocator(const safe_device_allocator<U>& other) noexcept;
 
     /**
      * \brief Copy assignment operator
      * \return *this
      */
     safe_device_allocator&
-    operator=(const safe_device_allocator&) = default;
+    operator=(const safe_device_allocator&) noexcept = default;
+
+    /**
+     * \brief Move constructor
+     */
+    safe_device_allocator(safe_device_allocator&&) noexcept = default;
+
+    /**
+     * \brief Move assignment operator
+     * \return *this
+     */
+    safe_device_allocator&
+    operator=(safe_device_allocator&&) noexcept = default;
 
     /**
      * \brief Allocates a memory block of the given size
@@ -522,12 +539,17 @@ struct safe_host_allocator
     /**
      * \brief Default constructor
      */
-    safe_host_allocator() = default;
+    safe_host_allocator() noexcept = default;
+
+    /**
+     * \brief Default destructor
+     */
+    ~safe_host_allocator() noexcept = default;
 
     /**
      * \brief Copy constructor
      */
-    safe_host_allocator(const safe_host_allocator&) = default;
+    safe_host_allocator(const safe_host_allocator&) noexcept = default;
 
     /**
      * \brief Copy constructor
@@ -535,14 +557,26 @@ struct safe_host_allocator
      * \param[in] other The allocator to be copied from
      */
     template <typename U>
-    explicit safe_host_allocator(const safe_host_allocator<U>& other);
+    explicit safe_host_allocator(const safe_host_allocator<U>& other) noexcept;
 
     /**
      * \brief Copy assignment operator
      * \return *this
      */
     safe_host_allocator&
-    operator=(const safe_host_allocator&) = default;
+    operator=(const safe_host_allocator&) noexcept = default;
+
+    /**
+     * \brief Move constructor
+     */
+    safe_host_allocator(safe_host_allocator&&) noexcept = default;
+
+    /**
+     * \brief Move assignment operator
+     * \return *this
+     */
+    safe_host_allocator&
+    operator=(safe_host_allocator&&) noexcept = default;
 
     /**
      * \brief Allocates a memory block of the given size
@@ -579,12 +613,17 @@ struct safe_managed_allocator
     /**
      * \brief Default constructor
      */
-    safe_managed_allocator() = default;
+    safe_managed_allocator() noexcept = default;
+
+    /**
+     * \brief Default destructor
+     */
+    ~safe_managed_allocator() noexcept = default;
 
     /**
      * \brief Copy constructor
      */
-    safe_managed_allocator(const safe_managed_allocator&) = default;
+    safe_managed_allocator(const safe_managed_allocator&) noexcept = default;
 
     /**
      * \brief Copy constructor
@@ -592,14 +631,26 @@ struct safe_managed_allocator
      * \param[in] other The allocator to be copied from
      */
     template <typename U>
-    explicit safe_managed_allocator(const safe_managed_allocator<U>& other);
+    explicit safe_managed_allocator(const safe_managed_allocator<U>& other) noexcept;
 
     /**
      * \brief Copy assignment operator
      * \return *this
      */
     safe_managed_allocator&
-    operator=(const safe_managed_allocator&) = default;
+    operator=(const safe_managed_allocator&) noexcept = default;
+
+    /**
+     * \brief Move constructor
+     */
+    safe_managed_allocator(safe_managed_allocator&&) noexcept = default;
+
+    /**
+     * \brief Move assignment operator
+     * \return *this
+     */
+    safe_managed_allocator&
+    operator=(safe_managed_allocator&&) noexcept = default;
 
     /**
      * \brief Allocates a memory block of the given size

--- a/src/stdgpu/openmp/atomic.h
+++ b/src/stdgpu/openmp/atomic.h
@@ -20,10 +20,7 @@
 
 #include <stdgpu/impl/type_traits.h>
 
-namespace stdgpu
-{
-
-namespace openmp
+namespace stdgpu::openmp
 {
 
 /**
@@ -181,9 +178,7 @@ template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::v
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address, const T arg);
 
-} // namespace openmp
-
-} // namespace stdgpu
+} // namespace stdgpu::openmp
 
 #include <stdgpu/openmp/impl/atomic_detail.h>
 

--- a/src/stdgpu/openmp/device.h
+++ b/src/stdgpu/openmp/device.h
@@ -16,10 +16,7 @@
 #ifndef STDGPU_OPENMP_DEVICE_H
 #define STDGPU_OPENMP_DEVICE_H
 
-namespace stdgpu
-{
-
-namespace openmp
+namespace stdgpu::openmp
 {
 
 /**
@@ -28,8 +25,6 @@ namespace openmp
 void
 print_device_information();
 
-} // namespace openmp
-
-} // namespace stdgpu
+} // namespace stdgpu::openmp
 
 #endif // STDGPU_OPENMP_DEVICE_H

--- a/src/stdgpu/openmp/impl/atomic_detail.h
+++ b/src/stdgpu/openmp/impl/atomic_detail.h
@@ -20,10 +20,7 @@
 
 #include <stdgpu/platform.h>
 
-namespace stdgpu
-{
-
-namespace openmp
+namespace stdgpu::openmp
 {
 
 inline STDGPU_HOST_DEVICE bool
@@ -225,8 +222,6 @@ atomic_fetch_dec_mod(T* address, const T arg)
     return old;
 }
 
-} // namespace openmp
-
-} // namespace stdgpu
+} // namespace stdgpu::openmp
 
 #endif // STDGPU_OPENMP_ATOMIC_DETAIL_H

--- a/src/stdgpu/openmp/impl/device.cpp
+++ b/src/stdgpu/openmp/impl/device.cpp
@@ -20,10 +20,7 @@
 #include <string>
 #include <thread>
 
-namespace stdgpu
-{
-
-namespace openmp
+namespace stdgpu::openmp
 {
 
 void
@@ -42,6 +39,4 @@ print_device_information()
     printf("+---------------------------------------------------------+\n\n");
 }
 
-} // namespace openmp
-
-} // namespace stdgpu
+} // namespace stdgpu::openmp

--- a/src/stdgpu/openmp/impl/memory.cpp
+++ b/src/stdgpu/openmp/impl/memory.cpp
@@ -19,9 +19,7 @@
 #include <cstdlib>
 #include <cstring>
 
-namespace stdgpu
-{
-namespace openmp
+namespace stdgpu::openmp
 {
 
 void
@@ -91,6 +89,4 @@ workaround_synchronize_managed_memory()
     // No synchronization workaround required for OpenMP backend
 }
 
-} // namespace openmp
-
-} // namespace stdgpu
+} // namespace stdgpu::openmp

--- a/src/stdgpu/openmp/memory.h
+++ b/src/stdgpu/openmp/memory.h
@@ -19,9 +19,7 @@
 #include <stdgpu/cstddef.h>
 #include <stdgpu/memory.h>
 
-namespace stdgpu
-{
-namespace openmp
+namespace stdgpu::openmp
 {
 
 /**
@@ -62,8 +60,6 @@ dispatch_memcpy(void* destination,
 void
 workaround_synchronize_managed_memory();
 
-} // namespace openmp
-
-} // namespace stdgpu
+} // namespace stdgpu::openmp
 
 #endif // STDGPU_OPENMP_MEMORY_H

--- a/src/stdgpu/openmp/platform.h
+++ b/src/stdgpu/openmp/platform.h
@@ -16,9 +16,7 @@
 #ifndef STDGPU_OPENMP_PLATFORM_H
 #define STDGPU_OPENMP_PLATFORM_H
 
-namespace stdgpu
-{
-namespace openmp
+namespace stdgpu::openmp // NOLINT(modernize-concat-nested-namespaces)
 {
 
 /**
@@ -73,8 +71,6 @@ namespace detail
 
 } // namespace detail
 
-} // namespace openmp
-
-} // namespace stdgpu
+} // namespace stdgpu::openmp
 
 #endif // STDGPU_OPENMP_PLATFORM_H

--- a/src/stdgpu/openmp/platform_check.h
+++ b/src/stdgpu/openmp/platform_check.h
@@ -16,15 +16,11 @@
 #ifndef STDGPU_OPENMP_PLATFORM_CHECK_H
 #define STDGPU_OPENMP_PLATFORM_CHECK_H
 
-namespace stdgpu
-{
-namespace openmp
+namespace stdgpu::openmp
 {
 
 // No check required
 
-} // namespace openmp
-
-} // namespace stdgpu
+} // namespace stdgpu::openmp
 
 #endif // STDGPU_OPENMP_PLATFORM_CHECK_H

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -386,7 +386,7 @@ private:
     using base_type =
             detail::unordered_base<key_type, value_type, detail::select1st<value_type>, hasher, key_equal, Allocator>;
 
-    explicit unordered_map(const base_type& base);
+    explicit unordered_map(base_type&& base);
 
     base_type _base = {};
 };

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -375,7 +375,7 @@ public:
 private:
     using base_type = detail::unordered_base<key_type, value_type, identity, hasher, key_equal, Allocator>;
 
-    explicit unordered_set(const base_type& base);
+    explicit unordered_set(base_type&& base);
 
     base_type _base = {};
 };

--- a/test/stdgpu/algorithm.cpp
+++ b/test/stdgpu/algorithm.cpp
@@ -352,7 +352,7 @@ TEST_F(stdgpu_algorithm, fill)
     std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    T init(42.0F);
+    const T init(42.0F);
     stdgpu::fill(stdgpu::execution::host, values_vector.begin(), values_vector.end(), init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -369,7 +369,7 @@ TEST_F(stdgpu_algorithm, fill_n)
     std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    T init(42.0F);
+    const T init(42.0F);
     stdgpu::fill_n(stdgpu::execution::host, values_vector.begin(), N, init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -382,6 +382,7 @@ class assignable_float
 {
 public:
     assignable_float() = default;
+    ~assignable_float() = default;
 
     explicit assignable_float(const float f)
       : _f(f)

--- a/test/stdgpu/contract.cpp
+++ b/test/stdgpu/contract.cpp
@@ -52,8 +52,8 @@ TEST_F(stdgpu_contract, expects_host_value)
 TEST_F(stdgpu_contract, expects_host_expression)
 {
 #if STDGPU_ENABLE_CONTRACT_CHECKS
-    volatile int value_1 = 42;
-    volatile int value_2 = 24;
+    volatile int value_1 = 42; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+    volatile int value_2 = 24; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 
     STDGPU_EXPECTS(value_1 == 42 && value_2 > 0);
 
@@ -87,8 +87,8 @@ TEST_F(stdgpu_contract, ensures_host_value)
 TEST_F(stdgpu_contract, ensures_host_expression)
 {
 #if STDGPU_ENABLE_CONTRACT_CHECKS
-    volatile int value_1 = 42;
-    volatile int value_2 = 24;
+    volatile int value_1 = 42; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+    volatile int value_2 = 24; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 
     STDGPU_ENSURES(value_1 == 42 && value_2 > 0);
 
@@ -122,8 +122,8 @@ TEST_F(stdgpu_contract, assert_host_value)
 TEST_F(stdgpu_contract, assert_host_expression)
 {
 #if STDGPU_ENABLE_CONTRACT_CHECKS
-    volatile int value_1 = 42;
-    volatile int value_2 = 24;
+    volatile int value_1 = 42; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+    volatile int value_2 = 24; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 
     STDGPU_ASSERT(value_1 == 42 && value_2 > 0);
 

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -248,6 +248,14 @@ public:
         // nontrivial destructor
     }
 
+    nondefault_int_deque(const nondefault_int_deque&) = default;
+    nondefault_int_deque&
+    operator=(const nondefault_int_deque&) = default;
+
+    nondefault_int_deque(nondefault_int_deque&&) = default;
+    nondefault_int_deque&
+    operator=(nondefault_int_deque&&) = default;
+
     STDGPU_HOST_DEVICE
     operator int() const // NOLINT(hicpp-explicit-conversions)
     {

--- a/test/stdgpu/iterator.cpp
+++ b/test/stdgpu/iterator.cpp
@@ -159,7 +159,7 @@ TEST_F(stdgpu_iterator, size_device_void)
     const stdgpu::index64_t size = 42;
     int* array = createDeviceArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size(reinterpret_cast<void*>(array)), size * static_cast<stdgpu::index64_t>(sizeof(int)));
+    EXPECT_EQ(stdgpu::size(static_cast<void*>(array)), size * static_cast<stdgpu::index64_t>(sizeof(int)));
 
     destroyDeviceArray<int>(array);
 }
@@ -169,7 +169,7 @@ TEST_F(stdgpu_iterator, size_host_void)
     const stdgpu::index64_t size = 42;
     int* array = createHostArray<int>(size);
 
-    EXPECT_EQ(stdgpu::size(reinterpret_cast<void*>(array)), size * static_cast<stdgpu::index64_t>(sizeof(int)));
+    EXPECT_EQ(stdgpu::size(static_cast<void*>(array)), size * static_cast<stdgpu::index64_t>(sizeof(int)));
 
     destroyHostArray<int>(array);
 }
@@ -177,7 +177,7 @@ TEST_F(stdgpu_iterator, size_host_void)
 TEST_F(stdgpu_iterator, size_nullptr_void)
 {
     int* array = nullptr;
-    EXPECT_EQ(stdgpu::size(reinterpret_cast<void*>(array)), static_cast<stdgpu::index64_t>(0));
+    EXPECT_EQ(stdgpu::size(static_cast<void*>(array)), static_cast<stdgpu::index64_t>(0));
 }
 
 TEST_F(stdgpu_iterator, size_device)
@@ -230,6 +230,7 @@ TEST_F(stdgpu_iterator, size_device_wrong_alignment)
 {
     int* array = createDeviceArray<int>(1);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     EXPECT_EQ(stdgpu::size(reinterpret_cast<std::size_t*>(array)), static_cast<stdgpu::index64_t>(0));
 
     destroyDeviceArray<int>(array);
@@ -239,6 +240,7 @@ TEST_F(stdgpu_iterator, size_host_wrong_alignment)
 {
     int* array_result = createHostArray<int>(1);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     EXPECT_EQ(stdgpu::size(reinterpret_cast<std::size_t*>(array_result)), static_cast<stdgpu::index64_t>(0));
 
     destroyHostArray<int>(array_result);
@@ -277,8 +279,8 @@ TEST_F(stdgpu_iterator, device_begin_end_const)
     const stdgpu::index_t size = 42;
     int* array = createDeviceArray<int>(size);
 
-    const int* array_begin = stdgpu::device_begin(reinterpret_cast<const int*>(array)).get();
-    const int* array_end = stdgpu::device_end(reinterpret_cast<const int*>(array)).get();
+    const int* array_begin = stdgpu::device_begin(static_cast<const int*>(array)).get();
+    const int* array_end = stdgpu::device_end(static_cast<const int*>(array)).get();
 
     EXPECT_EQ(array_begin, array);
     EXPECT_EQ(array_end, array + size);
@@ -291,8 +293,8 @@ TEST_F(stdgpu_iterator, host_begin_end_const)
     const stdgpu::index_t size = 42;
     int* array_result = createHostArray<int>(size);
 
-    const int* array_result_begin = stdgpu::host_begin(reinterpret_cast<const int*>(array_result)).get();
-    const int* array_result_end = stdgpu::host_end(reinterpret_cast<const int*>(array_result)).get();
+    const int* array_result_begin = stdgpu::host_begin(static_cast<const int*>(array_result)).get();
+    const int* array_result_end = stdgpu::host_end(static_cast<const int*>(array_result)).get();
 
     EXPECT_EQ(array_result_begin, array_result);
     EXPECT_EQ(array_result_end, array_result + size);

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -238,14 +238,15 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_managed_on_host)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_invalid_pointer)
 {
-    int* array_invalid = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    // NOLINTNEXTLINE(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+    int* array_invalid = reinterpret_cast<int*>(42); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
     EXPECT_EQ(stdgpu::get_dynamic_memory_type(array_invalid), stdgpu::dynamic_memory_type::invalid);
 }
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, dynamic_memory_type_variable_pointer)
 {
-    int non_dynamic_array = 42; // NOLINT(readability-magic-numbers)
+    int non_dynamic_array = 42; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 
     EXPECT_EQ(stdgpu::get_dynamic_memory_type(&non_dynamic_array), stdgpu::dynamic_memory_type::invalid);
 }
@@ -885,10 +886,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2HostArray_empty)
 {
     int* array_host = createHostArray<int>(1, 0);
 
-    int* array_host_copy = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    // NOLINTNEXTLINE(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+    int* array_host_copy = reinterpret_cast<int*>(42); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
     copyHost2HostArray<int>(array_host, 0, array_host_copy);
-    EXPECT_EQ(array_host_copy, reinterpret_cast<int*>(42));
+    EXPECT_EQ(array_host_copy, reinterpret_cast<int*>(42)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
     destroyHostArray<int>(array_host);
 }
@@ -897,10 +899,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2HostArray_empty)
 {
     int* array_device = createDeviceArray<int>(1, 0);
 
-    int* array_host_copy = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    // NOLINTNEXTLINE(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+    int* array_host_copy = reinterpret_cast<int*>(42); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
     copyDevice2HostArray<int>(array_device, 0, array_host_copy);
-    EXPECT_EQ(array_host_copy, reinterpret_cast<int*>(42));
+    EXPECT_EQ(array_host_copy, reinterpret_cast<int*>(42)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
     destroyDeviceArray<int>(array_device);
 }
@@ -909,10 +912,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyHost2DeviceArray_empty)
 {
     int* array_host = createHostArray<int>(1, 0);
 
-    int* array_device_copy = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    // NOLINTNEXTLINE(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+    int* array_device_copy = reinterpret_cast<int*>(42); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
     copyHost2DeviceArray<int>(array_host, 0, array_device_copy);
-    EXPECT_EQ(array_device_copy, reinterpret_cast<int*>(42));
+    EXPECT_EQ(array_device_copy, reinterpret_cast<int*>(42)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
     destroyHostArray<int>(array_host);
 }
 
@@ -920,10 +924,11 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, copyDevice2DeviceArray_empty)
 {
     int* array_device = createDeviceArray<int>(1, 0);
 
-    int* array_device_copy = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    // NOLINTNEXTLINE(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+    int* array_device_copy = reinterpret_cast<int*>(42); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
     copyDevice2DeviceArray<int>(array_device, 0, array_device_copy);
-    EXPECT_EQ(array_device_copy, reinterpret_cast<int*>(42));
+    EXPECT_EQ(array_device_copy, reinterpret_cast<int*>(42)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
     destroyDeviceArray<int>(array_device);
 }
@@ -1468,6 +1473,14 @@ public:
         }
     }
 
+    Counter(const Counter&) = default;
+    Counter&
+    operator=(const Counter&) = default;
+
+    Counter(Counter&&) = default;
+    Counter&
+    operator=(Counter&&) = default;
+
 private:
     int* _constructor_calls = nullptr;
     int* _destructor_calls = nullptr;
@@ -1558,7 +1571,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_max_size_and_select)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, to_address_raw_pointer)
 {
-    int i = 42;
+    int i = 42; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 
     int* p = &i;
 
@@ -1567,7 +1580,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, to_address_raw_pointer)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, to_address_device_ptr)
 {
-    int i = 42;
+    int i = 42; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 
     int* p = &i;
     stdgpu::device_ptr<int> device_p(&i);
@@ -1577,7 +1590,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, to_address_device_ptr)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, to_address_host_ptr)
 {
-    int i = 42;
+    int i = 42; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 
     int* p = &i;
     stdgpu::host_ptr<int> host_p(&i);
@@ -1615,7 +1628,7 @@ private:
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, to_address_custom_fancy_ptr)
 {
-    int i = 42;
+    int i = 42; // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 
     int* p = &i;
     FancyPtr<int> fancy_p(&i);
@@ -1745,6 +1758,7 @@ class copyable_float
 {
 public:
     copyable_float() = default;
+    ~copyable_float() = default;
 
     explicit copyable_float(const float f)
       : _f(f)
@@ -1780,7 +1794,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill)
     std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    T init(42.0F);
+    const T init(42.0F);
     stdgpu::uninitialized_fill(stdgpu::execution::host, stdgpu::make_host(values), stdgpu::make_host(values + N), init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1797,7 +1811,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill_only_copyable)
     std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    T init(42.0F);
+    const T init(42.0F);
     stdgpu::uninitialized_fill(stdgpu::execution::host, stdgpu::make_host(values), stdgpu::make_host(values + N), init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1814,7 +1828,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill_n)
     std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    T init(42.0F);
+    const T init(42.0F);
     stdgpu::uninitialized_fill_n(stdgpu::execution::host, stdgpu::make_host(values), N, init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1831,7 +1845,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_fill_n_only_copyable)
     std::vector<T> values_vector(static_cast<std::size_t>(N));
     T* values = values_vector.data();
 
-    T init(42.0F);
+    const T init(42.0F);
     stdgpu::uninitialized_fill_n(stdgpu::execution::host, stdgpu::make_host(values), N, init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -1924,7 +1938,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, uninitialized_copy_n_only_copyable)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory)
 {
-    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
     const stdgpu::index64_t n = 24;
 
     stdgpu::register_memory(p, n, stdgpu::dynamic_memory_type::host);
@@ -1938,7 +1953,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory_double_register)
 {
-    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
     const stdgpu::index64_t n = 24;
 
     stdgpu::register_memory(p, n, stdgpu::dynamic_memory_type::host);
@@ -1956,7 +1972,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory_double_register)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory_double_deregister)
 {
-    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
     const stdgpu::index64_t n = 24;
 
     stdgpu::register_memory(p, n, stdgpu::dynamic_memory_type::host);
@@ -1974,7 +1991,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory_double_deregister)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory_unknown_deregister)
 {
-    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
     const stdgpu::index64_t n = 24;
 
     EXPECT_EQ(stdgpu::size(p), 0);
@@ -2000,7 +2018,8 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory_nullptr)
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, register_memory_empty_size)
 {
-    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    int* p = reinterpret_cast<int*>(42); // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
     const stdgpu::index64_t n = 0;
 
     stdgpu::register_memory(p, n, stdgpu::dynamic_memory_type::host);

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -200,7 +200,7 @@ lock_single(const stdgpu::mutex_array<>& locks, const stdgpu::index_t n)
 
     stdgpu::for_each_index(stdgpu::execution::device, 1, lock_single_functor(locks, n, result));
 
-    std::uint8_t host_result;
+    std::uint8_t host_result = {};
     copyDevice2HostArray<std::uint8_t>(result, 1, &host_result, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<std::uint8_t>(result);
@@ -261,7 +261,7 @@ lock_multiple(const stdgpu::mutex_array<>& locks, const stdgpu::index_t n_0, con
 
     stdgpu::for_each_index(stdgpu::execution::device, 1, lock_multiple_functor(locks, n_0, n_1, result));
 
-    int host_result;
+    int host_result = {};
     copyDevice2HostArray<int>(result, 1, &host_result, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<int>(result);

--- a/test/stdgpu/numeric.cpp
+++ b/test/stdgpu/numeric.cpp
@@ -43,7 +43,7 @@ TEST_F(stdgpu_numeric, iota)
     std::vector<stdgpu::index_t> indices_vector(static_cast<std::size_t>(N));
     stdgpu::index_t* indices = indices_vector.data();
 
-    stdgpu::index_t init = 42;
+    const stdgpu::index_t init = 42;
     stdgpu::iota(stdgpu::execution::host, indices_vector.begin(), indices_vector.end(), init);
 
     for (stdgpu::index_t i = 0; i < N; ++i)
@@ -76,10 +76,10 @@ TEST_F(stdgpu_numeric, transform_reduce_index)
     std::vector<std::int64_t> numbers_vector(static_cast<std::size_t>(N));
     std::int64_t* numbers = numbers_vector.data();
 
-    std::int64_t init = 42;
+    const std::int64_t init = 42;
     stdgpu::iota(stdgpu::execution::host, numbers_vector.begin(), numbers_vector.end(), init);
 
-    std::int64_t shift = 21;
+    const std::int64_t shift = 21;
     std::int64_t shifted_sum = stdgpu::transform_reduce_index(stdgpu::execution::host,
                                                               N,
                                                               shift,

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -273,7 +273,7 @@ class insert_single
 {
 public:
     insert_single(const HashDataStructure& hash_datastructure,
-                  const typename HashDataStructure::key_type& key,
+                  const typename HashDataStructure::key_type& key, // NOLINT(modernize-pass-by-value)
                   stdgpu::index_t* inserted)
       : _hash_datastructure(hash_datastructure)
       , _key(key)
@@ -306,7 +306,7 @@ insert_key(HashDataStructure& hash_datastructure, const typename HashDataStructu
                            1,
                            insert_single<HashDataStructure>(hash_datastructure, key, inserted));
 
-    stdgpu::index_t host_inserted;
+    stdgpu::index_t host_inserted = {};
     copyDevice2HostArray<stdgpu::index_t>(inserted, 1, &host_inserted, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<stdgpu::index_t>(inserted);
@@ -345,7 +345,7 @@ erase_key(test_unordered_datastructure& hash_datastructure, const test_unordered
 
     stdgpu::for_each_index(stdgpu::execution::device, 1, erase_single(hash_datastructure, key, erased));
 
-    stdgpu::index_t host_erased;
+    stdgpu::index_t host_erased = {};
     copyDevice2HostArray<stdgpu::index_t>(erased, 1, &host_erased, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<stdgpu::index_t>(erased);
@@ -409,7 +409,7 @@ regular_contains_key(const test_unordered_datastructure& hash_datastructure,
 
     stdgpu::for_each_index(stdgpu::execution::device, 1, contains_key_functor(hash_datastructure, key, contained));
 
-    stdgpu::index_t host_contained;
+    stdgpu::index_t host_contained = {};
     copyDevice2HostArray<stdgpu::index_t>(contained, 1, &host_contained, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<stdgpu::index_t>(contained);
@@ -427,7 +427,7 @@ transparent_contains_key(const test_unordered_datastructure& hash_datastructure,
                            1,
                            transparent_contains_key_functor(hash_datastructure, key, contained));
 
-    stdgpu::index_t host_contained;
+    stdgpu::index_t host_contained = {};
     copyDevice2HostArray<stdgpu::index_t>(contained, 1, &host_contained, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<stdgpu::index_t>(contained);
@@ -550,7 +550,7 @@ non_const_find_key(const test_unordered_datastructure& hash_datastructure,
 
     stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_find_key_functor(hash_datastructure, key, result));
 
-    test_unordered_datastructure::iterator host_result;
+    test_unordered_datastructure::iterator host_result = {};
     copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<test_unordered_datastructure::iterator>(result);
@@ -567,7 +567,7 @@ const_find_key(const test_unordered_datastructure& hash_datastructure,
 
     stdgpu::for_each_index(stdgpu::execution::device, 1, const_find_key_functor(hash_datastructure, key, result));
 
-    test_unordered_datastructure::const_iterator host_result;
+    test_unordered_datastructure::const_iterator host_result = {};
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<test_unordered_datastructure::const_iterator>(result);
@@ -585,7 +585,7 @@ transparent_non_const_find_key(const test_unordered_datastructure& hash_datastru
                            1,
                            transparent_non_const_find_key_functor(hash_datastructure, key, result));
 
-    test_unordered_datastructure::iterator host_result;
+    test_unordered_datastructure::iterator host_result = {};
     copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<test_unordered_datastructure::iterator>(result);
@@ -604,7 +604,7 @@ transparent_const_find_key(const test_unordered_datastructure& hash_datastructur
                            1,
                            transparent_const_find_key_functor(hash_datastructure, key, result));
 
-    test_unordered_datastructure::const_iterator host_result;
+    test_unordered_datastructure::const_iterator host_result = {};
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<test_unordered_datastructure::const_iterator>(result);
@@ -700,7 +700,7 @@ non_const_begin_iterator(const test_unordered_datastructure& hash_datastructure)
 
     stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_begin_iterator_functor(hash_datastructure, result));
 
-    test_unordered_datastructure::iterator host_result;
+    test_unordered_datastructure::iterator host_result = {};
     copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<test_unordered_datastructure::iterator>(result);
@@ -716,7 +716,7 @@ const_begin_iterator(const test_unordered_datastructure& hash_datastructure)
 
     stdgpu::for_each_index(stdgpu::execution::device, 1, const_begin_iterator_functor(hash_datastructure, result));
 
-    test_unordered_datastructure::const_iterator host_result;
+    test_unordered_datastructure::const_iterator host_result = {};
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<test_unordered_datastructure::const_iterator>(result);
@@ -732,7 +732,7 @@ cbegin_iterator(const test_unordered_datastructure& hash_datastructure)
 
     stdgpu::for_each_index(stdgpu::execution::device, 1, cbegin_iterator_functor(hash_datastructure, result));
 
-    test_unordered_datastructure::const_iterator host_result;
+    test_unordered_datastructure::const_iterator host_result = {};
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<test_unordered_datastructure::const_iterator>(result);
@@ -823,7 +823,7 @@ non_const_end_iterator(const test_unordered_datastructure& hash_datastructure)
 
     stdgpu::for_each_index(stdgpu::execution::device, 1, non_const_end_iterator_functor(hash_datastructure, result));
 
-    test_unordered_datastructure::iterator host_result;
+    test_unordered_datastructure::iterator host_result = {};
     copyDevice2HostArray<test_unordered_datastructure::iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<test_unordered_datastructure::iterator>(result);
@@ -839,7 +839,7 @@ const_end_iterator(const test_unordered_datastructure& hash_datastructure)
 
     stdgpu::for_each_index(stdgpu::execution::device, 1, const_end_iterator_functor(hash_datastructure, result));
 
-    test_unordered_datastructure::const_iterator host_result;
+    test_unordered_datastructure::const_iterator host_result = {};
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<test_unordered_datastructure::const_iterator>(result);
@@ -855,7 +855,7 @@ cend_iterator(const test_unordered_datastructure& hash_datastructure)
 
     stdgpu::for_each_index(stdgpu::execution::device, 1, cend_iterator_functor(hash_datastructure, result));
 
-    test_unordered_datastructure::const_iterator host_result;
+    test_unordered_datastructure::const_iterator host_result = {};
     copyDevice2HostArray<test_unordered_datastructure::const_iterator>(result, 1, &host_result, MemoryCopy::NO_CHECK);
 
     destroyDeviceArray<test_unordered_datastructure::const_iterator>(result);

--- a/test/stdgpu/unordered_map.inc
+++ b/test/stdgpu/unordered_map.inc
@@ -147,6 +147,14 @@ struct vec3int32
         // nontrivial destructor
     }
 
+    vec3int32(const vec3int32&) = default;
+    vec3int32&
+    operator=(const vec3int32&) = default;
+
+    vec3int32(vec3int32&&) = default;
+    vec3int32&
+    operator=(vec3int32&&) = default;
+
     std::int32_t x = 0; // NOLINT(misc-non-private-member-variables-in-classes)
     std::int32_t y = 0; // NOLINT(misc-non-private-member-variables-in-classes)
     std::int32_t z = 0; // NOLINT(misc-non-private-member-variables-in-classes)

--- a/test/stdgpu/unordered_set.inc
+++ b/test/stdgpu/unordered_set.inc
@@ -142,6 +142,14 @@ struct vec3int32
         // nontrivial destructor
     }
 
+    vec3int32(const vec3int32&) = default;
+    vec3int32&
+    operator=(const vec3int32&) = default;
+
+    vec3int32(vec3int32&&) = default;
+    vec3int32&
+    operator=(vec3int32&&) = default;
+
     std::int32_t x = 0; // NOLINT(misc-non-private-member-variables-in-classes)
     std::int32_t y = 0; // NOLINT(misc-non-private-member-variables-in-classes)
     std::int32_t z = 0; // NOLINT(misc-non-private-member-variables-in-classes)

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -246,6 +246,14 @@ public:
         // nontrivial destructor
     }
 
+    nondefault_int_vector(const nondefault_int_vector&) = default;
+    nondefault_int_vector&
+    operator=(const nondefault_int_vector&) = default;
+
+    nondefault_int_vector(nondefault_int_vector&&) = default;
+    nondefault_int_vector&
+    operator=(nondefault_int_vector&&) = default;
+
     STDGPU_HOST_DEVICE
     operator int() const // NOLINT(hicpp-explicit-conversions)
     {

--- a/test/test_memory_utils.h
+++ b/test/test_memory_utils.h
@@ -93,6 +93,17 @@ public:
     test_device_allocator(const test_device_allocator<U>& other);
 
     /**
+     * \brief Deleted move constructor
+     */
+    test_device_allocator(test_device_allocator&&) = delete;
+
+    /**
+     * \brief Deleted move assignment operator
+     */
+    test_device_allocator&
+    operator=(test_device_allocator&&) = delete;
+
+    /**
      * \brief Allocates a memory block of the given size
      * \param[in] n The size of the memory block in bytes
      * \return A pointer to the allocated memory block


### PR DESCRIPTION
The recent upgrade of the CI from Ubuntu 20.04 to 22.04 also resulted in having clang-tidy 14 in place which includes more checks than previous versions. Furthermore, more warnings have been enabled (in #327) such that the list of globally suppressed warnings grew over time. Fix various of these warnings and enable them to increase the code quality.