### PR TITLE
src: Fix recent clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,6 +19,7 @@ hicpp-*,\
 -hicpp-vararg,\
 -hicpp-use-auto,\
 misc-*,\
+-misc-const-correctness,\
 modernize-*,\
 -modernize-avoid-c-arrays,\
 -modernize-use-auto,\

--- a/src/stdgpu/iterator.h
+++ b/src/stdgpu/iterator.h
@@ -54,11 +54,11 @@ using host_ptr = thrust::pointer<T, thrust::host_system_tag>;
 } // namespace stdgpu
 
 //! @cond Doxygen_Suppress
-namespace std
+namespace std // NOLINT(cert-dcl58-cpp)
 {
 
 template <typename T>
-struct iterator_traits<stdgpu::device_ptr<T>>
+struct iterator_traits<stdgpu::device_ptr<T>> // NOLINT(cert-dcl58-cpp)
 {
     using difference_type = typename std::iterator_traits<T*>::difference_type;
     using value_type = typename std::iterator_traits<T*>::value_type;
@@ -68,7 +68,7 @@ struct iterator_traits<stdgpu::device_ptr<T>>
 };
 
 template <typename T>
-struct iterator_traits<stdgpu::host_ptr<T>>
+struct iterator_traits<stdgpu::host_ptr<T>> // NOLINT(cert-dcl58-cpp)
 {
     using difference_type = typename std::iterator_traits<T*>::difference_type;
     using value_type = typename std::iterator_traits<T*>::value_type;


### PR DESCRIPTION
With the recent release of clang-tidy 15, some rules are more consistently and stricter enforced. Therefore, handle them and disable the noisy const-correctness warning for now.