### PR TITLE
memory: Simplify to_address implementation

### DIFF
--- a/src/stdgpu/impl/type_traits.h
+++ b/src/stdgpu/impl/type_traits.h
@@ -38,15 +38,6 @@ namespace stdgpu::detail
 #define STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(...)                                                                      \
     typename stdgpu_DummyType, std::enable_if_t<__VA_ARGS__, stdgpu_DummyType>*
 
-template <typename... Types>
-struct void_helper
-{
-    using type = void;
-};
-
-template <typename... Types>
-using void_t = typename void_helper<Types...>::type;
-
 #define STDGPU_DETAIL_DEFINE_TRAIT(name, ...)                                                                          \
     template <typename T, typename = void>                                                                             \
     struct name : std::false_type                                                                                      \
@@ -54,7 +45,7 @@ using void_t = typename void_helper<Types...>::type;
     };                                                                                                                 \
                                                                                                                        \
     template <typename T>                                                                                              \
-    struct name<T, stdgpu::detail::void_t<__VA_ARGS__>> : std::true_type                                               \
+    struct name<T, std::void_t<__VA_ARGS__>> : std::true_type                                                          \
     {                                                                                                                  \
     };
 
@@ -74,6 +65,14 @@ STDGPU_DETAIL_DEFINE_TRAIT(has_arrow_operator,
                            decltype(std::declval<T>()
                                             .
                                             operator->()))
+
+template <typename T>
+struct dependent_false : std::false_type
+{
+};
+
+template <typename T>
+inline constexpr bool dependent_false_v = dependent_false<T>::value;
 
 } // namespace stdgpu::detail
 

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -34,7 +34,6 @@
 
 #include <stdgpu/config.h>
 #include <stdgpu/cstddef.h>
-#include <stdgpu/impl/type_traits.h>
 #include <stdgpu/platform.h>
 
 /**
@@ -794,18 +793,11 @@ to_address(T* p) noexcept;
  * \brief Converts a potential fancy pointer to a raw pointer
  * \tparam Ptr The fancy pointer type
  * \param[in] p A fancy pointer
- * \return The raw pointer held by the fancy pointer obtained via operator->()
+ * \return The raw pointer held by the fancy pointer obtained via operator->() or get()
  */
-template <typename Ptr, STDGPU_DETAIL_OVERLOAD_IF(detail::has_arrow_operator<Ptr>::value)>
+template <typename Ptr>
 STDGPU_HOST_DEVICE auto
 to_address(const Ptr& p) noexcept;
-
-//! @cond Doxygen_Suppress
-template <typename Ptr,
-          STDGPU_DETAIL_OVERLOAD_IF(!detail::has_arrow_operator<Ptr>::value && detail::has_get<Ptr>::value)>
-STDGPU_HOST_DEVICE auto
-to_address(const Ptr& p) noexcept;
-//! @endcond
 
 /**
  * \ingroup memory


### PR DESCRIPTION
Currently, `to_address` uses a quite complex SFINAE check with the internal overload macro from the `type_traits` module. Simplify this implementation by using `if constexpr` instead. Furthermore, remove the obsolete backport of `void_t`.

Partially addresses #314 