### PR TITLE
src,test: Add missing noexcept to many functions

### DIFF
--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -64,7 +64,7 @@ enum memory_order
  * \note The synchronization might be stricter than requested
  */
 STDGPU_DEVICE_ONLY void
-atomic_thread_fence(const memory_order order);
+atomic_thread_fence(const memory_order order) noexcept;
 
 /**
  * \ingroup atomic
@@ -73,7 +73,7 @@ atomic_thread_fence(const memory_order order);
  * \note The synchronization might be stricter than requested
  */
 STDGPU_DEVICE_ONLY void
-atomic_signal_fence(const memory_order order);
+atomic_signal_fence(const memory_order order) noexcept;
 
 /**
  * \ingroup atomic
@@ -127,21 +127,21 @@ public:
     /**
      * \brief Empty constructor
      */
-    atomic();
+    atomic() noexcept;
 
     /**
      * \brief Returns the container allocator
      * \return The container allocator
      */
     STDGPU_HOST_DEVICE allocator_type
-    get_allocator() const;
+    get_allocator() const noexcept;
 
     /**
      * \brief Checks whether the atomic operations are lock-free
      * \return True if the operations are lock-free, false otherwise
      */
     STDGPU_HOST_DEVICE bool
-    is_lock_free() const;
+    is_lock_free() const noexcept;
 
     /**
      * \brief Atomically loads and returns the current value of the atomic object
@@ -181,7 +181,7 @@ public:
      * \return The old value
      */
     STDGPU_DEVICE_ONLY T
