### PR TITLE
memory: Fix missing-return warning in to_address with NVCC

### DIFF
--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -34,6 +34,7 @@
 
 #include <stdgpu/config.h>
 #include <stdgpu/cstddef.h>
+#include <stdgpu/impl/type_traits.h>
 #include <stdgpu/platform.h>
 
 /**
@@ -793,11 +794,17 @@ to_address(T* p) noexcept;
  * \brief Converts a potential fancy pointer to a raw pointer
  * \tparam Ptr The fancy pointer type
  * \param[in] p A fancy pointer
- * \return The raw pointer held by the fancy pointer obtained via operator->() or get()
+ * \return The raw pointer held by the fancy pointer obtained via operator->()
  */
-template <typename Ptr>
+template <typename Ptr, STDGPU_DETAIL_OVERLOAD_IF(detail::has_arrow_operator_v<Ptr>)>
 STDGPU_HOST_DEVICE auto
 to_address(const Ptr& p) noexcept;
+
+//! @cond Doxygen_Suppress
+template <typename Ptr, STDGPU_DETAIL_OVERLOAD_IF(!detail::has_arrow_operator_v<Ptr> && detail::has_get_v<Ptr>)>
+STDGPU_HOST_DEVICE auto
+to_address(const Ptr& p) noexcept;
+//! @endcond
 
 /**
  * \ingroup memory


### PR DESCRIPTION
The simplification of the implementation of `to_address` in #332 resulted in a missing-return warning with NVCC for older CUDA versions. This compiler bug has been fixed in newer version, potentially in CUDA 11.5+. Revert to the old pre-C++17 implementation but keep the new code commented for future usage when the requirements will be increased. Furthermore, clean up some namespace qualifications to improve the readability.