### PR TITLE
CI: Automatically deploy latest documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: write
+
 jobs:
   Doxygen:
     runs-on: ubuntu-22.04
@@ -39,3 +42,11 @@ jobs:
         shell: bash
         run: |
           bash scripts/utils/build_documentation.sh
+
+      - name: Deploy documentation
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: build/doc/html
+          clean: true
+          single-commit: true
+        if: github.event_name != 'pull_request'


### PR DESCRIPTION
The deployed documentation on https://stotko.github.io/stdgpu/ quickly gets outdated between releases. Since users are also often interested in the latest set of features, deploying the corresponding documentation will expose them to these features in a more convenient way.

Furthermore, this enables a quicker tracking of issues with the documentation not tracked by the warnings as the current state will always be visible without requiring to always manually build the documentation by hand.