### PR TITLE
src: Use shorter inline variables for detail type traits

### DIFF
--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -48,7 +48,7 @@ template <typename T, typename Allocator>
 bool
 is_allocator_destroy_optimizable()
 {
-    return std::is_trivially_destructible_v<T> && detail::is_base<allocator_traits<Allocator>>::value;
+    return std::is_trivially_destructible_v<T> && detail::is_base_v<allocator_traits<Allocator>>;
 }
 
 [[nodiscard]] void*
@@ -716,17 +716,17 @@ template <typename Ptr>
 STDGPU_HOST_DEVICE auto
 to_address(const Ptr& p) noexcept
 {
-    if constexpr (detail::has_arrow_operator<Ptr>::value)
+    if constexpr (detail::has_arrow_operator_v<Ptr>)
     {
         return to_address(p.operator->());
     }
-    else if constexpr (!detail::has_arrow_operator<Ptr>::value && detail::has_get<Ptr>::value)
+    else if constexpr (!detail::has_arrow_operator_v<Ptr> && detail::has_get_v<Ptr>)
     {
         return to_address(p.get());
     }
     else
     {
-        static_assert(detail::dependent_false<Ptr>::value, "Ptr has neither operator->() or get() defined.");
+        static_assert(detail::dependent_false_v<Ptr>, "Ptr has neither operator->() or get() defined.");
 
         // This reduces the number of compiler errors in calling contexts and makes the failed assertion more apparent.
         return static_cast<void*>(nullptr);

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -190,7 +190,7 @@ public:
      * \return The number of elements with the given key-like value, i.e. 1 or 0
      */
     template <typename KeyLike,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
     STDGPU_DEVICE_ONLY index_type
     count(const KeyLike& key) const;
 
@@ -216,7 +216,7 @@ public:
      * \return An iterator to the position of the requested key-like value if it was found, end() otherwise
      */
     template <typename KeyLike,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
     STDGPU_DEVICE_ONLY iterator
     find(const KeyLike& key);
 
@@ -226,7 +226,7 @@ public:
      * \return An iterator to the position of the requested key-like value if it was found, end() otherwise
      */
     template <typename KeyLike,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
     STDGPU_DEVICE_ONLY const_iterator
     find(const KeyLike& key) const;
 
@@ -244,7 +244,7 @@ public:
      * \return True if the requested key-like value was found, false otherwise
      */
     template <typename KeyLike,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
     STDGPU_DEVICE_ONLY bool
     contains(const KeyLike& key) const;
 
@@ -287,7 +287,7 @@ public:
      * \param[in] begin The begin of the range
      * \param[in] end The end of the range
      */
-    template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator<ValueIterator>::value)>
+    template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<ValueIterator>)>
     void
     insert(ValueIterator begin, ValueIterator end);
 
@@ -304,7 +304,7 @@ public:
      * \param[in] begin The begin of the range
      * \param[in] end The end of the range
      */
