### PR TITLE
bit: Use std::byte in bit_cast implementation

### DIFF
--- a/src/stdgpu/impl/bit_detail.h
+++ b/src/stdgpu/impl/bit_detail.h
@@ -16,6 +16,8 @@
 #ifndef STDGPU_BIT_DETAIL_H
 #define STDGPU_BIT_DETAIL_H
 
+#include <cstddef>
+
 #include <stdgpu/contract.h>
 #include <stdgpu/limits.h>
 
@@ -136,12 +138,12 @@ bit_cast(const From& object)
     To result;
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    auto* result_bytes = reinterpret_cast<unsigned char*>(&result);
+    auto* result_bytes = reinterpret_cast<std::byte*>(&result);
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    const auto* object_bytes = reinterpret_cast<const unsigned char*>(&object);
+    const auto* object_bytes = reinterpret_cast<const std::byte*>(&object);
 
-    for (unsigned int i = 0; i < sizeof(To); ++i)
+    for (std::size_t i = 0; i < sizeof(To); ++i)
     {
         result_bytes[i] = object_bytes[i];
     }


### PR DESCRIPTION
C++17 also introduced `std:.byte` as a distinct type to better represent a collection of bits. Since the type aliasing rules for `reinterpret_cast` have been extended accordingly to also allow `std::byte` in addition to `char` and `unsigned char`, port the implementation of `bit_cast` to this new type.

Partially addresses #314