### PR TITLE
src,test: Use shorter inline variables as type traits

### DIFF
--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -99,8 +99,8 @@ template <typename T, typename Allocator>
 class atomic
 {
 public:
-    static_assert(std::is_same<T, unsigned int>::value || std::is_same<T, int>::value ||
-                          std::is_same<T, unsigned long long int>::value || std::is_same<T, float>::value,
+    static_assert(std::is_same_v<T, unsigned int> || std::is_same_v<T, int> ||
+                          std::is_same_v<T, unsigned long long int> || std::is_same_v<T, float>,
                   "stdgpu::atomic: No support for type T");
 
     using value_type = T;               /**< T */
@@ -209,7 +209,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_add(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -219,7 +219,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_sub(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -229,7 +229,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_and(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -239,7 +239,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_or(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -249,7 +249,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_xor(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -259,7 +259,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_min(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -269,7 +269,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_max(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -279,7 +279,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same_v<T, unsigned int>)>
     STDGPU_DEVICE_ONLY T
     fetch_inc_mod(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -289,7 +289,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same_v<T, unsigned int>)>
     STDGPU_DEVICE_ONLY T
     fetch_dec_mod(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -297,7 +297,7 @@ public:
      * \brief Atomically increments the current value. Equivalent to fetch_add(1) + 1
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator++() noexcept;
 
@@ -305,7 +305,7 @@ public:
      * \brief Atomically increments the current value. Equivalent to fetch_add(1)
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator++(int) noexcept;
 
@@ -313,7 +313,7 @@ public:
      * \brief Atomically decrements the current value. Equivalent to fetch_sub(1) - 1
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator--() noexcept;
 
@@ -321,7 +321,7 @@ public:
      * \brief Atomically decrements the current value. Equivalent to fetch_sub(1)
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator--(int) noexcept;
 
@@ -330,7 +330,7 @@ public:
      * \param[in] arg The other argument of addition
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator+=(const T arg) noexcept;
 
@@ -339,7 +339,7 @@ public:
      * \param[in] arg The other argument of subtraction
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator-=(const T arg) noexcept;
 
@@ -348,7 +348,7 @@ public:
      * \param[in] arg The other argument of bitwise AND
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator&=(const T arg) noexcept;
 
@@ -357,7 +357,7 @@ public:
      * \param[in] arg The other argument of bitwise OR
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator|=(const T arg) noexcept;
 
@@ -366,7 +366,7 @@ public:
      * \param[in] arg The other argument of bitwise XOR
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator^=(const T arg) noexcept;
 
@@ -402,8 +402,8 @@ template <typename T>
 class atomic_ref
 {
 public:
-    static_assert(std::is_same<T, unsigned int>::value || std::is_same<T, int>::value ||
-                          std::is_same<T, unsigned long long int>::value || std::is_same<T, float>::value,
+    static_assert(std::is_same_v<T, unsigned int> || std::is_same_v<T, int> ||
+                          std::is_same_v<T, unsigned long long int> || std::is_same_v<T, float>,
                   "stdgpu::atomic_ref: No support for type T");
 
     using value_type = T;               /**< T */
@@ -497,7 +497,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_add(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -507,7 +507,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_sub(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -517,7 +517,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_and(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -527,7 +527,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_or(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -537,7 +537,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_xor(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -547,7 +547,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_min(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -557,7 +557,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_max(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -567,7 +567,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same_v<T, unsigned int>)>
     STDGPU_DEVICE_ONLY T
     fetch_inc_mod(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -577,7 +577,7 @@ public:
      * \param[in] order The memory order
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_same_v<T, unsigned int>)>
     STDGPU_DEVICE_ONLY T
     fetch_dec_mod(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
@@ -585,7 +585,7 @@ public:
      * \brief Atomically increments the current value. Equivalent to fetch_add(1) + 1
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator++() noexcept;
 
@@ -593,7 +593,7 @@ public:
      * \brief Atomically increments the current value. Equivalent to fetch_add(1)
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator++(int) noexcept;
 
@@ -601,7 +601,7 @@ public:
      * \brief Atomically decrements the current value. Equivalent to fetch_sub(1) - 1
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator--() noexcept;
 
@@ -609,7 +609,7 @@ public:
      * \brief Atomically decrements the current value. Equivalent to fetch_sub(1)
      * \return The old value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator--(int) noexcept;
 
@@ -618,7 +618,7 @@ public:
      * \param[in] arg The other argument of addition
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator+=(const T arg) noexcept;
 
@@ -627,7 +627,7 @@ public:
      * \param[in] arg The other argument of subtraction
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator-=(const T arg) noexcept;
 
@@ -636,7 +636,7 @@ public:
      * \param[in] arg The other argument of bitwise AND
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator&=(const T arg) noexcept;
 
@@ -645,7 +645,7 @@ public:
      * \param[in] arg The other argument of bitwise OR
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator|=(const T arg) noexcept;
 
@@ -654,7 +654,7 @@ public:
      * \param[in] arg The other argument of bitwise XOR
      * \return The new value
      */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     operator^=(const T arg) noexcept;
 

--- a/src/stdgpu/bit.h
+++ b/src/stdgpu/bit.h
@@ -40,7 +40,7 @@ namespace stdgpu
  * \param[in] number A number
  * \return True if number is a power of two, false otherwise
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned_v<T>)>
 STDGPU_HOST_DEVICE bool
 has_single_bit(const T number) noexcept;
 
@@ -50,7 +50,7 @@ has_single_bit(const T number) noexcept;
  * \param[in] number A number
  * \return The smallest power of two which is larger than the given number
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned_v<T>)>
 STDGPU_HOST_DEVICE T
 bit_ceil(const T number) noexcept;
 
@@ -60,7 +60,7 @@ bit_ceil(const T number) noexcept;
  * \param[in] number A number
  * \return The largest power of two which is smaller than the given number
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned_v<T>)>
 STDGPU_HOST_DEVICE T
 bit_floor(const T number) noexcept;
 
@@ -74,7 +74,7 @@ bit_floor(const T number) noexcept;
  * \post result >= 0
  * \post result < divider
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned_v<T>)>
 STDGPU_HOST_DEVICE T
 bit_mod(const T number, const T divider) noexcept;
 
@@ -86,7 +86,7 @@ bit_mod(const T number, const T divider) noexcept;
  * \post result >= 0
  * \post result <= numeric_limits<T>::digits
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned_v<T>)>
 STDGPU_HOST_DEVICE T
 bit_width(const T number) noexcept;
 
@@ -98,7 +98,7 @@ bit_width(const T number) noexcept;
  * \post result >= 0
  * \post result <= numeric_limits<T>::digits
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_unsigned_v<T>)>
 STDGPU_HOST_DEVICE int
 popcount(const T number) noexcept;
 
@@ -110,8 +110,8 @@ popcount(const T number) noexcept;
  */
 template <typename To,
           typename From,
-          STDGPU_DETAIL_OVERLOAD_IF(sizeof(To) == sizeof(From) && std::is_trivially_copyable<To>::value &&
-                                    std::is_trivially_copyable<From>::value)>
+          STDGPU_DETAIL_OVERLOAD_IF(sizeof(To) == sizeof(From) && std::is_trivially_copyable_v<To> &&
+                                    std::is_trivially_copyable_v<From>)>
 STDGPU_HOST_DEVICE To
 bit_cast(const From& object) noexcept;
 

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -136,8 +136,7 @@ public:
     private:
         using block_type = Block; /**< The type of the stored bit blocks, must be the same as for bitset */
 
-        static_assert(std::is_same<block_type, unsigned int>::value ||
-                              std::is_same<block_type, unsigned long long int>::value,
+        static_assert(std::is_same_v<block_type, unsigned int> || std::is_same_v<block_type, unsigned long long int>,
                       "stdgpu::bitset::reference: block_type not supported");
 
         friend bitset;
@@ -154,7 +153,7 @@ public:
         index_t _bit_n = -1;
     };
 
-    static_assert(std::is_same<Block, unsigned int>::value || std::is_same<Block, unsigned long long int>::value,
+    static_assert(std::is_same_v<Block, unsigned int> || std::is_same_v<Block, unsigned long long int>,
                   "stdgpu::bitset: Block not supported");
 
     using block_type = Block;         /**< Block */

--- a/src/stdgpu/cuda/atomic.cuh
+++ b/src/stdgpu/cuda/atomic.cuh
@@ -63,7 +63,7 @@ atomic_store(T* address, const T desired) noexcept;
  * \param[in] desired The desired argument to store
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address, const T desired) noexcept;
 
@@ -75,7 +75,7 @@ atomic_exchange(T* address, const T desired) noexcept;
  * \param[in] desired The desired argument to store
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address, const T expected, const T desired) noexcept;
 
@@ -86,7 +86,7 @@ atomic_compare_exchange(T* address, const T expected, const T desired) noexcept;
  * \param[in] arg The other argument of addition
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address, const T arg) noexcept;
 
@@ -97,7 +97,7 @@ atomic_fetch_add(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of subtraction
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address, const T arg) noexcept;
 
@@ -108,7 +108,7 @@ atomic_fetch_sub(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of bitwise AND
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address, const T arg) noexcept;
 
@@ -119,7 +119,7 @@ atomic_fetch_and(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of bitwise OR
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address, const T arg) noexcept;
 
@@ -130,7 +130,7 @@ atomic_fetch_or(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of bitwise XOR
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address, const T arg) noexcept;
 
@@ -141,7 +141,7 @@ atomic_fetch_xor(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of minimum
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address, const T arg) noexcept;
 
@@ -152,7 +152,7 @@ atomic_fetch_min(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of maximum
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address, const T arg) noexcept;
 
@@ -163,7 +163,7 @@ atomic_fetch_max(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same_v<T, unsigned int>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address, const T arg) noexcept;
 
@@ -174,7 +174,7 @@ atomic_fetch_inc_mod(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same_v<T, unsigned int>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address, const T arg) noexcept;
 

--- a/src/stdgpu/cuda/impl/atomic_detail.cuh
+++ b/src/stdgpu/cuda/impl/atomic_detail.cuh
@@ -99,83 +99,77 @@ atomic_store(T* address, const T desired) noexcept
     *volatile_address = desired;
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address, const T desired) noexcept
 {
     return atomicExch(address, desired);
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address, const T expected, const T desired) noexcept
 {
     return atomicCAS(address, expected, desired);
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address, const T arg) noexcept
 {
     return atomicAdd(address, arg);
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address, const T arg) noexcept
 {
     return atomicSub(address, arg);
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address, const T arg) noexcept
 {
     return atomicAnd(address, arg);
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address, const T arg) noexcept
 {
     return atomicOr(address, arg);
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address, const T arg) noexcept
 {
     return atomicXor(address, arg);
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address, const T arg) noexcept
 {
     return atomicMin(address, arg);
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address, const T arg) noexcept
 {
     return atomicMax(address, arg);
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same_v<T, unsigned int>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address, const T arg) noexcept
 {
     return atomicInc(address, arg);
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same_v<T, unsigned int>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address, const T arg) noexcept
 {

--- a/src/stdgpu/functional.h
+++ b/src/stdgpu/functional.h
@@ -349,7 +349,7 @@ private:
     /**
      * \brief Restrict specializations to enumerations
      */
-    using sfinae = std::enable_if_t<std::is_enum<E>::value, E>;
+    using sfinae = std::enable_if_t<std::is_enum_v<E>, E>;
 };
 
 /**

--- a/src/stdgpu/hip/atomic.h
+++ b/src/stdgpu/hip/atomic.h
@@ -63,7 +63,7 @@ atomic_store(T* address, const T desired) noexcept;
  * \param[in] desired The desired argument to store
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address, const T desired) noexcept;
 
@@ -75,7 +75,7 @@ atomic_exchange(T* address, const T desired) noexcept;
  * \param[in] desired The desired argument to store
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address, const T expected, const T desired) noexcept;
 
@@ -86,7 +86,7 @@ atomic_compare_exchange(T* address, const T expected, const T desired) noexcept;
  * \param[in] arg The other argument of addition
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address, const T arg) noexcept;
 
@@ -97,7 +97,7 @@ atomic_fetch_add(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of subtraction
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address, const T arg) noexcept;
 
@@ -108,7 +108,7 @@ atomic_fetch_sub(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of bitwise AND
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address, const T arg) noexcept;
 
@@ -119,7 +119,7 @@ atomic_fetch_and(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of bitwise OR
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address, const T arg) noexcept;
 
@@ -130,7 +130,7 @@ atomic_fetch_or(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of bitwise XOR
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address, const T arg) noexcept;
 
@@ -141,7 +141,7 @@ atomic_fetch_xor(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of minimum
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address, const T arg) noexcept;
 
@@ -152,7 +152,7 @@ atomic_fetch_min(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of maximum
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address, const T arg) noexcept;
 
@@ -163,7 +163,7 @@ atomic_fetch_max(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same_v<T, unsigned int>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address, const T arg) noexcept;
 
@@ -174,7 +174,7 @@ atomic_fetch_inc_mod(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same_v<T, unsigned int>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address, const T arg) noexcept;
 

--- a/src/stdgpu/hip/impl/atomic_detail.h
+++ b/src/stdgpu/hip/impl/atomic_detail.h
@@ -53,83 +53,77 @@ atomic_store(T* address, const T desired) noexcept
     *volatile_address = desired;
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address, const T desired) noexcept
 {
     return atomicExch(address, desired);
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address, const T expected, const T desired) noexcept
 {
     return atomicCAS(address, expected, desired);
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address, const T arg) noexcept
 {
     return atomicAdd(address, arg);
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address, const T arg) noexcept
 {
     return atomicSub(address, arg);
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address, const T arg) noexcept
 {
     return atomicAnd(address, arg);
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address, const T arg) noexcept
 {
     return atomicOr(address, arg);
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address, const T arg) noexcept
 {
     return atomicXor(address, arg);
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address, const T arg) noexcept
 {
     return atomicMin(address, arg);
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address, const T arg) noexcept
 {
     return atomicMax(address, arg);
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same_v<T, unsigned int>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address, const T arg) noexcept
 {
     return atomicInc(address, arg);
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same_v<T, unsigned int>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address, const T arg) noexcept
 {

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -224,7 +224,7 @@ atomic<T, Allocator>::compare_exchange_strong(T& expected, const T desired, cons
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::fetch_add(const T arg, const memory_order order) noexcept
 {
@@ -232,7 +232,7 @@ atomic<T, Allocator>::fetch_add(const T arg, const memory_order order) noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::fetch_sub(const T arg, const memory_order order) noexcept
 {
@@ -240,7 +240,7 @@ atomic<T, Allocator>::fetch_sub(const T arg, const memory_order order) noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::fetch_and(const T arg, const memory_order order) noexcept
 {
@@ -248,7 +248,7 @@ atomic<T, Allocator>::fetch_and(const T arg, const memory_order order) noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::fetch_or(const T arg, const memory_order order) noexcept
 {
@@ -256,7 +256,7 @@ atomic<T, Allocator>::fetch_or(const T arg, const memory_order order) noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::fetch_xor(const T arg, const memory_order order) noexcept
 {
@@ -264,7 +264,7 @@ atomic<T, Allocator>::fetch_xor(const T arg, const memory_order order) noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::fetch_min(const T arg, const memory_order order) noexcept
 {
@@ -272,7 +272,7 @@ atomic<T, Allocator>::fetch_min(const T arg, const memory_order order) noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::fetch_max(const T arg, const memory_order order) noexcept
 {
@@ -280,7 +280,7 @@ atomic<T, Allocator>::fetch_max(const T arg, const memory_order order) noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same_v<T, unsigned int>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::fetch_inc_mod(const T arg, const memory_order order) noexcept
 {
@@ -288,7 +288,7 @@ atomic<T, Allocator>::fetch_inc_mod(const T arg, const memory_order order) noexc
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same_v<T, unsigned int>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::fetch_dec_mod(const T arg, const memory_order order) noexcept
 {
@@ -296,7 +296,7 @@ atomic<T, Allocator>::fetch_dec_mod(const T arg, const memory_order order) noexc
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::operator++() noexcept
 {
@@ -304,7 +304,7 @@ atomic<T, Allocator>::operator++() noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::operator++(int) noexcept
 {
@@ -312,7 +312,7 @@ atomic<T, Allocator>::operator++(int) noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::operator--() noexcept
 {
@@ -320,7 +320,7 @@ atomic<T, Allocator>::operator--() noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::operator--(int) noexcept
 {
@@ -328,7 +328,7 @@ atomic<T, Allocator>::operator--(int) noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::operator+=(const T arg) noexcept
 {
@@ -336,7 +336,7 @@ atomic<T, Allocator>::operator+=(const T arg) noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::operator-=(const T arg) noexcept
 {
@@ -344,7 +344,7 @@ atomic<T, Allocator>::operator-=(const T arg) noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::operator&=(const T arg) noexcept
 {
@@ -352,7 +352,7 @@ atomic<T, Allocator>::operator&=(const T arg) noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::operator|=(const T arg) noexcept
 {
@@ -360,7 +360,7 @@ atomic<T, Allocator>::operator|=(const T arg) noexcept
 }
 
 template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::operator^=(const T arg) noexcept
 {
@@ -488,7 +488,7 @@ atomic_ref<T>::compare_exchange_strong(T& expected, const T desired, const memor
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_add(const T arg, const memory_order order) noexcept
 {
@@ -502,7 +502,7 @@ atomic_ref<T>::fetch_add(const T arg, const memory_order order) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_sub(const T arg, const memory_order order) noexcept
 {
@@ -516,7 +516,7 @@ atomic_ref<T>::fetch_sub(const T arg, const memory_order order) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_and(const T arg, const memory_order order) noexcept
 {
@@ -530,7 +530,7 @@ atomic_ref<T>::fetch_and(const T arg, const memory_order order) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_or(const T arg, const memory_order order) noexcept
 {
@@ -544,7 +544,7 @@ atomic_ref<T>::fetch_or(const T arg, const memory_order order) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_xor(const T arg, const memory_order order) noexcept
 {
@@ -558,7 +558,7 @@ atomic_ref<T>::fetch_xor(const T arg, const memory_order order) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_min(const T arg, const memory_order order) noexcept
 {
@@ -572,7 +572,7 @@ atomic_ref<T>::fetch_min(const T arg, const memory_order order) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_max(const T arg, const memory_order order) noexcept
 {
@@ -586,7 +586,7 @@ atomic_ref<T>::fetch_max(const T arg, const memory_order order) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same_v<T, unsigned int>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_inc_mod(const T arg, const memory_order order) noexcept
 {
@@ -600,7 +600,7 @@ atomic_ref<T>::fetch_inc_mod(const T arg, const memory_order order) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same_v<T, unsigned int>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_dec_mod(const T arg, const memory_order order) noexcept
 {
@@ -614,7 +614,7 @@ atomic_ref<T>::fetch_dec_mod(const T arg, const memory_order order) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator++() noexcept
 {
@@ -622,7 +622,7 @@ atomic_ref<T>::operator++() noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator++(int) noexcept
 {
@@ -630,7 +630,7 @@ atomic_ref<T>::operator++(int) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator--() noexcept
 {
@@ -638,7 +638,7 @@ atomic_ref<T>::operator--() noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator--(int) noexcept
 {
@@ -646,7 +646,7 @@ atomic_ref<T>::operator--(int) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator+=(const T arg) noexcept
 {
@@ -654,7 +654,7 @@ atomic_ref<T>::operator+=(const T arg) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator-=(const T arg) noexcept
 {
@@ -662,7 +662,7 @@ atomic_ref<T>::operator-=(const T arg) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator&=(const T arg) noexcept
 {
@@ -670,7 +670,7 @@ atomic_ref<T>::operator&=(const T arg) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator|=(const T arg) noexcept
 {
@@ -678,7 +678,7 @@ atomic_ref<T>::operator|=(const T arg) noexcept
 }
 
 template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::operator^=(const T arg) noexcept
 {

--- a/src/stdgpu/impl/bit_detail.h
+++ b/src/stdgpu/impl/bit_detail.h
@@ -24,14 +24,14 @@
 namespace stdgpu
 {
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned_v<T>)>
 STDGPU_HOST_DEVICE bool
 has_single_bit(const T number) noexcept
 {
     return ((number != 0) && !(number & (number - static_cast<T>(1))));
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned_v<T>)>
 STDGPU_HOST_DEVICE T
 bit_ceil(const T number) noexcept
 {
@@ -54,7 +54,7 @@ bit_ceil(const T number) noexcept
     return result;
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned_v<T>)>
 STDGPU_HOST_DEVICE T
 bit_floor(const T number) noexcept
 {
@@ -76,7 +76,7 @@ bit_floor(const T number) noexcept
     return result;
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned_v<T>)>
 STDGPU_HOST_DEVICE T
 bit_mod(const T number, const T divider) noexcept
 {
@@ -89,7 +89,7 @@ bit_mod(const T number, const T divider) noexcept
     return result;
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned_v<T>)>
 STDGPU_HOST_DEVICE T
 bit_width(const T number) noexcept
 {
@@ -110,7 +110,7 @@ bit_width(const T number) noexcept
     return result;
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_unsigned_v<T>)>
 STDGPU_HOST_DEVICE int
 popcount(const T number) noexcept
 {
@@ -130,8 +130,8 @@ popcount(const T number) noexcept
 
 template <typename To,
           typename From,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(sizeof(To) == sizeof(From) && std::is_trivially_copyable<To>::value &&
-                                               std::is_trivially_copyable<From>::value)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(sizeof(To) == sizeof(From) && std::is_trivially_copyable_v<To> &&
+                                               std::is_trivially_copyable_v<From>)>
 STDGPU_HOST_DEVICE To
 bit_cast(const From& object) noexcept
 {

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -41,14 +41,14 @@ template <typename T>
 bool
 is_destroy_optimizable()
 {
-    return std::is_trivially_destructible<T>::value;
+    return std::is_trivially_destructible_v<T>;
 }
 
 template <typename T, typename Allocator>
 bool
 is_allocator_destroy_optimizable()
 {
-    return std::is_trivially_destructible<T>::value && detail::is_base<allocator_traits<Allocator>>::value;
+    return std::is_trivially_destructible_v<T> && detail::is_base<allocator_traits<Allocator>>::value;
 }
 
 [[nodiscard]] void*

--- a/src/stdgpu/openmp/atomic.h
+++ b/src/stdgpu/openmp/atomic.h
@@ -63,7 +63,7 @@ atomic_store(T* address, const T desired) noexcept;
  * \param[in] desired The desired argument to store
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address, const T desired) noexcept;
 
@@ -75,7 +75,7 @@ atomic_exchange(T* address, const T desired) noexcept;
  * \param[in] desired The desired argument to store
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address, const T expected, const T desired) noexcept;
 
@@ -86,7 +86,7 @@ atomic_compare_exchange(T* address, const T expected, const T desired) noexcept;
  * \param[in] arg The other argument of addition
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address, const T arg) noexcept;
 
@@ -97,7 +97,7 @@ atomic_fetch_add(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of subtraction
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address, const T arg) noexcept;
 
@@ -108,7 +108,7 @@ atomic_fetch_sub(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of bitwise AND
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address, const T arg) noexcept;
 
@@ -119,7 +119,7 @@ atomic_fetch_and(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of bitwise OR
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address, const T arg) noexcept;
 
@@ -130,7 +130,7 @@ atomic_fetch_or(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of bitwise XOR
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address, const T arg) noexcept;
 
@@ -141,7 +141,7 @@ atomic_fetch_xor(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of minimum
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address, const T arg) noexcept;
 
@@ -152,7 +152,7 @@ atomic_fetch_min(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of maximum
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address, const T arg) noexcept;
 
@@ -163,7 +163,7 @@ atomic_fetch_max(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same_v<T, unsigned int>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address, const T arg) noexcept;
 
@@ -174,7 +174,7 @@ atomic_fetch_inc_mod(T* address, const T arg) noexcept;
  * \param[in] arg The other argument of modulus
  * \return The old value
  */
-template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same<T, unsigned int>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_IF(std::is_same_v<T, unsigned int>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address, const T arg) noexcept;
 

--- a/src/stdgpu/openmp/impl/atomic_detail.h
+++ b/src/stdgpu/openmp/impl/atomic_detail.h
@@ -53,8 +53,7 @@ atomic_store(T* address, const T desired) noexcept
     *address = desired;
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_exchange(T* address, const T desired) noexcept
 {
@@ -67,8 +66,7 @@ atomic_exchange(T* address, const T desired) noexcept
     return old;
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_compare_exchange(T* address, const T expected, const T desired) noexcept
 {
@@ -81,8 +79,7 @@ atomic_compare_exchange(T* address, const T expected, const T desired) noexcept
     return old;
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_add(T* address, const T arg) noexcept
 {
@@ -99,8 +96,7 @@ atomic_fetch_add(T* address, const T arg) noexcept
     return old;
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_sub(T* address, const T arg) noexcept
 {
@@ -117,7 +113,7 @@ atomic_fetch_sub(T* address, const T arg) noexcept
     return old;
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and(T* address, const T arg) noexcept
 {
@@ -134,7 +130,7 @@ atomic_fetch_and(T* address, const T arg) noexcept
     return old;
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or(T* address, const T arg) noexcept
 {
@@ -151,7 +147,7 @@ atomic_fetch_or(T* address, const T arg) noexcept
     return old;
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor(T* address, const T arg) noexcept
 {
@@ -168,8 +164,7 @@ atomic_fetch_xor(T* address, const T arg) noexcept
     return old;
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_min(T* address, const T arg) noexcept
 {
@@ -182,8 +177,7 @@ atomic_fetch_min(T* address, const T arg) noexcept
     return old;
 }
 
-template <typename T,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral<T>::value || std::is_floating_point<T>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_max(T* address, const T arg) noexcept
 {
@@ -196,7 +190,7 @@ atomic_fetch_max(T* address, const T arg) noexcept
     return old;
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same_v<T, unsigned int>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_inc_mod(T* address, const T arg) noexcept
 {
@@ -209,7 +203,7 @@ atomic_fetch_inc_mod(T* address, const T arg) noexcept
     return old;
 }
 
-template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same<T, unsigned int>::value)>
+template <typename T, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_same_v<T, unsigned int>)>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_dec_mod(T* address, const T arg) noexcept
 {

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -94,7 +94,7 @@ public:
     using pointer = value_type*;               /**< value_type* */
     using const_pointer = const value_type*;   /**< const value_type* */
 
-    static_assert(!std::is_same<T, bool>::value, "std::vector<bool> specialization not provided");
+    static_assert(!std::is_same_v<T, bool>, "std::vector<bool> specialization not provided");
 
     /**
      * \brief Creates an object of this class on the GPU (device)

--- a/test/stdgpu/contract.cpp
+++ b/test/stdgpu/contract.cpp
@@ -64,10 +64,10 @@ TEST_F(stdgpu_contract, expects_host_expression)
 TEST_F(stdgpu_contract, expects_host_comma_expression)
 {
 #if STDGPU_ENABLE_CONTRACT_CHECKS
-    STDGPU_EXPECTS(std::is_same<int, int>::value); // NOLINT(hicpp-static-assert,misc-static-assert,cert-dcl03-c)
+    STDGPU_EXPECTS(std::is_same_v<int, int>); // NOLINT(hicpp-static-assert,misc-static-assert,cert-dcl03-c)
 
     // NOLINTNEXTLINE(hicpp-no-array-decay,hicpp-avoid-goto,hicpp-static-assert,misc-static-assert,cert-dcl03-c)
-    EXPECT_DEATH(STDGPU_EXPECTS(std::is_same<int, float>::value), "");
+    EXPECT_DEATH(STDGPU_EXPECTS(std::is_same_v<int, float>), "");
 #endif
 }
 
@@ -99,10 +99,10 @@ TEST_F(stdgpu_contract, ensures_host_expression)
 TEST_F(stdgpu_contract, ensures_host_comma_expression)
 {
 #if STDGPU_ENABLE_CONTRACT_CHECKS
-    STDGPU_ENSURES(std::is_same<int, int>::value); // NOLINT(hicpp-static-assert,misc-static-assert,cert-dcl03-c)
+    STDGPU_ENSURES(std::is_same_v<int, int>); // NOLINT(hicpp-static-assert,misc-static-assert,cert-dcl03-c)
 
     // NOLINTNEXTLINE(hicpp-no-array-decay,hicpp-avoid-goto,hicpp-static-assert,misc-static-assert,cert-dcl03-c)
-    EXPECT_DEATH(STDGPU_ENSURES(std::is_same<int, float>::value), "");
+    EXPECT_DEATH(STDGPU_ENSURES(std::is_same_v<int, float>), "");
 #endif
 }
 
@@ -134,9 +134,9 @@ TEST_F(stdgpu_contract, assert_host_expression)
 TEST_F(stdgpu_contract, assert_host_comma_expression)
 {
 #if STDGPU_ENABLE_CONTRACT_CHECKS
-    STDGPU_ASSERT(std::is_same<int, int>::value); // NOLINT(hicpp-static-assert,misc-static-assert,cert-dcl03-c)
+    STDGPU_ASSERT(std::is_same_v<int, int>); // NOLINT(hicpp-static-assert,misc-static-assert,cert-dcl03-c)
 
     // NOLINTNEXTLINE(hicpp-no-array-decay,hicpp-avoid-goto,hicpp-static-assert,misc-static-assert,cert-dcl03-c)
-    EXPECT_DEATH(STDGPU_ASSERT(std::is_same<int, float>::value), "");
+    EXPECT_DEATH(STDGPU_ASSERT(std::is_same_v<int, float>), "");
 #endif
 }


### PR DESCRIPTION
Many classes and functions are conditionally enabled based on some type properties and make use of the type traits provided by the C++ standard library. Port these traits to the new and shorter `*_v` inline variable versions to improve the readability.

Partially addresses #314 