-    exchange(const T desired, const memory_order order = memory_order_seq_cst);
+    exchange(const T desired, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically compares the current value with the given value and exchanges it with the desired one in case
@@ -191,7 +191,7 @@ public:
      * \return True if the value has been changed to desired, false otherwise
      */
     STDGPU_DEVICE_ONLY bool
-    compare_exchange_weak(T& expected, const T desired, const memory_order order = memory_order_seq_cst);
+    compare_exchange_weak(T& expected, const T desired, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically compares the current value with the given value and exchanges it with the desired one in case
@@ -201,7 +201,7 @@ public:
      * \return True if the value has been changed to desired, false otherwise
      */
     STDGPU_DEVICE_ONLY bool
-    compare_exchange_strong(T& expected, const T desired, const memory_order order = memory_order_seq_cst);
+    compare_exchange_strong(T& expected, const T desired, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the addition of the stored value and the given argument
@@ -211,7 +211,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_add(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_add(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the subtraction of the stored value and the given argument
@@ -221,7 +221,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_sub(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_sub(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the bitwise AND of the stored value and the given argument
@@ -231,7 +231,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_and(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_and(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the bitwise OR of the stored value and the given argument
@@ -241,7 +241,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_or(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_or(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the bitwise XOR of the stored value and the given argument
@@ -251,7 +251,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_xor(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_xor(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the minimum of the stored value and the given argument
@@ -261,7 +261,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_min(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_min(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the maximum of the stored value and the given argument
@@ -271,7 +271,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_max(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_max(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the incrementation of the value and modulus with arg
@@ -281,7 +281,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_inc_mod(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_inc_mod(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the decrementation of the value and modulus with arg
@@ -291,7 +291,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_dec_mod(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_dec_mod(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically increments the current value. Equivalent to fetch_add(1) + 1
@@ -299,7 +299,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator++();
+    operator++() noexcept;
 
     /**
      * \brief Atomically increments the current value. Equivalent to fetch_add(1)
@@ -307,7 +307,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator++(int);
+    operator++(int) noexcept;
 
     /**
      * \brief Atomically decrements the current value. Equivalent to fetch_sub(1) - 1
@@ -315,7 +315,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator--();
+    operator--() noexcept;
 
     /**
      * \brief Atomically decrements the current value. Equivalent to fetch_sub(1)
@@ -323,7 +323,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator--(int);
+    operator--(int) noexcept;
 
     /**
      * \brief Computes the atomic addition with the argument. Equivalent to fetch_add(arg) + arg
@@ -332,7 +332,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator+=(const T arg);
+    operator+=(const T arg) noexcept;
 
     /**
      * \brief Computes the atomic subtraction with the argument. Equivalent to fetch_sub(arg) + arg
@@ -341,7 +341,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator-=(const T arg);
+    operator-=(const T arg) noexcept;
 
     /**
      * \brief Computes the atomic bitwise AND with the argument. Equivalent to fetch_and(arg) & arg
@@ -350,7 +350,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator&=(const T arg);
+    operator&=(const T arg) noexcept;
 
     /**
      * \brief Computes the atomic bitwise OR with the argument. Equivalent to fetch_or(arg) | arg
@@ -359,7 +359,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator|=(const T arg);
+    operator|=(const T arg) noexcept;
 
     /**
      * \brief Computes the atomic bitwise XOR with the argument. Equivalent to fetch_xor(arg) ^ arg
@@ -368,10 +368,10 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator^=(const T arg);
+    operator^=(const T arg) noexcept;
 
 private:
-    explicit atomic(const Allocator& allocator);
+    explicit atomic(const Allocator& allocator) noexcept;
 
     atomic_ref<T> _value_ref;
     allocator_type _allocator = {};
@@ -420,14 +420,14 @@ public:
      * \param[in] obj A reference to the object
      */
     STDGPU_HOST_DEVICE
-    explicit atomic_ref(T& obj);
+    explicit atomic_ref(T& obj) noexcept;
 
     /**
      * \brief Checks whether the atomic operations are lock-free
      * \return True if the operations are lock-free, false otherwise
      */
     STDGPU_HOST_DEVICE bool
-    is_lock_free() const;
+    is_lock_free() const noexcept;
 
     /**
      * \brief Loads and returns the current value of the atomic object
@@ -469,7 +469,7 @@ public:
      * \return The old value
      */
     STDGPU_DEVICE_ONLY T
-    exchange(const T desired, const memory_order order = memory_order_seq_cst);
+    exchange(const T desired, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically compares the current value with the given value and exchanges it with the desired one in case
@@ -479,7 +479,7 @@ public:
      * \return True if the value has been changed to desired, false otherwise
      */
     STDGPU_DEVICE_ONLY bool
-    compare_exchange_weak(T& expected, const T desired, const memory_order order = memory_order_seq_cst);
+    compare_exchange_weak(T& expected, const T desired, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically compares the current value with the given value and exchanges it with the desired one in case
@@ -489,7 +489,7 @@ public:
      * \return True if the value has been changed to desired, false otherwise
      */
     STDGPU_DEVICE_ONLY bool
-    compare_exchange_strong(T& expected, const T desired, const memory_order order = memory_order_seq_cst);
+    compare_exchange_strong(T& expected, const T desired, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the addition of the stored value and the given argument
@@ -499,7 +499,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_add(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_add(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the subtraction of the stored value and the given argument
@@ -509,7 +509,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_sub(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_sub(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the bitwise AND of the stored value and the given argument
@@ -519,7 +519,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_and(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_and(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the bitwise OR of the stored value and the given argument
@@ -529,7 +529,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_or(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_or(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the bitwise XOR of the stored value and the given argument
@@ -539,7 +539,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_xor(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_xor(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the minimum of the stored value and the given argument
@@ -549,7 +549,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_min(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_min(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the maximum of the stored value and the given argument
@@ -559,7 +559,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_max(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_max(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the incrementation of the value and modulus with arg
@@ -569,7 +569,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_inc_mod(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_inc_mod(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the decrementation of the value and modulus with arg
@@ -579,7 +579,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
     STDGPU_DEVICE_ONLY T
-    fetch_dec_mod(const T arg, const memory_order order = memory_order_seq_cst);
+    fetch_dec_mod(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically increments the current value. Equivalent to fetch_add(1) + 1
@@ -587,7 +587,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator++();
+    operator++() noexcept;
 
     /**
      * \brief Atomically increments the current value. Equivalent to fetch_add(1)
@@ -595,7 +595,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator++(int);
+    operator++(int) noexcept;
 
     /**
      * \brief Atomically decrements the current value. Equivalent to fetch_sub(1) - 1
@@ -603,7 +603,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator--();
+    operator--() noexcept;
 
     /**
      * \brief Atomically decrements the current value. Equivalent to fetch_sub(1)
@@ -611,7 +611,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator--(int);
+    operator--(int) noexcept;
 
     /**
      * \brief Computes the atomic addition with the argument. Equivalent to fetch_add(arg) + arg
@@ -620,7 +620,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator+=(const T arg);
+    operator+=(const T arg) noexcept;
 
     /**
      * \brief Computes the atomic subtraction with the argument. Equivalent to fetch_sub(arg) + arg
@@ -629,7 +629,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator-=(const T arg);
+    operator-=(const T arg) noexcept;
 
     /**
      * \brief Computes the atomic bitwise AND with the argument. Equivalent to fetch_and(arg) & arg
@@ -638,7 +638,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator&=(const T arg);
+    operator&=(const T arg) noexcept;
 
     /**
      * \brief Computes the atomic bitwise OR with the argument. Equivalent to fetch_or(arg) | arg
@@ -647,7 +647,7 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator|=(const T arg);
+    operator|=(const T arg) noexcept;
 
     /**
      * \brief Computes the atomic bitwise XOR with the argument. Equivalent to fetch_xor(arg) ^ arg
@@ -656,14 +656,14 @@ public:
      */
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
     STDGPU_DEVICE_ONLY T
-    operator^=(const T arg);
+    operator^=(const T arg) noexcept;
 
 private:
     template <typename T2, typename Allocator>
     friend class atomic;
 
     STDGPU_HOST_DEVICE
-    explicit atomic_ref(T* value);
+    explicit atomic_ref(T* value) noexcept;
 
     T* _value = nullptr;
 };
@@ -676,7 +676,7 @@ private:
  */
 template <typename T, typename Allocator>
 STDGPU_HOST_DEVICE bool
-atomic_is_lock_free(const atomic<T, Allocator>* obj);
+atomic_is_lock_free(const atomic<T, Allocator>* obj) noexcept;
 
 /**
  * \ingroup atomic
@@ -686,7 +686,7 @@ atomic_is_lock_free(const atomic<T, Allocator>* obj);
  */
 template <typename T, typename Allocator>
 STDGPU_HOST_DEVICE T
-atomic_load(const atomic<T, Allocator>* obj);
+atomic_load(const atomic<T, Allocator>* obj) noexcept;
 
 /**
  * \ingroup atomic
@@ -697,7 +697,7 @@ atomic_load(const atomic<T, Allocator>* obj);
  */
 template <typename T, typename Allocator>
 STDGPU_HOST_DEVICE T
-atomic_load_explicit(const atomic<T, Allocator>* obj, const memory_order order);
+atomic_load_explicit(const atomic<T, Allocator>* obj, const memory_order order) noexcept;
 
 /**
  * \ingroup atomic
@@ -707,7 +707,7 @@ atomic_load_explicit(const atomic<T, Allocator>* obj, const memory_order order);
  */
 template <typename T, typename Allocator>
 STDGPU_HOST_DEVICE void
-atomic_store(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type desired);
+atomic_store(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type desired) noexcept;
 
 /**
  * \ingroup atomic
@@ -720,7 +720,7 @@ template <typename T, typename Allocator>
 STDGPU_HOST_DEVICE void
 atomic_store_explicit(atomic<T, Allocator>* obj,
                       const typename atomic<T, Allocator>::value_type desired,
-                      const memory_order order);
+                      const memory_order order) noexcept;
 
 /**
  * \ingroup atomic
@@ -731,7 +731,7 @@ atomic_store_explicit(atomic<T, Allocator>* obj,
  */
 template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
-atomic_exchange(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type desired);
+atomic_exchange(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type desired) noexcept;
 
 /**
  * \ingroup atomic
@@ -745,7 +745,7 @@ template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
 atomic_exchange_explicit(atomic<T, Allocator>* obj,
                          const typename atomic<T, Allocator>::value_type desired,
-                         const memory_order order);
+                         const memory_order order) noexcept;
 
 /**
  * \ingroup atomic
@@ -758,7 +758,7 @@ template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY bool
 atomic_compare_exchange_weak(atomic<T, Allocator>* obj,
                              typename atomic<T, Allocator>::value_type* expected,
-                             const typename atomic<T, Allocator>::value_type desired);
+                             const typename atomic<T, Allocator>::value_type desired) noexcept;
 
 /**
  * \ingroup atomic
@@ -771,7 +771,7 @@ template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY bool
 atomic_compare_exchange_strong(atomic<T, Allocator>* obj,
                                typename atomic<T, Allocator>::value_type* expected,
-                               const typename atomic<T, Allocator>::value_type desired);
+                               const typename atomic<T, Allocator>::value_type desired) noexcept;
 
 /**
  * \ingroup atomic
@@ -782,7 +782,7 @@ atomic_compare_exchange_strong(atomic<T, Allocator>* obj,
  */
 template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_add(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg);
+atomic_fetch_add(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept;
 
 /**
  * \ingroup atomic
@@ -796,7 +796,7 @@ template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_add_explicit(atomic<T, Allocator>* obj,
                           const typename atomic<T, Allocator>::difference_type arg,
-                          const memory_order order);
+                          const memory_order order) noexcept;
 
 /**
  * \ingroup atomic
@@ -807,7 +807,7 @@ atomic_fetch_add_explicit(atomic<T, Allocator>* obj,
  */
 template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_sub(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg);
+atomic_fetch_sub(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept;
 
 /**
  * \ingroup atomic
@@ -821,7 +821,7 @@ template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_sub_explicit(atomic<T, Allocator>* obj,
                           const typename atomic<T, Allocator>::difference_type arg,
-                          const memory_order order);
+                          const memory_order order) noexcept;
 
 /**
  * \ingroup atomic
@@ -832,7 +832,7 @@ atomic_fetch_sub_explicit(atomic<T, Allocator>* obj,
  */
 template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_and(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg);
+atomic_fetch_and(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept;
 
 /**
  * \ingroup atomic
@@ -846,7 +846,7 @@ template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and_explicit(atomic<T, Allocator>* obj,
                           const typename atomic<T, Allocator>::difference_type arg,
-                          const memory_order order);
+                          const memory_order order) noexcept;
 
 /**
  * \ingroup atomic
@@ -857,7 +857,7 @@ atomic_fetch_and_explicit(atomic<T, Allocator>* obj,
  */
 template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_or(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg);
+atomic_fetch_or(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept;
 
 /**
  * \ingroup atomic
@@ -871,7 +871,7 @@ template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or_explicit(atomic<T, Allocator>* obj,
                          const typename atomic<T, Allocator>::difference_type arg,
-                         const memory_order order);
+                         const memory_order order) noexcept;
 
 /**
  * \ingroup atomic
@@ -882,7 +882,7 @@ atomic_fetch_or_explicit(atomic<T, Allocator>* obj,
  */
 template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_xor(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg);
+atomic_fetch_xor(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept;
 
 /**
  * \ingroup atomic
@@ -896,7 +896,7 @@ template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor_explicit(atomic<T, Allocator>* obj,
                           const typename atomic<T, Allocator>::difference_type arg,
-                          const memory_order order);
+                          const memory_order order) noexcept;
 
 } // namespace stdgpu
 

--- a/src/stdgpu/bit.h
+++ b/src/stdgpu/bit.h
@@ -42,7 +42,7 @@ namespace stdgpu
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE bool
-has_single_bit(const T number);
+has_single_bit(const T number) noexcept;
 
 /**
  * \ingroup bit
@@ -52,7 +52,7 @@ has_single_bit(const T number);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
-bit_ceil(const T number);
+bit_ceil(const T number) noexcept;
 
 /**
  * \ingroup bit
@@ -62,7 +62,7 @@ bit_ceil(const T number);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
-bit_floor(const T number);
+bit_floor(const T number) noexcept;
 
 /**
  * \ingroup bit
@@ -76,7 +76,7 @@ bit_floor(const T number);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
-bit_mod(const T number, const T divider);
+bit_mod(const T number, const T divider) noexcept;
 
 /**
  * \ingroup bit
@@ -88,7 +88,7 @@ bit_mod(const T number, const T divider);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
-bit_width(const T number);
+bit_width(const T number) noexcept;
 
 /**
  * \ingroup bit
@@ -100,7 +100,7 @@ bit_width(const T number);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE int
-popcount(const T number);
+popcount(const T number) noexcept;
 
 /**
  * \ingroup bit
@@ -113,7 +113,7 @@ template <typename To,
           STDGPU_DETAIL_OVERLOAD_IF(sizeof(To) == sizeof(From) && std::is_trivially_copyable<To>::value &&
                                     std::is_trivially_copyable<From>::value)>
 STDGPU_HOST_DEVICE To
-bit_cast(const From& object);
+bit_cast(const From& object) noexcept;
 
 } // namespace stdgpu
 

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -76,14 +76,14 @@ public:
         /**
          * \brief Default destructor
          */
-        ~reference() = default;
+        ~reference() noexcept = default;
 
         /**
          * \brief Default copy constructor
          * \param[in] x The reference object to copy
          */
         STDGPU_HOST_DEVICE
-        reference(const reference& x) = default;
+        reference(const reference& x) noexcept = default;
 
         /**
          * \brief Performs atomic assignment of a bit value
@@ -91,7 +91,7 @@ public:
          * \return The old value of the bit
          */
         STDGPU_DEVICE_ONLY bool // NOLINT(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
-        operator=(bool x);
+        operator=(bool x) noexcept;
 
         /**
          * \brief Performs atomic assignment of a bit value
@@ -99,7 +99,7 @@ public:
          * \return The old value of the bit
          */
         STDGPU_DEVICE_ONLY bool // NOLINT(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
-        operator=(const reference& x);
+        operator=(const reference& x) noexcept;
 
         /**
          * \brief Deleted move constructor
@@ -117,21 +117,21 @@ public:
          * \return The value of the bit
          */
         STDGPU_DEVICE_ONLY
-        operator bool() const; // NOLINT(hicpp-explicit-conversions)
+        operator bool() const noexcept; // NOLINT(hicpp-explicit-conversions)
 
         /**
          * \brief Returns the inverse of the value of the bit
          * \return The inverse of the value of the bit
          */
         STDGPU_DEVICE_ONLY bool
-        operator~() const;
+        operator~() const noexcept;
 
         /**
          * \brief Flips the bit atomically
          * \return The old value of the bit
          */
         STDGPU_DEVICE_ONLY bool
-        flip();
+        flip() noexcept;
 
     private:
         using block_type = Block; /**< The type of the stored bit blocks, must be the same as for bitset */
@@ -146,7 +146,7 @@ public:
         reference(block_type* bit_block, const index_t bit_n);
 
         static STDGPU_DEVICE_ONLY bool
-        bit(block_type bits, const index_t n);
+        bit(block_type bits, const index_t n) noexcept;
 
         static constexpr index_t _bits_per_block = std::numeric_limits<block_type>::digits;
 
@@ -179,14 +179,14 @@ public:
     /**
      * \brief Empty constructor
      */
-    bitset() = default;
+    bitset() noexcept = default;
 
     /**
      * \brief Returns the container allocator
      * \return The container allocator
      */
     STDGPU_HOST_DEVICE allocator_type
-    get_allocator() const;
+    get_allocator() const noexcept;
 
     /**
      * \brief Sets all bits
@@ -268,14 +268,14 @@ public:
      * \return True if this object is empty, false otherwise
      */
     [[nodiscard]] STDGPU_HOST_DEVICE bool
-    empty() const;
+    empty() const noexcept;
 
     /**
      * \brief The size
      * \return The size of the object
      */
     STDGPU_HOST_DEVICE index_t
-    size() const;
+    size() const noexcept;
 
     /**
      * \brief The number of set bits
@@ -306,10 +306,10 @@ public:
     none() const;
 
 private:
-    explicit bitset(const Allocator& allocator);
+    explicit bitset(const Allocator& allocator) noexcept;
 
     static index_t
-    number_bit_blocks(const index_t size);
+    number_bit_blocks(const index_t size) noexcept;
 
     static constexpr index_t _bits_per_block = std::numeric_limits<block_type>::digits;
 

--- a/src/stdgpu/cuda/atomic.cuh
+++ b/src/stdgpu/cuda/atomic.cuh
@@ -28,13 +28,13 @@ namespace stdgpu::cuda
  * \return True if the operations are lock-free, false otherwise
  */
 STDGPU_HOST_DEVICE bool
-atomic_is_lock_free();
+atomic_is_lock_free() noexcept;
 
 /**
  * \brief A synchronization fence enforcing sequentially consistent memory ordering
  */
 STDGPU_DEVICE_ONLY void
-atomic_thread_fence();
+atomic_thread_fence() noexcept;
 
 /**
  * \brief Atomically loads and returns the current value of the atomic object
@@ -44,7 +44,7 @@ atomic_thread_fence();
  */
 template <typename T>
 STDGPU_DEVICE_ONLY T
-atomic_load(T* address);
+atomic_load(T* address) noexcept;
 
 /**
  * \brief Atomically replaces the current value with desired one
@@ -54,7 +54,7 @@ atomic_load(T* address);
  */
 template <typename T>
 STDGPU_DEVICE_ONLY void
-atomic_store(T* address, const T desired);
+atomic_store(T* address, const T desired) noexcept;
 
 /**
  * \brief Atomically exchanges the stored value with the given argument
@@ -65,7 +65,7 @@ atomic_store(T* address, const T desired);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_exchange(T* address, const T desired);
+atomic_exchange(T* address, const T desired) noexcept;
 
 /**
  * \brief Atomically exchanges the stored value with the given argument if it equals the expected value
@@ -77,7 +77,7 @@ atomic_exchange(T* address, const T desired);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_compare_exchange(T* address, const T expected, const T desired);
+atomic_compare_exchange(T* address, const T expected, const T desired) noexcept;
 
 /**
  * \brief Atomically computes and stores the addition of the stored value and the given argument
@@ -88,7 +88,7 @@ atomic_compare_exchange(T* address, const T expected, const T desired);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_add(T* address, const T arg);
+atomic_fetch_add(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the subtraction of the stored value and the given argument
@@ -99,7 +99,7 @@ atomic_fetch_add(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_sub(T* address, const T arg);
+atomic_fetch_sub(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the bitwise AND of the stored value and the given argument
@@ -110,7 +110,7 @@ atomic_fetch_sub(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_and(T* address, const T arg);
+atomic_fetch_and(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the bitwise OR of the stored value and the given argument
@@ -121,7 +121,7 @@ atomic_fetch_and(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_or(T* address, const T arg);
+atomic_fetch_or(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the bitwise XOR of the stored value and the given argument
@@ -132,7 +132,7 @@ atomic_fetch_or(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_xor(T* address, const T arg);
+atomic_fetch_xor(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the minimum of the stored value and the given argument
@@ -143,7 +143,7 @@ atomic_fetch_xor(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_min(T* address, const T arg);
+atomic_fetch_min(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the maximum of the stored value and the given argument
@@ -154,7 +154,7 @@ atomic_fetch_min(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_max(T* address, const T arg);
+atomic_fetch_max(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the incrementation of the value and modulus with arg
@@ -165,7 +165,7 @@ atomic_fetch_max(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_inc_mod(T* address, const T arg);
+atomic_fetch_inc_mod(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the decrementation of the value and modulus with arg
@@ -176,7 +176,7 @@ atomic_fetch_inc_mod(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_dec_mod(T* address, const T arg);
+atomic_fetch_dec_mod(T* address, const T arg) noexcept;
 
 } // namespace stdgpu::cuda
 

--- a/src/stdgpu/cuda/impl/atomic_detail.cuh
+++ b/src/stdgpu/cuda/impl/atomic_detail.cuh
@@ -70,20 +70,20 @@ namespace stdgpu::cuda
 {
 
 inline STDGPU_HOST_DEVICE bool
-atomic_is_lock_free()
+atomic_is_lock_free() noexcept
 {
     return true;
 }
 
 inline STDGPU_DEVICE_ONLY void
-atomic_thread_fence()
+atomic_thread_fence() noexcept
 {
     __threadfence();
 }
 
 template <typename T>
 STDGPU_DEVICE_ONLY T
-atomic_load(T* address)
+atomic_load(T* address) noexcept
 {
     volatile T* volatile_address = address;
     T current = *volatile_address;
@@ -93,7 +93,7 @@ atomic_load(T* address)
 
 template <typename T>
 STDGPU_DEVICE_ONLY void
-atomic_store(T* address, const T desired)
+atomic_store(T* address, const T desired) noexcept
 {
     volatile T* volatile_address = address;
     *volatile_address = desired;
@@ -102,7 +102,7 @@ atomic_store(T* address, const T desired)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_exchange(T* address, const T desired)
+atomic_exchange(T* address, const T desired) noexcept
 {
     return atomicExch(address, desired);
 }
@@ -110,7 +110,7 @@ atomic_exchange(T* address, const T desired)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_compare_exchange(T* address, const T expected, const T desired)
+atomic_compare_exchange(T* address, const T expected, const T desired) noexcept
 {
     return atomicCAS(address, expected, desired);
 }
@@ -118,7 +118,7 @@ atomic_compare_exchange(T* address, const T expected, const T desired)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_add(T* address, const T arg)
+atomic_fetch_add(T* address, const T arg) noexcept
 {
     return atomicAdd(address, arg);
 }
@@ -126,28 +126,28 @@ atomic_fetch_add(T* address, const T arg)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_sub(T* address, const T arg)
+atomic_fetch_sub(T* address, const T arg) noexcept
 {
     return atomicSub(address, arg);
 }
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_and(T* address, const T arg)
+atomic_fetch_and(T* address, const T arg) noexcept
 {
     return atomicAnd(address, arg);
 }
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_or(T* address, const T arg)
+atomic_fetch_or(T* address, const T arg) noexcept
 {
     return atomicOr(address, arg);
 }
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_xor(T* address, const T arg)
+atomic_fetch_xor(T* address, const T arg) noexcept
 {
     return atomicXor(address, arg);
 }
@@ -155,7 +155,7 @@ atomic_fetch_xor(T* address, const T arg)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_min(T* address, const T arg)
+atomic_fetch_min(T* address, const T arg) noexcept
 {
     return atomicMin(address, arg);
 }
@@ -163,21 +163,21 @@ atomic_fetch_min(T* address, const T arg)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_max(T* address, const T arg)
+atomic_fetch_max(T* address, const T arg) noexcept
 {
     return atomicMax(address, arg);
 }
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_inc_mod(T* address, const T arg)
+atomic_fetch_inc_mod(T* address, const T arg) noexcept
 {
     return atomicInc(address, arg);
 }
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_dec_mod(T* address, const T arg)
+atomic_fetch_dec_mod(T* address, const T arg) noexcept
 {
     return atomicDec(address, arg);
 }

--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -99,14 +99,14 @@ public:
     /**
      * \brief Empty constructor
      */
-    deque() = default;
+    deque() noexcept = default;
 
     /**
      * \brief Returns the container allocator
      * \return The container allocator
      */
     STDGPU_HOST_DEVICE allocator_type
-    get_allocator() const;
+    get_allocator() const noexcept;
 
     /**
      * \brief Reads the value at position n
@@ -246,14 +246,14 @@ public:
      * \return The maximal size
      */
     STDGPU_HOST_DEVICE index_t
-    max_size() const;
+    max_size() const noexcept;
 
     /**
      * \brief Returns the capacity
      * \return The capacity
      */
     STDGPU_HOST_DEVICE index_t
-    capacity() const;
+    capacity() const noexcept;
 
     /**
      * \brief Requests to shrink the capacity to the current size
@@ -267,14 +267,14 @@ public:
      * \return The underlying array
      */
     const T*
-    data() const;
+    data() const noexcept;
 
     /**
      * \brief Returns a pointer to the underlying data
      * \return The underlying array
      */
     T*
-    data();
+    data() noexcept;
 
     /**
      * \brief Clears the complete object

--- a/src/stdgpu/functional.h
+++ b/src/stdgpu/functional.h
@@ -366,7 +366,7 @@ struct identity
      */
     template <typename T>
     STDGPU_HOST_DEVICE T&&
-    operator()(T&& t) const;
+    operator()(T&& t) const noexcept;
 };
 
 /**

--- a/src/stdgpu/hip/atomic.h
+++ b/src/stdgpu/hip/atomic.h
@@ -28,13 +28,13 @@ namespace stdgpu::hip
  * \return True if the operations are lock-free, false otherwise
  */
 STDGPU_HOST_DEVICE bool
-atomic_is_lock_free();
+atomic_is_lock_free() noexcept;
 
 /**
  * \brief A synchronization fence enforcing sequentially consistent memory ordering
  */
 STDGPU_DEVICE_ONLY void
-atomic_thread_fence();
+atomic_thread_fence() noexcept;
 
 /**
  * \brief Atomically loads and returns the current value of the atomic object
@@ -44,7 +44,7 @@ atomic_thread_fence();
  */
 template <typename T>
 STDGPU_DEVICE_ONLY T
-atomic_load(T* address);
+atomic_load(T* address) noexcept;
 
 /**
  * \brief Atomically replaces the current value with desired one
@@ -54,7 +54,7 @@ atomic_load(T* address);
  */
 template <typename T>
 STDGPU_DEVICE_ONLY void
-atomic_store(T* address, const T desired);
+atomic_store(T* address, const T desired) noexcept;
 
 /**
  * \brief Atomically exchanges the stored value with the given argument
@@ -65,7 +65,7 @@ atomic_store(T* address, const T desired);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_exchange(T* address, const T desired);
+atomic_exchange(T* address, const T desired) noexcept;
 
 /**
  * \brief Atomically exchanges the stored value with the given argument if it equals the expected value
@@ -77,7 +77,7 @@ atomic_exchange(T* address, const T desired);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_compare_exchange(T* address, const T expected, const T desired);
+atomic_compare_exchange(T* address, const T expected, const T desired) noexcept;
 
 /**
  * \brief Atomically computes and stores the addition of the stored value and the given argument
@@ -88,7 +88,7 @@ atomic_compare_exchange(T* address, const T expected, const T desired);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_add(T* address, const T arg);
+atomic_fetch_add(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the subtraction of the stored value and the given argument
@@ -99,7 +99,7 @@ atomic_fetch_add(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_sub(T* address, const T arg);
+atomic_fetch_sub(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the bitwise AND of the stored value and the given argument
@@ -110,7 +110,7 @@ atomic_fetch_sub(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_and(T* address, const T arg);
+atomic_fetch_and(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the bitwise OR of the stored value and the given argument
@@ -121,7 +121,7 @@ atomic_fetch_and(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_or(T* address, const T arg);
+atomic_fetch_or(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the bitwise XOR of the stored value and the given argument
@@ -132,7 +132,7 @@ atomic_fetch_or(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_xor(T* address, const T arg);
+atomic_fetch_xor(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the minimum of the stored value and the given argument
@@ -143,7 +143,7 @@ atomic_fetch_xor(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_min(T* address, const T arg);
+atomic_fetch_min(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the maximum of the stored value and the given argument
@@ -154,7 +154,7 @@ atomic_fetch_min(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_max(T* address, const T arg);
+atomic_fetch_max(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the incrementation of the value and modulus with arg
@@ -165,7 +165,7 @@ atomic_fetch_max(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_inc_mod(T* address, const T arg);
+atomic_fetch_inc_mod(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the decrementation of the value and modulus with arg
@@ -176,7 +176,7 @@ atomic_fetch_inc_mod(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_dec_mod(T* address, const T arg);
+atomic_fetch_dec_mod(T* address, const T arg) noexcept;
 
 } // namespace stdgpu::hip
 

--- a/src/stdgpu/hip/impl/atomic_detail.h
+++ b/src/stdgpu/hip/impl/atomic_detail.h
@@ -24,20 +24,20 @@ namespace stdgpu::hip
 {
 
 inline STDGPU_HOST_DEVICE bool
-atomic_is_lock_free()
+atomic_is_lock_free() noexcept
 {
     return true;
 }
 
 inline STDGPU_DEVICE_ONLY void
-atomic_thread_fence()
+atomic_thread_fence() noexcept
 {
     __threadfence();
 }
 
 template <typename T>
 STDGPU_DEVICE_ONLY T
-atomic_load(T* address)
+atomic_load(T* address) noexcept
 {
     volatile T* volatile_address = address;
     T current = *volatile_address;
@@ -47,7 +47,7 @@ atomic_load(T* address)
 
 template <typename T>
 STDGPU_DEVICE_ONLY void
-atomic_store(T* address, const T desired)
+atomic_store(T* address, const T desired) noexcept
 {
     volatile T* volatile_address = address;
     *volatile_address = desired;
@@ -56,7 +56,7 @@ atomic_store(T* address, const T desired)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_exchange(T* address, const T desired)
+atomic_exchange(T* address, const T desired) noexcept
 {
     return atomicExch(address, desired);
 }
@@ -64,7 +64,7 @@ atomic_exchange(T* address, const T desired)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_compare_exchange(T* address, const T expected, const T desired)
+atomic_compare_exchange(T* address, const T expected, const T desired) noexcept
 {
     return atomicCAS(address, expected, desired);
 }
@@ -72,7 +72,7 @@ atomic_compare_exchange(T* address, const T expected, const T desired)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_add(T* address, const T arg)
+atomic_fetch_add(T* address, const T arg) noexcept
 {
     return atomicAdd(address, arg);
 }
@@ -80,28 +80,28 @@ atomic_fetch_add(T* address, const T arg)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_sub(T* address, const T arg)
+atomic_fetch_sub(T* address, const T arg) noexcept
 {
     return atomicSub(address, arg);
 }
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_and(T* address, const T arg)
+atomic_fetch_and(T* address, const T arg) noexcept
 {
     return atomicAnd(address, arg);
 }
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_or(T* address, const T arg)
+atomic_fetch_or(T* address, const T arg) noexcept
 {
     return atomicOr(address, arg);
 }
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_xor(T* address, const T arg)
+atomic_fetch_xor(T* address, const T arg) noexcept
 {
     return atomicXor(address, arg);
 }
@@ -109,7 +109,7 @@ atomic_fetch_xor(T* address, const T arg)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_min(T* address, const T arg)
+atomic_fetch_min(T* address, const T arg) noexcept
 {
     return atomicMin(address, arg);
 }
@@ -117,21 +117,21 @@ atomic_fetch_min(T* address, const T arg)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_max(T* address, const T arg)
+atomic_fetch_max(T* address, const T arg) noexcept
 {
     return atomicMax(address, arg);
 }
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_inc_mod(T* address, const T arg)
+atomic_fetch_inc_mod(T* address, const T arg) noexcept
 {
     return atomicInc(address, arg);
 }
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_dec_mod(T* address, const T arg)
+atomic_fetch_dec_mod(T* address, const T arg) noexcept
 {
     return atomicDec(address, arg);
 }

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -31,7 +31,7 @@ namespace stdgpu
 namespace detail
 {
 inline STDGPU_DEVICE_ONLY void
-atomic_load_thread_fence(const memory_order order)
+atomic_load_thread_fence(const memory_order order) noexcept
 {
     switch (order)
     {
@@ -54,7 +54,7 @@ atomic_load_thread_fence(const memory_order order)
 }
 
 inline STDGPU_DEVICE_ONLY void
-atomic_store_thread_fence(const memory_order order)
+atomic_store_thread_fence(const memory_order order) noexcept
 {
     switch (order)
     {
@@ -77,7 +77,7 @@ atomic_store_thread_fence(const memory_order order)
 }
 
 inline STDGPU_DEVICE_ONLY void
-atomic_consistency_thread_fence(const memory_order order)
+atomic_consistency_thread_fence(const memory_order order) noexcept
 {
     switch (order)
     {
@@ -101,7 +101,7 @@ atomic_consistency_thread_fence(const memory_order order)
 } // namespace detail
 
 inline STDGPU_DEVICE_ONLY void
-atomic_thread_fence(const memory_order order)
+atomic_thread_fence(const memory_order order) noexcept
 {
     switch (order)
     {
@@ -124,7 +124,7 @@ atomic_thread_fence(const memory_order order)
 }
 
 inline STDGPU_DEVICE_ONLY void
-atomic_signal_fence(const memory_order order)
+atomic_signal_fence(const memory_order order) noexcept
 {
     atomic_thread_fence(order);
 }
@@ -147,13 +147,13 @@ atomic<T, Allocator>::destroyDeviceObject(atomic<T, Allocator>& device_object)
 }
 
 template <typename T, typename Allocator>
-inline atomic<T, Allocator>::atomic()
+inline atomic<T, Allocator>::atomic() noexcept
   : _value_ref(nullptr)
 {
 }
 
 template <typename T, typename Allocator>
-inline atomic<T, Allocator>::atomic(const Allocator& allocator)
+inline atomic<T, Allocator>::atomic(const Allocator& allocator) noexcept
   : _value_ref(nullptr)
   , _allocator(allocator)
 {
@@ -161,14 +161,14 @@ inline atomic<T, Allocator>::atomic(const Allocator& allocator)
 
 template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE typename atomic<T, Allocator>::allocator_type
-atomic<T, Allocator>::get_allocator() const
+atomic<T, Allocator>::get_allocator() const noexcept
 {
     return _allocator;
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE bool
-atomic<T, Allocator>::is_lock_free() const
+atomic<T, Allocator>::is_lock_free() const noexcept
 {
     return _value_ref.is_lock_free();
 }
@@ -204,21 +204,21 @@ atomic<T, Allocator>::operator=(const T desired)
 
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::exchange(const T desired, const memory_order order)
+atomic<T, Allocator>::exchange(const T desired, const memory_order order) noexcept
 {
     return _value_ref.exchange(desired, order);
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY bool
-atomic<T, Allocator>::compare_exchange_weak(T& expected, const T desired, const memory_order order)
+atomic<T, Allocator>::compare_exchange_weak(T& expected, const T desired, const memory_order order) noexcept
 {
     return _value_ref.compare_exchange_weak(expected, desired, order);
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY bool
-atomic<T, Allocator>::compare_exchange_strong(T& expected, const T desired, const memory_order order)
+atomic<T, Allocator>::compare_exchange_strong(T& expected, const T desired, const memory_order order) noexcept
 {
     return _value_ref.compare_exchange_strong(expected, desired, order);
 }
@@ -226,7 +226,7 @@ atomic<T, Allocator>::compare_exchange_strong(T& expected, const T desired, cons
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::fetch_add(const T arg, const memory_order order)
+atomic<T, Allocator>::fetch_add(const T arg, const memory_order order) noexcept
 {
     return _value_ref.fetch_add(arg, order);
 }
@@ -234,7 +234,7 @@ atomic<T, Allocator>::fetch_add(const T arg, const memory_order order)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::fetch_sub(const T arg, const memory_order order)
+atomic<T, Allocator>::fetch_sub(const T arg, const memory_order order) noexcept
 {
     return _value_ref.fetch_sub(arg, order);
 }
@@ -242,7 +242,7 @@ atomic<T, Allocator>::fetch_sub(const T arg, const memory_order order)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::fetch_and(const T arg, const memory_order order)
+atomic<T, Allocator>::fetch_and(const T arg, const memory_order order) noexcept
 {
     return _value_ref.fetch_and(arg, order);
 }
@@ -250,7 +250,7 @@ atomic<T, Allocator>::fetch_and(const T arg, const memory_order order)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::fetch_or(const T arg, const memory_order order)
+atomic<T, Allocator>::fetch_or(const T arg, const memory_order order) noexcept
 {
     return _value_ref.fetch_or(arg, order);
 }
@@ -258,7 +258,7 @@ atomic<T, Allocator>::fetch_or(const T arg, const memory_order order)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::fetch_xor(const T arg, const memory_order order)
+atomic<T, Allocator>::fetch_xor(const T arg, const memory_order order) noexcept
 {
     return _value_ref.fetch_xor(arg, order);
 }
@@ -266,7 +266,7 @@ atomic<T, Allocator>::fetch_xor(const T arg, const memory_order order)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::fetch_min(const T arg, const memory_order order)
+atomic<T, Allocator>::fetch_min(const T arg, const memory_order order) noexcept
 {
     return _value_ref.fetch_min(arg, order);
 }
@@ -274,7 +274,7 @@ atomic<T, Allocator>::fetch_min(const T arg, const memory_order order)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::fetch_max(const T arg, const memory_order order)
+atomic<T, Allocator>::fetch_max(const T arg, const memory_order order) noexcept
 {
     return _value_ref.fetch_max(arg, order);
 }
@@ -282,7 +282,7 @@ atomic<T, Allocator>::fetch_max(const T arg, const memory_order order)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::fetch_inc_mod(const T arg, const memory_order order)
+atomic<T, Allocator>::fetch_inc_mod(const T arg, const memory_order order) noexcept
 {
     return _value_ref.fetch_inc_mod(arg, order);
 }
@@ -290,7 +290,7 @@ atomic<T, Allocator>::fetch_inc_mod(const T arg, const memory_order order)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::fetch_dec_mod(const T arg, const memory_order order)
+atomic<T, Allocator>::fetch_dec_mod(const T arg, const memory_order order) noexcept
 {
     return _value_ref.fetch_dec_mod(arg, order);
 }
@@ -298,7 +298,7 @@ atomic<T, Allocator>::fetch_dec_mod(const T arg, const memory_order order)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::operator++()
+atomic<T, Allocator>::operator++() noexcept
 {
     return ++_value_ref;
 }
@@ -306,7 +306,7 @@ atomic<T, Allocator>::operator++()
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::operator++(int)
+atomic<T, Allocator>::operator++(int) noexcept
 {
     return _value_ref++;
 }
@@ -314,7 +314,7 @@ atomic<T, Allocator>::operator++(int)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::operator--()
+atomic<T, Allocator>::operator--() noexcept
 {
     return --_value_ref;
 }
@@ -322,7 +322,7 @@ atomic<T, Allocator>::operator--()
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::operator--(int)
+atomic<T, Allocator>::operator--(int) noexcept
 {
     return _value_ref--;
 }
@@ -330,7 +330,7 @@ atomic<T, Allocator>::operator--(int)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::operator+=(const T arg)
+atomic<T, Allocator>::operator+=(const T arg) noexcept
 {
     return _value_ref += arg;
 }
@@ -338,7 +338,7 @@ atomic<T, Allocator>::operator+=(const T arg)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::operator-=(const T arg)
+atomic<T, Allocator>::operator-=(const T arg) noexcept
 {
     return _value_ref -= arg;
 }
@@ -346,7 +346,7 @@ atomic<T, Allocator>::operator-=(const T arg)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::operator&=(const T arg)
+atomic<T, Allocator>::operator&=(const T arg) noexcept
 {
     return _value_ref &= arg;
 }
@@ -354,7 +354,7 @@ atomic<T, Allocator>::operator&=(const T arg)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::operator|=(const T arg)
+atomic<T, Allocator>::operator|=(const T arg) noexcept
 {
     return _value_ref |= arg;
 }
@@ -362,28 +362,28 @@ atomic<T, Allocator>::operator|=(const T arg)
 template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::operator^=(const T arg)
+atomic<T, Allocator>::operator^=(const T arg) noexcept
 {
     return _value_ref ^= arg;
 }
 
 template <typename T>
 inline STDGPU_HOST_DEVICE
-atomic_ref<T>::atomic_ref(T& obj)
+atomic_ref<T>::atomic_ref(T& obj) noexcept
   : _value(&obj)
 {
 }
 
 template <typename T>
 inline STDGPU_HOST_DEVICE
-atomic_ref<T>::atomic_ref(T* value)
+atomic_ref<T>::atomic_ref(T* value) noexcept
   : _value(value)
 {
 }
 
 template <typename T>
 inline STDGPU_HOST_DEVICE bool
-atomic_ref<T>::is_lock_free() const
+atomic_ref<T>::is_lock_free() const noexcept
 {
     return stdgpu::STDGPU_BACKEND_NAMESPACE::atomic_is_lock_free();
 }
@@ -450,7 +450,7 @@ atomic_ref<T>::operator=(const T desired)
 
 template <typename T>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::exchange(const T desired, const memory_order order)
+atomic_ref<T>::exchange(const T desired, const memory_order order) noexcept
 {
     detail::atomic_load_thread_fence(order);
 
@@ -463,14 +463,14 @@ atomic_ref<T>::exchange(const T desired, const memory_order order)
 
 template <typename T>
 inline STDGPU_DEVICE_ONLY bool
-atomic_ref<T>::compare_exchange_weak(T& expected, const T desired, const memory_order order)
+atomic_ref<T>::compare_exchange_weak(T& expected, const T desired, const memory_order order) noexcept
 {
     return compare_exchange_strong(expected, desired, order);
 }
 
 template <typename T>
 inline STDGPU_DEVICE_ONLY bool
-atomic_ref<T>::compare_exchange_strong(T& expected, const T desired, const memory_order order)
+atomic_ref<T>::compare_exchange_strong(T& expected, const T desired, const memory_order order) noexcept
 {
     detail::atomic_load_thread_fence(order);
 
@@ -490,7 +490,7 @@ atomic_ref<T>::compare_exchange_strong(T& expected, const T desired, const memor
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::fetch_add(const T arg, const memory_order order)
+atomic_ref<T>::fetch_add(const T arg, const memory_order order) noexcept
 {
     detail::atomic_load_thread_fence(order);
 
@@ -504,7 +504,7 @@ atomic_ref<T>::fetch_add(const T arg, const memory_order order)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::fetch_sub(const T arg, const memory_order order)
+atomic_ref<T>::fetch_sub(const T arg, const memory_order order) noexcept
 {
     detail::atomic_load_thread_fence(order);
 
@@ -518,7 +518,7 @@ atomic_ref<T>::fetch_sub(const T arg, const memory_order order)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::fetch_and(const T arg, const memory_order order)
+atomic_ref<T>::fetch_and(const T arg, const memory_order order) noexcept
 {
     detail::atomic_load_thread_fence(order);
 
@@ -532,7 +532,7 @@ atomic_ref<T>::fetch_and(const T arg, const memory_order order)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::fetch_or(const T arg, const memory_order order)
+atomic_ref<T>::fetch_or(const T arg, const memory_order order) noexcept
 {
     detail::atomic_load_thread_fence(order);
 
@@ -546,7 +546,7 @@ atomic_ref<T>::fetch_or(const T arg, const memory_order order)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::fetch_xor(const T arg, const memory_order order)
+atomic_ref<T>::fetch_xor(const T arg, const memory_order order) noexcept
 {
     detail::atomic_load_thread_fence(order);
 
@@ -560,7 +560,7 @@ atomic_ref<T>::fetch_xor(const T arg, const memory_order order)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::fetch_min(const T arg, const memory_order order)
+atomic_ref<T>::fetch_min(const T arg, const memory_order order) noexcept
 {
     detail::atomic_load_thread_fence(order);
 
@@ -574,7 +574,7 @@ atomic_ref<T>::fetch_min(const T arg, const memory_order order)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::fetch_max(const T arg, const memory_order order)
+atomic_ref<T>::fetch_max(const T arg, const memory_order order) noexcept
 {
     detail::atomic_load_thread_fence(order);
 
@@ -588,7 +588,7 @@ atomic_ref<T>::fetch_max(const T arg, const memory_order order)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::fetch_inc_mod(const T arg, const memory_order order)
+atomic_ref<T>::fetch_inc_mod(const T arg, const memory_order order) noexcept
 {
     detail::atomic_load_thread_fence(order);
 
@@ -602,7 +602,7 @@ atomic_ref<T>::fetch_inc_mod(const T arg, const memory_order order)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::fetch_dec_mod(const T arg, const memory_order order)
+atomic_ref<T>::fetch_dec_mod(const T arg, const memory_order order) noexcept
 {
     detail::atomic_load_thread_fence(order);
 
@@ -616,7 +616,7 @@ atomic_ref<T>::fetch_dec_mod(const T arg, const memory_order order)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::operator++()
+atomic_ref<T>::operator++() noexcept
 {
     return fetch_add(1) + 1;
 }
@@ -624,7 +624,7 @@ atomic_ref<T>::operator++()
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::operator++(int)
+atomic_ref<T>::operator++(int) noexcept
 {
     return fetch_add(1);
 }
@@ -632,7 +632,7 @@ atomic_ref<T>::operator++(int)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::operator--()
+atomic_ref<T>::operator--() noexcept
 {
     return fetch_sub(1) - 1;
 }
@@ -640,7 +640,7 @@ atomic_ref<T>::operator--()
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::operator--(int)
+atomic_ref<T>::operator--(int) noexcept
 {
     return fetch_sub(1);
 }
@@ -648,7 +648,7 @@ atomic_ref<T>::operator--(int)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::operator+=(const T arg)
+atomic_ref<T>::operator+=(const T arg) noexcept
 {
     return fetch_add(arg) + arg;
 }
@@ -656,7 +656,7 @@ atomic_ref<T>::operator+=(const T arg)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::operator-=(const T arg)
+atomic_ref<T>::operator-=(const T arg) noexcept
 {
     return fetch_sub(arg) - arg;
 }
@@ -664,7 +664,7 @@ atomic_ref<T>::operator-=(const T arg)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::operator&=(const T arg)
+atomic_ref<T>::operator&=(const T arg) noexcept
 {
     return fetch_and(arg) & arg; // NOLINT(hicpp-signed-bitwise)
 }
@@ -672,7 +672,7 @@ atomic_ref<T>::operator&=(const T arg)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::operator|=(const T arg)
+atomic_ref<T>::operator|=(const T arg) noexcept
 {
     return fetch_or(arg) | arg; // NOLINT(hicpp-signed-bitwise)
 }
@@ -680,35 +680,35 @@ atomic_ref<T>::operator|=(const T arg)
 template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::operator^=(const T arg)
+atomic_ref<T>::operator^=(const T arg) noexcept
 {
     return fetch_xor(arg) ^ arg; // NOLINT(hicpp-signed-bitwise)
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE bool
-atomic_is_lock_free(const atomic<T, Allocator>* obj)
+atomic_is_lock_free(const atomic<T, Allocator>* obj) noexcept
 {
     return obj->is_lock_free();
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE T
-atomic_load(const atomic<T, Allocator>* obj)
+atomic_load(const atomic<T, Allocator>* obj) noexcept
 {
     return obj->load();
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE T
-atomic_load_explicit(const atomic<T, Allocator>* obj, const memory_order order)
+atomic_load_explicit(const atomic<T, Allocator>* obj, const memory_order order) noexcept
 {
     return obj->load(order);
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE void
-atomic_store(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type desired)
+atomic_store(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type desired) noexcept
 {
     obj->store(desired);
 }
@@ -717,14 +717,14 @@ template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE void
 atomic_store_explicit(atomic<T, Allocator>* obj,
                       const typename atomic<T, Allocator>::value_type desired,
-                      const memory_order order)
+                      const memory_order order) noexcept
 {
     obj->store(desired, order);
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
-atomic_exchange(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type desired)
+atomic_exchange(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type desired) noexcept
 {
     return obj->exchange(desired);
 }
@@ -733,7 +733,7 @@ template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
 atomic_exchange_explicit(atomic<T, Allocator>* obj,
                          const typename atomic<T, Allocator>::value_type desired,
-                         const memory_order order)
+                         const memory_order order) noexcept
 {
     return obj->exchange(desired, order);
 }
@@ -742,7 +742,7 @@ template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY bool
 atomic_compare_exchange_weak(atomic<T, Allocator>* obj,
                              typename atomic<T, Allocator>::value_type* expected,
-                             const typename atomic<T, Allocator>::value_type desired)
+                             const typename atomic<T, Allocator>::value_type desired) noexcept
 {
     return obj->compare_exchange_weak(*expected, desired);
 }
@@ -751,14 +751,14 @@ template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY bool
 atomic_compare_exchange_strong(atomic<T, Allocator>* obj,
                                typename atomic<T, Allocator>::value_type* expected,
-                               const typename atomic<T, Allocator>::value_type desired)
+                               const typename atomic<T, Allocator>::value_type desired) noexcept
 {
     return obj->compare_exchange_strong(*expected, desired);
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
-atomic_fetch_add(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg)
+atomic_fetch_add(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept
 {
     return obj->fetch_add(arg);
 }
@@ -767,14 +767,14 @@ template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
 atomic_fetch_add_explicit(atomic<T, Allocator>* obj,
                           const typename atomic<T, Allocator>::difference_type arg,
-                          const memory_order order)
+                          const memory_order order) noexcept
 {
     return obj->fetch_add(arg, order);
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
-atomic_fetch_sub(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg)
+atomic_fetch_sub(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept
 {
     return obj->fetch_sub(arg);
 }
@@ -783,14 +783,14 @@ template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
 atomic_fetch_sub_explicit(atomic<T, Allocator>* obj,
                           const typename atomic<T, Allocator>::difference_type arg,
-                          const memory_order order)
+                          const memory_order order) noexcept
 {
     return obj->fetch_sub(arg, order);
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
-atomic_fetch_and(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg)
+atomic_fetch_and(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept
 {
     return obj->fetch_and(arg);
 }
@@ -799,14 +799,14 @@ template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
 atomic_fetch_and_explicit(atomic<T, Allocator>* obj,
                           const typename atomic<T, Allocator>::difference_type arg,
-                          const memory_order order)
+                          const memory_order order) noexcept
 {
     return obj->fetch_and(arg, order);
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
-atomic_fetch_or(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg)
+atomic_fetch_or(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept
 {
     return obj->fetch_or(arg);
 }
@@ -815,14 +815,14 @@ template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
 atomic_fetch_or_explicit(atomic<T, Allocator>* obj,
                          const typename atomic<T, Allocator>::difference_type arg,
-                         const memory_order order)
+                         const memory_order order) noexcept
 {
     return obj->fetch_or(arg, order);
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
-atomic_fetch_xor(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg)
+atomic_fetch_xor(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept
 {
     return obj->fetch_xor(arg);
 }
@@ -831,7 +831,7 @@ template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
 atomic_fetch_xor_explicit(atomic<T, Allocator>* obj,
                           const typename atomic<T, Allocator>::difference_type arg,
-                          const memory_order order)
+                          const memory_order order) noexcept
 {
     return obj->fetch_xor(arg, order);
 }

--- a/src/stdgpu/impl/bit_detail.h
+++ b/src/stdgpu/impl/bit_detail.h
@@ -26,14 +26,14 @@ namespace stdgpu
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE bool
-has_single_bit(const T number)
+has_single_bit(const T number) noexcept
 {
     return ((number != 0) && !(number & (number - static_cast<T>(1))));
 }
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
-bit_ceil(const T number)
+bit_ceil(const T number) noexcept
 {
     T result = number;
 
@@ -56,7 +56,7 @@ bit_ceil(const T number)
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
-bit_floor(const T number)
+bit_floor(const T number) noexcept
 {
     // Special case zero
     if (number == 0)
@@ -78,7 +78,7 @@ bit_floor(const T number)
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
-bit_mod(const T number, const T divider)
+bit_mod(const T number, const T divider) noexcept
 {
     STDGPU_EXPECTS(has_single_bit(divider));
 
@@ -91,7 +91,7 @@ bit_mod(const T number, const T divider)
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE T
-bit_width(const T number)
+bit_width(const T number) noexcept
 {
     if (number == 0)
     {
@@ -112,7 +112,7 @@ bit_width(const T number)
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
 STDGPU_HOST_DEVICE int
-popcount(const T number)
+popcount(const T number) noexcept
 {
     int result = 0;
     T cleared_number = number;
@@ -133,7 +133,7 @@ template <typename To,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(sizeof(To) == sizeof(From) && std::is_trivially_copyable<To>::value &&
                                                std::is_trivially_copyable<From>::value)>
 STDGPU_HOST_DEVICE To
-bit_cast(const From& object)
+bit_cast(const From& object) noexcept
 {
     To result;
 

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -45,7 +45,7 @@ bitset<Block, Allocator>::reference::reference(bitset<Block, Allocator>::referen
 template <typename Block, typename Allocator>
 // NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
 inline STDGPU_DEVICE_ONLY bool
-bitset<Block, Allocator>::reference::operator=(bool x)
+bitset<Block, Allocator>::reference::operator=(bool x) noexcept
 {
     block_type set_pattern = static_cast<block_type>(1) << static_cast<block_type>(_bit_n);
     block_type reset_pattern = ~set_pattern;
@@ -69,13 +69,13 @@ template <typename Block, typename Allocator>
 // NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
 inline STDGPU_DEVICE_ONLY bool
 // NOLINTNEXTLINE(bugprone-unhandled-self-assignment,cert-oop54-cpp)
-bitset<Block, Allocator>::reference::operator=(const reference& x)
+bitset<Block, Allocator>::reference::operator=(const reference& x) noexcept
 {
     return operator=(static_cast<bool>(x));
 }
 
 template <typename Block, typename Allocator>
-inline STDGPU_DEVICE_ONLY bitset<Block, Allocator>::reference::operator bool() const
+inline STDGPU_DEVICE_ONLY bitset<Block, Allocator>::reference::operator bool() const noexcept
 {
     atomic_ref<block_type> bit_block(*_bit_block);
     return bit(bit_block.load(), _bit_n);
@@ -83,14 +83,14 @@ inline STDGPU_DEVICE_ONLY bitset<Block, Allocator>::reference::operator bool() c
 
 template <typename Block, typename Allocator>
 inline STDGPU_DEVICE_ONLY bool
-bitset<Block, Allocator>::reference::operator~() const
+bitset<Block, Allocator>::reference::operator~() const noexcept
 {
     return !operator bool();
 }
 
 template <typename Block, typename Allocator>
 inline STDGPU_DEVICE_ONLY bool
-bitset<Block, Allocator>::reference::flip()
+bitset<Block, Allocator>::reference::flip() noexcept
 {
     block_type flip_pattern = static_cast<block_type>(1) << static_cast<block_type>(_bit_n);
 
@@ -102,7 +102,7 @@ bitset<Block, Allocator>::reference::flip()
 
 template <typename Block, typename Allocator>
 inline STDGPU_DEVICE_ONLY bool
-bitset<Block, Allocator>::reference::bit(bitset<Block, Allocator>::reference::block_type bits, const index_t n)
+bitset<Block, Allocator>::reference::bit(bitset<Block, Allocator>::reference::block_type bits, const index_t n) noexcept
 {
     STDGPU_EXPECTS(0 <= n);
     STDGPU_EXPECTS(n < _bits_per_block);
@@ -114,7 +114,7 @@ namespace detail
 {
 
 inline index_t
-div_up(const index_t a, const index_t b)
+div_up(const index_t a, const index_t b) noexcept
 {
     STDGPU_EXPECTS(a >= 0);
     STDGPU_EXPECTS(b > 0);
@@ -202,21 +202,21 @@ bitset<Block, Allocator>::destroyDeviceObject(bitset<Block, Allocator>& device_o
 }
 
 template <typename Block, typename Allocator>
-inline bitset<Block, Allocator>::bitset(const Allocator& allocator)
+inline bitset<Block, Allocator>::bitset(const Allocator& allocator) noexcept
   : _allocator(allocator)
 {
 }
 
 template <typename Block, typename Allocator>
 inline index_t
-bitset<Block, Allocator>::number_bit_blocks(const index_t size)
+bitset<Block, Allocator>::number_bit_blocks(const index_t size) noexcept
 {
     return detail::div_up(size, _bits_per_block);
 }
 
 template <typename Block, typename Allocator>
 inline STDGPU_HOST_DEVICE typename bitset<Block, Allocator>::allocator_type
-bitset<Block, Allocator>::get_allocator() const
+bitset<Block, Allocator>::get_allocator() const noexcept
 {
     return _allocator;
 }
@@ -314,14 +314,14 @@ bitset<Block, Allocator>::test(const index_t n) const
 
 template <typename Block, typename Allocator>
 inline STDGPU_HOST_DEVICE bool
-bitset<Block, Allocator>::empty() const
+bitset<Block, Allocator>::empty() const noexcept
 {
     return (size() == 0);
 }
 
 template <typename Block, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
-bitset<Block, Allocator>::size() const
+bitset<Block, Allocator>::size() const noexcept
 {
     return _size;
 }

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -86,7 +86,7 @@ inline deque<T, Allocator>::deque(const mutex_array<mutex_default_type, mutex_ar
 
 template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE typename deque<T, Allocator>::allocator_type
-deque<T, Allocator>::get_allocator() const
+deque<T, Allocator>::get_allocator() const noexcept
 {
     return _allocator;
 }
@@ -421,14 +421,14 @@ deque<T, Allocator>::size() const
 
 template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
-deque<T, Allocator>::max_size() const
+deque<T, Allocator>::max_size() const noexcept
 {
     return capacity();
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
-deque<T, Allocator>::capacity() const
+deque<T, Allocator>::capacity() const noexcept
 {
     return _occupied.size();
 }
@@ -442,14 +442,14 @@ deque<T, Allocator>::shrink_to_fit()
 
 template <typename T, typename Allocator>
 inline const T*
-deque<T, Allocator>::data() const
+deque<T, Allocator>::data() const noexcept
 {
     return _data;
 }
 
 template <typename T, typename Allocator>
 inline T*
-deque<T, Allocator>::data()
+deque<T, Allocator>::data() noexcept
 {
     return _data;
 }

--- a/src/stdgpu/impl/functional_detail.h
+++ b/src/stdgpu/impl/functional_detail.h
@@ -76,7 +76,7 @@ hash<E>::operator()(const E& key) const
 
 template <typename T>
 inline STDGPU_HOST_DEVICE T&&
-identity::operator()(T&& t) const
+identity::operator()(T&& t) const noexcept
 {
     return forward<T>(t);
 }

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -693,7 +693,7 @@ allocator_traits<Allocator>::destroy([[maybe_unused]] Allocator& a, T* p)
 
 template <typename Allocator>
 STDGPU_HOST_DEVICE typename allocator_traits<Allocator>::index_type
-allocator_traits<Allocator>::max_size([[maybe_unused]] const Allocator& a)
+allocator_traits<Allocator>::max_size([[maybe_unused]] const Allocator& a) noexcept
 {
     return stdgpu::numeric_limits<index_type>::max() / sizeof(value_type);
 }
@@ -707,14 +707,14 @@ allocator_traits<Allocator>::select_on_container_copy_construction(const Allocat
 
 template <typename T>
 STDGPU_HOST_DEVICE T*
-to_address(T* p)
+to_address(T* p) noexcept
 {
     return p;
 }
 
 template <typename Ptr, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::has_arrow_operator<Ptr>::value)>
 STDGPU_HOST_DEVICE auto
-to_address(const Ptr& p)
+to_address(const Ptr& p) noexcept
 {
     return to_address(p.operator->());
 }
@@ -722,7 +722,7 @@ to_address(const Ptr& p)
 template <typename Ptr,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(!detail::has_arrow_operator<Ptr>::value && detail::has_get<Ptr>::value)>
 STDGPU_HOST_DEVICE auto
-to_address(const Ptr& p)
+to_address(const Ptr& p) noexcept
 {
     return to_address(p.get());
 }

--- a/src/stdgpu/impl/mutex_detail.cuh
+++ b/src/stdgpu/impl/mutex_detail.cuh
@@ -76,7 +76,7 @@ inline mutex_array<Block, Allocator>::mutex_array(const bitset<Block, Allocator>
 
 template <typename Block, typename Allocator>
 inline STDGPU_HOST_DEVICE typename mutex_array<Block, Allocator>::allocator_type
-mutex_array<Block, Allocator>::get_allocator() const
+mutex_array<Block, Allocator>::get_allocator() const noexcept
 {
     return _lock_bits.get_allocator();
 }
@@ -100,14 +100,14 @@ mutex_array<Block, Allocator>::operator[](const index_t n) const
 
 template <typename Block, typename Allocator>
 inline STDGPU_HOST_DEVICE bool
-mutex_array<Block, Allocator>::empty() const
+mutex_array<Block, Allocator>::empty() const noexcept
 {
     return (size() == 0);
 }
 
 template <typename Block, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
-mutex_array<Block, Allocator>::size() const
+mutex_array<Block, Allocator>::size() const noexcept
 {
     return _lock_bits.size();
 }

--- a/src/stdgpu/impl/ranges_detail.h
+++ b/src/stdgpu/impl/ranges_detail.h
@@ -51,14 +51,14 @@ device_range<T>::device_range(typename device_range<T>::iterator begin, typename
 
 template <typename T>
 STDGPU_HOST_DEVICE typename device_range<T>::iterator
-device_range<T>::begin() const
+device_range<T>::begin() const noexcept
 {
     return _begin;
 }
 
 template <typename T>
 STDGPU_HOST_DEVICE typename device_range<T>::iterator
-device_range<T>::end() const
+device_range<T>::end() const noexcept
 {
     return _end;
 }
@@ -109,14 +109,14 @@ host_range<T>::host_range(typename host_range<T>::iterator begin, typename host_
 
 template <typename T>
 STDGPU_HOST_DEVICE typename host_range<T>::iterator
-host_range<T>::begin() const
+host_range<T>::begin() const noexcept
 {
     return _begin;
 }
 
 template <typename T>
 STDGPU_HOST_DEVICE typename host_range<T>::iterator
-host_range<T>::end() const
+host_range<T>::end() const noexcept
 {
     return _end;
 }
@@ -152,14 +152,14 @@ transform_range<R, UnaryFunction>::transform_range(R r, UnaryFunction f)
 
 template <typename R, typename UnaryFunction>
 STDGPU_HOST_DEVICE typename transform_range<R, UnaryFunction>::iterator
-transform_range<R, UnaryFunction>::begin() const
+transform_range<R, UnaryFunction>::begin() const noexcept
 {
     return _begin;
 }
 
 template <typename R, typename UnaryFunction>
 STDGPU_HOST_DEVICE typename transform_range<R, UnaryFunction>::iterator
-transform_range<R, UnaryFunction>::end() const
+transform_range<R, UnaryFunction>::end() const noexcept
 {
     return _end;
 }

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -94,14 +94,14 @@ public:
     /**
      * \brief Empty constructor
      */
-    unordered_base() = default;
+    unordered_base() noexcept = default;
 
     /**
      * \brief Returns the container allocator
      * \return The container allocator
      */
     STDGPU_HOST_DEVICE allocator_type
-    get_allocator() const;
+    get_allocator() const noexcept;
 
     /**
      * \brief Checks if the object is valid
@@ -115,42 +115,42 @@ public:
      * \return An iterator to the begin of the object
      */
     STDGPU_DEVICE_ONLY iterator
-    begin();
+    begin() noexcept;
 
     /**
      * \brief An iterator to the begin of the internal value array
      * \return A const iterator to the begin of the object
      */
     STDGPU_DEVICE_ONLY const_iterator
-    begin() const;
+    begin() const noexcept;
 
     /**
      * \brief An iterator to the begin of the internal value array
      * \return A const iterator to the begin of the object
      */
     STDGPU_DEVICE_ONLY const_iterator
-    cbegin() const;
+    cbegin() const noexcept;
 
     /**
      * \brief An iterator to the end of the internal value array
      * \return An iterator to the end of the object
      */
     STDGPU_DEVICE_ONLY iterator
-    end();
+    end() noexcept;
 
     /**
      * \brief An iterator to the end of the internal value array
      * \return A const iterator to the end of the object
      */
     STDGPU_DEVICE_ONLY const_iterator
-    end() const;
+    end() const noexcept;
 
     /**
      * \brief An iterator to the end of the internal value array
      * \return A const iterator to the end of the object
      */
     STDGPU_DEVICE_ONLY const_iterator
-    cend() const;
+    cend() const noexcept;
 
     /**
      * \brief Builds a range to the values in the container
@@ -340,7 +340,7 @@ public:
      * \return The maximum size
      */
     STDGPU_HOST_DEVICE index_t
-    max_size() const;
+    max_size() const noexcept;
 
     /**
      * \brief The bucket count
@@ -423,7 +423,7 @@ public:
     index_allocator_type _index_allocator = {}; /**< The index allocator */
 
     STDGPU_HOST_DEVICE index_t
-    total_count() const;
+    total_count() const noexcept;
 
     STDGPU_DEVICE_ONLY bool
     occupied(const index_t n) const;

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -85,49 +85,49 @@ fibonacci_hashing(const std::size_t hash, const index_t bucket_count)
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_HOST_DEVICE typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::allocator_type
-unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::get_allocator() const
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::get_allocator() const noexcept
 {
     return _allocator;
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::iterator
-unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::begin()
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::begin() noexcept
 {
     return _values;
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::const_iterator
-unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::begin() const
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::begin() const noexcept
 {
     return _values;
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::const_iterator
-unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::cbegin() const
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::cbegin() const noexcept
 {
     return begin();
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::iterator
-unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::end()
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::end() noexcept
 {
     return _values + total_count();
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::const_iterator
-unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::end() const
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::end() const noexcept
 {
     return _values + total_count();
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::const_iterator
-unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::cend() const
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::cend() const noexcept
 {
     return end();
 }
@@ -990,7 +990,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::size() cons
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
-unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::max_size() const
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::max_size() const noexcept
 {
     return total_count();
 }
@@ -1004,7 +1004,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::bucket_coun
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
-unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::total_count() const
+unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::total_count() const noexcept
 {
     return _occupied.size();
 }

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -42,49 +42,49 @@ struct select1st
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_HOST_DEVICE typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::allocator_type
-unordered_map<Key, T, Hash, KeyEqual, Allocator>::get_allocator() const
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::get_allocator() const noexcept
 {
     return _base.get_allocator();
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::iterator
-unordered_map<Key, T, Hash, KeyEqual, Allocator>::begin()
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::begin() noexcept
 {
     return _base.begin();
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::const_iterator
-unordered_map<Key, T, Hash, KeyEqual, Allocator>::begin() const
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::begin() const noexcept
 {
     return _base.begin();
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::const_iterator
-unordered_map<Key, T, Hash, KeyEqual, Allocator>::cbegin() const
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::cbegin() const noexcept
 {
     return _base.cbegin();
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::iterator
-unordered_map<Key, T, Hash, KeyEqual, Allocator>::end()
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::end() noexcept
 {
     return _base.end();
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::const_iterator
-unordered_map<Key, T, Hash, KeyEqual, Allocator>::end() const
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::end() const noexcept
 {
     return _base.end();
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::const_iterator
-unordered_map<Key, T, Hash, KeyEqual, Allocator>::cend() const
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::cend() const noexcept
 {
     return _base.cend();
 }
@@ -241,7 +241,7 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::size() const
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
-unordered_map<Key, T, Hash, KeyEqual, Allocator>::max_size() const
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::max_size() const noexcept
 {
     return _base.max_size();
 }

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -27,49 +27,49 @@ namespace stdgpu
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_HOST_DEVICE typename unordered_set<Key, Hash, KeyEqual, Allocator>::allocator_type
-unordered_set<Key, Hash, KeyEqual, Allocator>::get_allocator() const
+unordered_set<Key, Hash, KeyEqual, Allocator>::get_allocator() const noexcept
 {
     return _base.get_allocator();
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual, Allocator>::iterator
-unordered_set<Key, Hash, KeyEqual, Allocator>::begin()
+unordered_set<Key, Hash, KeyEqual, Allocator>::begin() noexcept
 {
     return _base.begin();
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual, Allocator>::const_iterator
-unordered_set<Key, Hash, KeyEqual, Allocator>::begin() const
+unordered_set<Key, Hash, KeyEqual, Allocator>::begin() const noexcept
 {
     return _base.begin();
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual, Allocator>::const_iterator
-unordered_set<Key, Hash, KeyEqual, Allocator>::cbegin() const
+unordered_set<Key, Hash, KeyEqual, Allocator>::cbegin() const noexcept
 {
     return _base.cbegin();
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual, Allocator>::iterator
-unordered_set<Key, Hash, KeyEqual, Allocator>::end()
+unordered_set<Key, Hash, KeyEqual, Allocator>::end() noexcept
 {
     return _base.end();
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual, Allocator>::const_iterator
-unordered_set<Key, Hash, KeyEqual, Allocator>::end() const
+unordered_set<Key, Hash, KeyEqual, Allocator>::end() const noexcept
 {
     return _base.end();
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual, Allocator>::const_iterator
-unordered_set<Key, Hash, KeyEqual, Allocator>::cend() const
+unordered_set<Key, Hash, KeyEqual, Allocator>::cend() const noexcept
 {
     return _base.cend();
 }
@@ -225,7 +225,7 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::size() const
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
-unordered_set<Key, Hash, KeyEqual, Allocator>::max_size() const
+unordered_set<Key, Hash, KeyEqual, Allocator>::max_size() const noexcept
 {
     return _base.max_size();
 }

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -74,7 +74,7 @@ inline vector<T, Allocator>::vector(const mutex_array<mutex_default_type, mutex_
 
 template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE typename vector<T, Allocator>::allocator_type
-vector<T, Allocator>::get_allocator() const
+vector<T, Allocator>::get_allocator() const noexcept
 {
     return _allocator;
 }
@@ -423,14 +423,14 @@ vector<T, Allocator>::size() const
 
 template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
-vector<T, Allocator>::max_size() const
+vector<T, Allocator>::max_size() const noexcept
 {
     return capacity();
 }
 
 template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
-vector<T, Allocator>::capacity() const
+vector<T, Allocator>::capacity() const noexcept
 {
     return _occupied.size();
 }
@@ -444,14 +444,14 @@ vector<T, Allocator>::shrink_to_fit()
 
 template <typename T, typename Allocator>
 inline const T*
-vector<T, Allocator>::data() const
+vector<T, Allocator>::data() const noexcept
 {
     return _data;
 }
 
 template <typename T, typename Allocator>
 inline T*
-vector<T, Allocator>::data()
+vector<T, Allocator>::data() noexcept
 {
     return _data;
 }

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -767,7 +767,7 @@ struct allocator_traits : public detail::allocator_traits_base<Allocator>
      * \return The maximum size that could be theoretically allocated
      */
     static STDGPU_HOST_DEVICE index_type
-    max_size(const Allocator& a);
+    max_size(const Allocator& a) noexcept;
 
     /**
      * \brief Returns a copy of the allocator
@@ -787,7 +787,7 @@ struct allocator_traits : public detail::allocator_traits_base<Allocator>
  */
 template <typename T>
 STDGPU_HOST_DEVICE T*
-to_address(T* p);
+to_address(T* p) noexcept;
 
 /**
  * \ingroup memory
@@ -798,13 +798,13 @@ to_address(T* p);
  */
 template <typename Ptr, STDGPU_DETAIL_OVERLOAD_IF(detail::has_arrow_operator<Ptr>::value)>
 STDGPU_HOST_DEVICE auto
-to_address(const Ptr& p);
+to_address(const Ptr& p) noexcept;
 
 //! @cond Doxygen_Suppress
 template <typename Ptr,
           STDGPU_DETAIL_OVERLOAD_IF(!detail::has_arrow_operator<Ptr>::value && detail::has_get<Ptr>::value)>
 STDGPU_HOST_DEVICE auto
-to_address(const Ptr& p);
+to_address(const Ptr& p) noexcept;
 //! @endcond
 
 /**

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -123,14 +123,14 @@ public:
     /**
      * \brief Empty constructor
      */
-    mutex_array() = default;
+    mutex_array() noexcept = default;
 
     /**
      * \brief Returns the container allocator
      * \return The container allocator
      */
     STDGPU_HOST_DEVICE allocator_type
-    get_allocator() const;
+    get_allocator() const noexcept;
 
     /**
      * \brief Returns a reference to the n-th mutex
@@ -155,14 +155,14 @@ public:
      * \return True if this object is empty, false otherwise
      */
     [[nodiscard]] STDGPU_HOST_DEVICE bool
-    empty() const;
+    empty() const noexcept;
 
     /**
      * \brief The size
      * \return The size of the object
      */
     STDGPU_HOST_DEVICE index_t
-    size() const;
+    size() const noexcept;
 
     /**
      * \brief Checks if the object is in valid state

--- a/src/stdgpu/openmp/atomic.h
+++ b/src/stdgpu/openmp/atomic.h
@@ -28,13 +28,13 @@ namespace stdgpu::openmp
  * \return True if the operations are lock-free, false otherwise
  */
 STDGPU_HOST_DEVICE bool
-atomic_is_lock_free();
+atomic_is_lock_free() noexcept;
 
 /**
  * \brief A synchronization fence enforcing sequentially consistent memory ordering
  */
 STDGPU_DEVICE_ONLY void
-atomic_thread_fence();
+atomic_thread_fence() noexcept;
 
 /**
  * \brief Atomically loads and returns the current value of the atomic object
@@ -44,7 +44,7 @@ atomic_thread_fence();
  */
 template <typename T>
 STDGPU_DEVICE_ONLY T
-atomic_load(T* address);
+atomic_load(T* address) noexcept;
 
 /**
  * \brief Atomically replaces the current value with desired one
@@ -54,7 +54,7 @@ atomic_load(T* address);
  */
 template <typename T>
 STDGPU_DEVICE_ONLY void
-atomic_store(T* address, const T desired);
+atomic_store(T* address, const T desired) noexcept;
 
 /**
  * \brief Atomically exchanges the stored value with the given argument
@@ -65,7 +65,7 @@ atomic_store(T* address, const T desired);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_exchange(T* address, const T desired);
+atomic_exchange(T* address, const T desired) noexcept;
 
 /**
  * \brief Atomically exchanges the stored value with the given argument if it equals the expected value
@@ -77,7 +77,7 @@ atomic_exchange(T* address, const T desired);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_compare_exchange(T* address, const T expected, const T desired);
+atomic_compare_exchange(T* address, const T expected, const T desired) noexcept;
 
 /**
  * \brief Atomically computes and stores the addition of the stored value and the given argument
@@ -88,7 +88,7 @@ atomic_compare_exchange(T* address, const T expected, const T desired);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_add(T* address, const T arg);
+atomic_fetch_add(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the subtraction of the stored value and the given argument
@@ -99,7 +99,7 @@ atomic_fetch_add(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_sub(T* address, const T arg);
+atomic_fetch_sub(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the bitwise AND of the stored value and the given argument
@@ -110,7 +110,7 @@ atomic_fetch_sub(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_and(T* address, const T arg);
+atomic_fetch_and(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the bitwise OR of the stored value and the given argument
@@ -121,7 +121,7 @@ atomic_fetch_and(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_or(T* address, const T arg);
+atomic_fetch_or(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the bitwise XOR of the stored value and the given argument
@@ -132,7 +132,7 @@ atomic_fetch_or(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_xor(T* address, const T arg);
+atomic_fetch_xor(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the minimum of the stored value and the given argument
@@ -143,7 +143,7 @@ atomic_fetch_xor(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_min(T* address, const T arg);
+atomic_fetch_min(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the maximum of the stored value and the given argument
@@ -154,7 +154,7 @@ atomic_fetch_min(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_max(T* address, const T arg);
+atomic_fetch_max(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the incrementation of the value and modulus with arg
@@ -165,7 +165,7 @@ atomic_fetch_max(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_inc_mod(T* address, const T arg);
+atomic_fetch_inc_mod(T* address, const T arg) noexcept;
 
 /**
  * \brief Atomically computes and stores the decrementation of the value and modulus with arg
@@ -176,7 +176,7 @@ atomic_fetch_inc_mod(T* address, const T arg);
  */
 template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_dec_mod(T* address, const T arg);
+atomic_fetch_dec_mod(T* address, const T arg) noexcept;
 
 } // namespace stdgpu::openmp
 

--- a/src/stdgpu/openmp/impl/atomic_detail.h
+++ b/src/stdgpu/openmp/impl/atomic_detail.h
@@ -24,20 +24,20 @@ namespace stdgpu::openmp
 {
 
 inline STDGPU_HOST_DEVICE bool
-atomic_is_lock_free()
+atomic_is_lock_free() noexcept
 {
     return false;
 }
 
 inline STDGPU_DEVICE_ONLY void
-atomic_thread_fence()
+atomic_thread_fence() noexcept
 {
 #pragma omp flush
 }
 
 template <typename T>
 STDGPU_DEVICE_ONLY T
-atomic_load(T* address)
+atomic_load(T* address) noexcept
 {
     T current;
 #pragma omp critical
@@ -47,7 +47,7 @@ atomic_load(T* address)
 
 template <typename T>
 STDGPU_DEVICE_ONLY void
-atomic_store(T* address, const T desired)
+atomic_store(T* address, const T desired) noexcept
 {
 #pragma omp critical
     *address = desired;
@@ -56,7 +56,7 @@ atomic_store(T* address, const T desired)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_exchange(T* address, const T desired)
+atomic_exchange(T* address, const T desired) noexcept
 {
     T old;
 #pragma omp critical
@@ -70,7 +70,7 @@ atomic_exchange(T* address, const T desired)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_compare_exchange(T* address, const T expected, const T desired)
+atomic_compare_exchange(T* address, const T expected, const T desired) noexcept
 {
     T old;
 #pragma omp critical
@@ -84,7 +84,7 @@ atomic_compare_exchange(T* address, const T expected, const T desired)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_add(T* address, const T arg)
+atomic_fetch_add(T* address, const T arg) noexcept
 {
     T old;
 #if STDGPU_OPENMP_DETAIL_VERSION >= STDGPU_OPENMP_DETAIL_VERSION_3_1
@@ -102,7 +102,7 @@ atomic_fetch_add(T* address, const T arg)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_sub(T* address, const T arg)
+atomic_fetch_sub(T* address, const T arg) noexcept
 {
     T old;
 #if STDGPU_OPENMP_DETAIL_VERSION >= STDGPU_OPENMP_DETAIL_VERSION_3_1
@@ -119,7 +119,7 @@ atomic_fetch_sub(T* address, const T arg)
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_and(T* address, const T arg)
+atomic_fetch_and(T* address, const T arg) noexcept
 {
     T old;
 #if STDGPU_OPENMP_DETAIL_VERSION >= STDGPU_OPENMP_DETAIL_VERSION_3_1
@@ -136,7 +136,7 @@ atomic_fetch_and(T* address, const T arg)
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_or(T* address, const T arg)
+atomic_fetch_or(T* address, const T arg) noexcept
 {
     T old;
 #if STDGPU_OPENMP_DETAIL_VERSION >= STDGPU_OPENMP_DETAIL_VERSION_3_1
@@ -153,7 +153,7 @@ atomic_fetch_or(T* address, const T arg)
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_xor(T* address, const T arg)
+atomic_fetch_xor(T* address, const T arg) noexcept
 {
     T old;
 #if STDGPU_OPENMP_DETAIL_VERSION >= STDGPU_OPENMP_DETAIL_VERSION_3_1
@@ -171,7 +171,7 @@ atomic_fetch_xor(T* address, const T arg)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_min(T* address, const T arg)
+atomic_fetch_min(T* address, const T arg) noexcept
 {
     T old;
 #pragma omp critical
@@ -185,7 +185,7 @@ atomic_fetch_min(T* address, const T arg)
 template <typename T,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_max(T* address, const T arg)
+atomic_fetch_max(T* address, const T arg) noexcept
 {
     T old;
 #pragma omp critical
@@ -198,7 +198,7 @@ atomic_fetch_max(T* address, const T arg)
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_inc_mod(T* address, const T arg)
+atomic_fetch_inc_mod(T* address, const T arg) noexcept
 {
     T old;
 #pragma omp critical
@@ -211,7 +211,7 @@ atomic_fetch_inc_mod(T* address, const T arg)
 
 template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_dec_mod(T* address, const T arg)
+atomic_fetch_dec_mod(T* address, const T arg) noexcept
 {
     T old;
 #pragma omp critical

--- a/src/stdgpu/ranges.h
+++ b/src/stdgpu/ranges.h
@@ -89,14 +89,14 @@ public:
      * \return An iterator to the begin of the range
      */
     STDGPU_HOST_DEVICE iterator
-    begin() const;
+    begin() const noexcept;
 
     /**
      * \brief An iterator to the end of the range
      * \return An iterator to the end of the range
      */
     STDGPU_HOST_DEVICE iterator
-    end() const;
+    end() const noexcept;
 
     /**
      * \brief The size
@@ -171,14 +171,14 @@ public:
      * \return An iterator to the begin of the range
      */
     STDGPU_HOST_DEVICE iterator
-    begin() const;
+    begin() const noexcept;
 
     /**
      * \brief An iterator to the end of the range
      * \return An iterator to the end of the range
      */
     STDGPU_HOST_DEVICE iterator
-    end() const;
+    end() const noexcept;
 
     /**
      * \brief The size
@@ -241,14 +241,14 @@ public:
      * \return An iterator to the begin of the range
      */
     STDGPU_HOST_DEVICE iterator
-    begin() const;
+    begin() const noexcept;
 
     /**
      * \brief An iterator to the end of the range
      * \return An iterator to the end of the range
      */
     STDGPU_HOST_DEVICE iterator
-    end() const;
+    end() const noexcept;
 
     /**
      * \brief The size

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -116,14 +116,14 @@ public:
     /**
      * \brief Empty constructor
      */
-    unordered_map() = default;
+    unordered_map() noexcept = default;
 
     /**
      * \brief Returns the container allocator
      * \return The container allocator
      */
     STDGPU_HOST_DEVICE allocator_type
-    get_allocator() const;
+    get_allocator() const noexcept;
 
     /**
      * \brief Checks if the object is valid
@@ -137,42 +137,42 @@ public:
      * \return An iterator to the begin of the object
      */
     STDGPU_DEVICE_ONLY iterator
-    begin();
+    begin() noexcept;
 
     /**
      * \brief An iterator to the begin of the internal value array
      * \return A const iterator to the begin of the object
      */
     STDGPU_DEVICE_ONLY const_iterator
-    begin() const;
+    begin() const noexcept;
 
     /**
      * \brief An iterator to the begin of the internal value array
      * \return A const iterator to the begin of the object
      */
     STDGPU_DEVICE_ONLY const_iterator
-    cbegin() const;
+    cbegin() const noexcept;
 
     /**
      * \brief An iterator to the end of the internal value array
      * \return An iterator to the end of the object
      */
     STDGPU_DEVICE_ONLY iterator
-    end();
+    end() noexcept;
 
     /**
      * \brief An iterator to the end of the internal value array
      * \return A const iterator to the end of the object
      */
     STDGPU_DEVICE_ONLY const_iterator
-    end() const;
+    end() const noexcept;
 
     /**
      * \brief An iterator to the end of the internal value array
      * \return A const iterator to the end of the object
      */
     STDGPU_DEVICE_ONLY const_iterator
-    cend() const;
+    cend() const noexcept;
 
     /**
      * \brief Builds a range to the values in the container
@@ -345,7 +345,7 @@ public:
      * \return The maximum size
      */
     STDGPU_HOST_DEVICE index_t
-    max_size() const;
+    max_size() const noexcept;
 
     /**
      * \brief The bucket count

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -106,14 +106,14 @@ public:
     /**
      * \brief Empty constructor
      */
-    unordered_set() = default;
+    unordered_set() noexcept = default;
 
     /**
      * \brief Returns the container allocator
      * \return The container allocator
      */
     STDGPU_HOST_DEVICE allocator_type
-    get_allocator() const;
+    get_allocator() const noexcept;
 
     /**
      * \brief Checks if the object is valid
@@ -127,42 +127,42 @@ public:
      * \return An iterator to the begin of the object
      */
     STDGPU_DEVICE_ONLY iterator
-    begin();
+    begin() noexcept;
 
     /**
      * \brief An iterator to the begin of the internal value array
      * \return A const iterator to the begin of the object
      */
     STDGPU_DEVICE_ONLY const_iterator
-    begin() const;
+    begin() const noexcept;
 
     /**
      * \brief An iterator to the begin of the internal value array
      * \return A const iterator to the begin of the object
      */
     STDGPU_DEVICE_ONLY const_iterator
-    cbegin() const;
+    cbegin() const noexcept;
 
     /**
      * \brief An iterator to the end of the internal value array
      * \return An iterator to the end of the object
      */
     STDGPU_DEVICE_ONLY iterator
-    end();
+    end() noexcept;
 
     /**
      * \brief An iterator to the end of the internal value array
      * \return A const iterator to the end of the object
      */
     STDGPU_DEVICE_ONLY const_iterator
-    end() const;
+    end() const noexcept;
 
     /**
      * \brief An iterator to the end of the internal value array
      * \return A const iterator to the end of the object
      */
     STDGPU_DEVICE_ONLY const_iterator
-    cend() const;
+    cend() const noexcept;
 
     /**
      * \brief Builds a range to the values in the container
@@ -335,7 +335,7 @@ public:
      * \return The maximum size
      */
     STDGPU_HOST_DEVICE index_t
-    max_size() const;
+    max_size() const noexcept;
 
     /**
      * \brief The bucket count

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -123,7 +123,7 @@ public:
      * \return The container allocator
      */
     STDGPU_HOST_DEVICE allocator_type
-    get_allocator() const;
+    get_allocator() const noexcept;
 
     /**
      * \brief Reads the value at position n
@@ -259,14 +259,14 @@ public:
      * \return The maximal size
      */
     STDGPU_HOST_DEVICE index_t
-    max_size() const;
+    max_size() const noexcept;
 
     /**
      * \brief Returns the capacity
      * \return The capacity
      */
     STDGPU_HOST_DEVICE index_t
-    capacity() const;
+    capacity() const noexcept;
 
     /**
      * \brief Requests to shrink the capacity to the current size
@@ -280,14 +280,14 @@ public:
      * \return The underlying array
      */
     const T*
-    data() const;
+    data() const noexcept;
 
     /**
      * \brief Returns a pointer to the underlying data
      * \return The underlying array
      */
     T*
-    data();
+    data() noexcept;
 
     /**
      * \brief Clears the complete object

--- a/test/test_memory_utils.h
+++ b/test/test_memory_utils.h
@@ -62,20 +62,20 @@ public:
      * \brief Default constructor
      */
     STDGPU_HOST_DEVICE
-    test_device_allocator();
+    test_device_allocator() noexcept;
 
     /**
      * \brief Destructor
      */
     STDGPU_HOST_DEVICE
-    ~test_device_allocator();
+    ~test_device_allocator() noexcept;
 
     /**
      * \brief Copy constructor
      * \param[in] other The allocator to be copied from
      */
     STDGPU_HOST_DEVICE
-    test_device_allocator(const test_device_allocator& other);
+    test_device_allocator(const test_device_allocator& other) noexcept;
 
     /**
      * \brief Deleted copy assignment operator
@@ -90,7 +90,7 @@ public:
      */
     template <typename U>
     explicit STDGPU_HOST_DEVICE
-    test_device_allocator(const test_device_allocator<U>& other);
+    test_device_allocator(const test_device_allocator<U>& other) noexcept;
 
     /**
      * \brief Deleted move constructor

--- a/test/test_memory_utils_detail.h
+++ b/test/test_memory_utils_detail.h
@@ -21,7 +21,7 @@ namespace test_utils
 
 template <typename T>
 STDGPU_HOST_DEVICE
-test_device_allocator<T>::test_device_allocator()
+test_device_allocator<T>::test_device_allocator() noexcept
 {
 #if STDGPU_CODE == STDGPU_CODE_HOST || STDGPU_BACKEND == STDGPU_BACKEND_OPENMP
     get_allocator_statistics().default_constructions++;
@@ -29,7 +29,7 @@ test_device_allocator<T>::test_device_allocator()
 }
 
 template <typename T>
-STDGPU_HOST_DEVICE test_device_allocator<T>::~test_device_allocator()
+STDGPU_HOST_DEVICE test_device_allocator<T>::~test_device_allocator() noexcept
 {
 #if STDGPU_CODE == STDGPU_CODE_HOST || STDGPU_BACKEND == STDGPU_BACKEND_OPENMP
     get_allocator_statistics().destructions++;
@@ -38,7 +38,7 @@ STDGPU_HOST_DEVICE test_device_allocator<T>::~test_device_allocator()
 
 template <typename T>
 STDGPU_HOST_DEVICE
-test_device_allocator<T>::test_device_allocator([[maybe_unused]] const test_device_allocator& other)
+test_device_allocator<T>::test_device_allocator([[maybe_unused]] const test_device_allocator& other) noexcept
 {
 #if STDGPU_CODE == STDGPU_CODE_HOST || STDGPU_BACKEND == STDGPU_BACKEND_OPENMP
     get_allocator_statistics().copy_constructions++;
@@ -48,7 +48,7 @@ test_device_allocator<T>::test_device_allocator([[maybe_unused]] const test_devi
 template <typename T>
 template <typename U>
 STDGPU_HOST_DEVICE
-test_device_allocator<T>::test_device_allocator([[maybe_unused]] const test_device_allocator<U>& other)
+test_device_allocator<T>::test_device_allocator([[maybe_unused]] const test_device_allocator<U>& other) noexcept
 {
 #if STDGPU_CODE == STDGPU_CODE_HOST || STDGPU_BACKEND == STDGPU_BACKEND_OPENMP
     get_allocator_statistics().copy_constructions++;


### PR DESCRIPTION
Since C++17 `noexcept` is part of the function signature and is generally useful to provide hints to the compiler for better optimization. Although, we do not throw any exceptions in device code which would qualify most functions to become `noexcept`, only flag a subset of them to match the definitions in the C++ standard library. 

Partially addresses #314 