-    template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator<KeyIterator>::value)>
+    template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<KeyIterator>)>
     void
     erase(KeyIterator begin, KeyIterator end);
 

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -520,8 +520,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::count(const
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 template <typename KeyLike,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
-                  detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
 inline STDGPU_DEVICE_ONLY index_t
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::count(const KeyLike& key) const
 {
@@ -553,8 +552,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::find(const 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 template <typename KeyLike,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
-                  detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
 inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::find(const KeyLike& key)
 {
@@ -564,8 +562,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::find(const 
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 template <typename KeyLike,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
-                  detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
 inline STDGPU_DEVICE_ONLY typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::const_iterator
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::find(const KeyLike& key) const
 {
@@ -612,8 +609,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::contains(co
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 template <typename KeyLike,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
-                  detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
 inline STDGPU_DEVICE_ONLY bool
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::contains(const KeyLike& key) const
 {
@@ -912,7 +908,7 @@ inline STDGPU_DEVICE_ONLY
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
-template <typename InputIt, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator<InputIt>::value)>
+template <typename InputIt, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<InputIt>)>
 inline void
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::insert(InputIt begin, InputIt end)
 {
@@ -944,7 +940,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::erase(
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
-template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator<KeyIterator>::value)>
+template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<KeyIterator>)>
 inline void
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::erase(KeyIterator begin, KeyIterator end)
 {

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -119,8 +119,7 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::count(const key_type& key) con
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 template <typename KeyLike,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
-                  detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
 inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::index_type
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::count(const KeyLike& key) const
 {
@@ -143,8 +142,7 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::find(const key_type& key) cons
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 template <typename KeyLike,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
-                  detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
 inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::iterator
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::find(const KeyLike& key)
 {
@@ -153,8 +151,7 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::find(const KeyLike& key)
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 template <typename KeyLike,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
-                  detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
 inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::const_iterator
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::find(const KeyLike& key) const
 {
@@ -170,8 +167,7 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::contains(const key_type& key) 
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 template <typename KeyLike,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
-                  detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
 inline STDGPU_DEVICE_ONLY bool
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::contains(const KeyLike& key) const
 {
@@ -195,7 +191,7 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::insert(
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator<ValueIterator>::value)>
+template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<ValueIterator>)>
 inline void
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::insert(ValueIterator begin, ValueIterator end)
 {
@@ -211,7 +207,7 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::erase(
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
-template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator<KeyIterator>::value)>
+template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<KeyIterator>)>
 inline void
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::erase(KeyIterator begin, KeyIterator end)
 {

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -104,8 +104,7 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::count(const key_type& key) const
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 template <typename KeyLike,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
-                  detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
 inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual, Allocator>::index_type
 unordered_set<Key, Hash, KeyEqual, Allocator>::count(const KeyLike& key) const
 {
@@ -128,8 +127,7 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::find(const key_type& key) const
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 template <typename KeyLike,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
-                  detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
 inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual, Allocator>::iterator
 unordered_set<Key, Hash, KeyEqual, Allocator>::find(const KeyLike& key)
 {
@@ -138,8 +136,7 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::find(const KeyLike& key)
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 template <typename KeyLike,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
-                  detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
 inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual, Allocator>::const_iterator
 unordered_set<Key, Hash, KeyEqual, Allocator>::find(const KeyLike& key) const
 {
@@ -155,8 +152,7 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::contains(const key_type& key) con
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 template <typename KeyLike,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
-                  detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
 inline STDGPU_DEVICE_ONLY bool
 unordered_set<Key, Hash, KeyEqual, Allocator>::contains(const KeyLike& key) const
 {
@@ -180,7 +176,7 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::insert(
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator<ValueIterator>::value)>
+template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<ValueIterator>)>
 inline void
 unordered_set<Key, Hash, KeyEqual, Allocator>::insert(ValueIterator begin, ValueIterator end)
 {
@@ -195,7 +191,7 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::erase(const unordered_set<Key, Ha
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
-template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator<KeyIterator>::value)>
+template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<KeyIterator>)>
 inline void
 unordered_set<Key, Hash, KeyEqual, Allocator>::erase(KeyIterator begin, KeyIterator end)
 {

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -324,7 +324,7 @@ vector_clear_iota(vector<T, Allocator>& v, const T& value)
 } // namespace detail
 
 template <typename T, typename Allocator>
-template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator<ValueIterator>::value)>
+template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<ValueIterator>)>
 inline void
 vector<T, Allocator>::insert(device_ptr<const T> position, ValueIterator begin, ValueIterator end)
 {

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -212,7 +212,7 @@ public:
      * \return The number of elements with the given key-like value, i.e. 1 or 0
      */
     template <typename KeyLike,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
     STDGPU_DEVICE_ONLY index_type
     count(const KeyLike& key) const;
 
@@ -238,7 +238,7 @@ public:
      * \return An iterator to the position of the requested key-like value if it was found, end() otherwise
      */
     template <typename KeyLike,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
     STDGPU_DEVICE_ONLY iterator
     find(const KeyLike& key);
 
@@ -248,7 +248,7 @@ public:
      * \return An iterator to the position of the requested key-like value if it was found, end() otherwise
      */
     template <typename KeyLike,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
     STDGPU_DEVICE_ONLY const_iterator
     find(const KeyLike& key) const;
 
@@ -266,7 +266,7 @@ public:
      * \return True if the requested key-like value was found, false otherwise
      */
     template <typename KeyLike,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
     STDGPU_DEVICE_ONLY bool
     contains(const KeyLike& key) const;
 
@@ -292,7 +292,7 @@ public:
      * \param[in] begin The begin of the range
      * \param[in] end The end of the range
      */
-    template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator<ValueIterator>::value)>
+    template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<ValueIterator>)>
     void
     insert(ValueIterator begin, ValueIterator end);
 
@@ -309,7 +309,7 @@ public:
      * \param[in] begin The begin of the range
      * \param[in] end The end of the range
      */
-    template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator<KeyIterator>::value)>
+    template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<KeyIterator>)>
     void
     erase(KeyIterator begin, KeyIterator end);
 

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -202,7 +202,7 @@ public:
      * \return The number of elements with the given key-like value, i.e. 1 or 0
      */
     template <typename KeyLike,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
     STDGPU_DEVICE_ONLY index_type
     count(const KeyLike& key) const;
 
@@ -228,7 +228,7 @@ public:
      * \return An iterator to the position of the requested key-like value if it was found, end() otherwise
      */
     template <typename KeyLike,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
     STDGPU_DEVICE_ONLY iterator
     find(const KeyLike& key);
 
@@ -238,7 +238,7 @@ public:
      * \return An iterator to the position of the requested key-like value if it was found, end() otherwise
      */
     template <typename KeyLike,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
     STDGPU_DEVICE_ONLY const_iterator
     find(const KeyLike& key) const;
 
@@ -256,7 +256,7 @@ public:
      * \return True if the requested key-like value was found, false otherwise
      */
     template <typename KeyLike,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent<Hash>::value&& detail::is_transparent<KeyEqual>::value)>
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_transparent_v<Hash>&& detail::is_transparent_v<KeyEqual>)>
     STDGPU_DEVICE_ONLY bool
     contains(const KeyLike& key) const;
 
@@ -282,7 +282,7 @@ public:
      * \param[in] begin The begin of the range
      * \param[in] end The end of the range
      */
-    template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator<ValueIterator>::value)>
+    template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<ValueIterator>)>
     void
     insert(ValueIterator begin, ValueIterator end);
 
@@ -299,7 +299,7 @@ public:
      * \param[in] begin The begin of the range
      * \param[in] end The end of the range
      */
-    template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator<KeyIterator>::value)>
+    template <typename KeyIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<KeyIterator>)>
     void
     erase(KeyIterator begin, KeyIterator end);
 

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -220,7 +220,7 @@ public:
      * \param[in] end The end of the range
      * \note position must be equal to device_end()
      */
-    template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator<ValueIterator>::value)>
+    template <typename ValueIterator, STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<ValueIterator>)>
     void
     insert(device_ptr<const T> position, ValueIterator begin, ValueIterator end);
 


### PR DESCRIPTION
While the use of type traits from the C++ standard library have been simplified in #333, our own implementation-specific traits are still referenced by the classic `*::value` notation. Port these traits to the newer `*_v` versions as well for consistency and better readability.

Partially addresses #314 