### PR TITLE
type_traits: Add inline variable alias in trait generation macro

### DIFF
--- a/benchmark/stdgpu/unordered_datastructure.inc
+++ b/benchmark/stdgpu/unordered_datastructure.inc
@@ -37,6 +37,7 @@
 
 #include <benchmark_utils.h>
 #include <stdgpu/algorithm.h>
+#include <stdgpu/impl/preprocessor.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
 

--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -91,6 +91,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                                        impl/mutex_detail.cuh
                                        impl/numeric_detail.h
                                        impl/platform_check.h
+                                       impl/preprocessor.h
                                        impl/queue_detail.cuh
                                        impl/ranges_detail.h
                                        impl/stack_detail.cuh

--- a/src/stdgpu/impl/preprocessor.h
+++ b/src/stdgpu/impl/preprocessor.h
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2022 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_PREPROCESSOR_H
+#define STDGPU_PREPROCESSOR_H
+
+namespace stdgpu::detail
+{
+
+#define STDGPU_DETAIL_CAT2_DIRECT(A, B) A##B
+#define STDGPU_DETAIL_CAT2(A, B) STDGPU_DETAIL_CAT2_DIRECT(A, B)
+
+#define STDGPU_DETAIL_CAT3(A, B, C) STDGPU_DETAIL_CAT2(A, STDGPU_DETAIL_CAT2(B, C))
+
+} // namespace stdgpu::detail
+
+#endif // STDGPU_PREPROCESSOR_H

--- a/src/stdgpu/impl/type_traits.h
+++ b/src/stdgpu/impl/type_traits.h
@@ -19,6 +19,8 @@
 #include <type_traits>
 #include <utility>
 
+#include <stdgpu/impl/preprocessor.h>
+
 namespace stdgpu::detail
 {
 
@@ -47,7 +49,10 @@ namespace stdgpu::detail
     template <typename T>                                                                                              \
     struct name<T, std::void_t<__VA_ARGS__>> : std::true_type                                                          \
     {                                                                                                                  \
-    };
+    };                                                                                                                 \
+                                                                                                                       \
+    template <typename T>                                                                                              \
+    inline constexpr bool STDGPU_DETAIL_CAT2(name, _v) = name<T>::value;
 
 // Clang does not detect T::pointer for thrust::device_pointer, so avoid checking it
 STDGPU_DETAIL_DEFINE_TRAIT(is_iterator,

--- a/src/stdgpu/platform.h
+++ b/src/stdgpu/platform.h
@@ -37,8 +37,8 @@
 
 #include STDGPU_DETAIL_BACKEND_HEADER(platform.h)
 
-// NOTE: For backwards compatibility only
-#include <stdgpu/compiler.h>
+#include <stdgpu/compiler.h> // NOTE: For backwards compatibility only
+#include <stdgpu/impl/preprocessor.h>
 
 namespace stdgpu
 {
@@ -69,17 +69,6 @@ namespace stdgpu
     #define STDGPU_BACKEND
 #endif
 // STDGPU_BACKEND is defined in stdgpu/config.h
-
-namespace detail
-{
-
-//! @cond Doxygen_Suppress
-#define STDGPU_DETAIL_CAT2_DIRECT(A, B) A##B
-#define STDGPU_DETAIL_CAT2(A, B) STDGPU_DETAIL_CAT2_DIRECT(A, B)
-#define STDGPU_DETAIL_CAT3(A, B, C) STDGPU_DETAIL_CAT2(A, STDGPU_DETAIL_CAT2(B, C))
-//! @endcond
-
-} // namespace detail
 
 /**
  * \ingroup platform


### PR DESCRIPTION
The internal `type_traits` module defines a macro to generate implementation-specific traits. Extend this macro by a an inline variable alias to enable using this shorter notation for our custom traits.

Furthermore, move the `STDGPU_DETAIL_CAT{2,3}` macros to a dedicated `preprocessor` module as this is required in the implementation of the alias. As a side effect, this makes the `platform` module a bit cleaner.