### PR TITLE
doc: Clean up redundant implicitly grouped elements

### DIFF
--- a/src/stdgpu/algorithm.h
+++ b/src/stdgpu/algorithm.h
@@ -17,9 +17,8 @@
 #define STDGPU_ALGORITHM_H
 
 /**
- * \addtogroup algorithm algorithm
+ * \defgroup algorithm algorithm
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -152,10 +151,6 @@ OutputIt
 copy_n(ExecutionPolicy&& policy, InputIt begin, Size n, OutputIt output_begin);
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/algorithm_detail.h>
 

--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -19,9 +19,8 @@
 #include <stdgpu/impl/platform_check.h>
 
 /**
- * \addtogroup atomic atomic
+ * \defgroup atomic atomic
  * \ingroup data_structures
- * @{
  */
 
 /**
@@ -899,10 +898,6 @@ atomic_fetch_xor_explicit(atomic<T, Allocator>* obj,
                           const memory_order order) noexcept;
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/atomic_detail.cuh>
 

--- a/src/stdgpu/atomic_fwd
+++ b/src/stdgpu/atomic_fwd
@@ -17,12 +17,6 @@
 #define STDGPU_ATOMIC_FWD
 
 /**
- * \addtogroup atomic atomic
- * \ingroup data_structures
- * @{
- */
-
-/**
  * \file stdgpu/atomic_fwd
  */
 
@@ -39,9 +33,5 @@ template <typename T>
 class atomic_ref;
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #endif // STDGPU_ATOMIC_FWD

--- a/src/stdgpu/bit.h
+++ b/src/stdgpu/bit.h
@@ -17,9 +17,8 @@
 #define STDGPU_BIT_H
 
 /**
- * \addtogroup bit bit
+ * \defgroup bit bit
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -116,10 +115,6 @@ STDGPU_HOST_DEVICE To
 bit_cast(const From& object) noexcept;
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/bit_detail.h>
 

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -19,9 +19,8 @@
 #include <stdgpu/impl/platform_check.h>
 
 /**
- * \addtogroup bitset bitset
+ * \defgroup bitset bitset
  * \ingroup data_structures
- * @{
  */
 
 /**
@@ -318,10 +317,6 @@ private:
 };
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/bitset_detail.cuh>
 

--- a/src/stdgpu/bitset_fwd
+++ b/src/stdgpu/bitset_fwd
@@ -17,12 +17,6 @@
 #define STDGPU_BITSET_FWD
 
 /**
- * \addtogroup bitset bitset
- * \ingroup data_structures
- * @{
- */
-
-/**
  * \file stdgpu/bitset_fwd
  */
 
@@ -38,9 +32,5 @@ template <typename Block = bitset_default_type, typename Allocator = safe_device
 class bitset;
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #endif // STDGPU_BITSET_FWD

--- a/src/stdgpu/cmath.h
+++ b/src/stdgpu/cmath.h
@@ -17,9 +17,8 @@
 #define STDGPU_CMATH_H
 
 /**
- * \addtogroup cmath cmath
+ * \defgroup cmath cmath
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -41,10 +40,6 @@ constexpr STDGPU_HOST_DEVICE float
 abs(const float arg);
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/cmath_detail.h>
 

--- a/src/stdgpu/compiler.h
+++ b/src/stdgpu/compiler.h
@@ -17,9 +17,8 @@
 #define STDGPU_COMPILER_H
 
 /**
- * \addtogroup compiler compiler
+ * \defgroup compiler compiler
  * \ingroup system
- * @{
  */
 
 /**
@@ -102,9 +101,5 @@ namespace stdgpu
 #endif
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #endif // STDGPU_COMPILER_H

--- a/src/stdgpu/config.h.in
+++ b/src/stdgpu/config.h.in
@@ -19,9 +19,8 @@
 //! @endcond
 
 /**
- * \addtogroup config config
+ * \defgroup config config
  * \ingroup system
- * @{
  */
 
 /**
@@ -92,10 +91,6 @@ namespace stdgpu
 } // namespace stdgpu
 
 
-
-/**
- * @}
- */
 
 
 

--- a/src/stdgpu/contract.h
+++ b/src/stdgpu/contract.h
@@ -17,9 +17,8 @@
 #define STDGPU_CONTRACT_H
 
 /**
- * \addtogroup contract contract
+ * \defgroup contract contract
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -115,9 +114,5 @@ namespace stdgpu
 #endif
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #endif // STDGPU_CONTRACT_H

--- a/src/stdgpu/cstddef.h
+++ b/src/stdgpu/cstddef.h
@@ -17,9 +17,8 @@
 #define STDGPU_CSTDDEF_H
 
 /**
- * \addtogroup cstddef cstddef
+ * \defgroup cstddef cstddef
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -96,9 +95,5 @@ using index_t = index64_t;
 #endif
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #endif // STDGPU_CSTDDEF_H

--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -19,9 +19,8 @@
 #include <stdgpu/impl/platform_check.h>
 
 /**
- * \addtogroup deque deque
+ * \defgroup deque deque
  * \ingroup data_structures
- * @{
  */
 
 /**
@@ -341,10 +340,6 @@ private:
 };
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/deque_detail.cuh>
 

--- a/src/stdgpu/deque_fwd
+++ b/src/stdgpu/deque_fwd
@@ -17,12 +17,6 @@
 #define STDGPU_DEQUE_FWD
 
 /**
- * \addtogroup deque deque
- * \ingroup data_structures
- * @{
- */
-
-/**
  * \file stdgpu/deque_fwd
  */
 
@@ -36,9 +30,5 @@ template <typename T, typename Allocator = safe_device_allocator<T>>
 class deque;
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #endif // STDGPU_DEQUE_FWD

--- a/src/stdgpu/execution.h
+++ b/src/stdgpu/execution.h
@@ -17,9 +17,8 @@
 #define STDGPU_EXECUTION_H
 
 /**
- * \addtogroup execution execution
+ * \defgroup execution execution
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -44,9 +43,5 @@ constexpr decltype(thrust::device) device;
 constexpr decltype(thrust::host) host;
 
 } // namespace stdgpu::execution
-
-/**
- * @}
- */
 
 #endif // STDGPU_EXECUTION_H

--- a/src/stdgpu/functional.h
+++ b/src/stdgpu/functional.h
@@ -17,9 +17,8 @@
 #define STDGPU_FUNCTIONAL_H
 
 /**
- * \addtogroup functional functional
+ * \defgroup functional functional
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -527,10 +526,6 @@ struct bit_not<void>
 };
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/functional_detail.h>
 

--- a/src/stdgpu/iterator.h
+++ b/src/stdgpu/iterator.h
@@ -17,9 +17,8 @@
 #define STDGPU_ITERATOR_H
 
 /**
- * \addtogroup iterator iterator
+ * \defgroup iterator iterator
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -533,10 +532,6 @@ STDGPU_HOST_DEVICE insert_iterator<Container>
 inserter(Container& c);
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/iterator_detail.h>
 

--- a/src/stdgpu/limits.h
+++ b/src/stdgpu/limits.h
@@ -17,9 +17,8 @@
 #define STDGPU_LIMITS_H
 
 /**
- * \addtogroup limits limits
+ * \defgroup limits limits
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -1564,10 +1563,6 @@ struct numeric_limits<long double>
 };
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/limits_detail.h>
 

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -17,9 +17,8 @@
 #define STDGPU_MEMORY_H
 
 /**
- * \addtogroup memory memory
+ * \defgroup memory memory
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -977,10 +976,6 @@ index64_t
 size_bytes(T* array);
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/memory_detail.h>
 

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -19,9 +19,8 @@
 #include <stdgpu/impl/platform_check.h>
 
 /**
- * \addtogroup mutex mutex
+ * \defgroup mutex mutex
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -190,10 +189,6 @@ STDGPU_DEVICE_ONLY int
 try_lock(Lockable1 lock1, Lockable2 lock2, LockableN... lockn);
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/mutex_detail.cuh>
 

--- a/src/stdgpu/mutex_fwd
+++ b/src/stdgpu/mutex_fwd
@@ -17,12 +17,6 @@
 #define STDGPU_MUTEX_FWD
 
 /**
- * \addtogroup mutex mutex
- * \ingroup utilities
- * @{
- */
-
-/**
  * \file stdgpu/mutex_fwd
  */
 
@@ -38,9 +32,5 @@ template <typename Block = mutex_default_type, typename Allocator = safe_device_
 class mutex_array;
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #endif // STDGPU_MUTEX_FWD

--- a/src/stdgpu/numeric.h
+++ b/src/stdgpu/numeric.h
@@ -17,9 +17,8 @@
 #define STDGPU_NUMERIC_H
 
 /**
- * \addtogroup numeric numeric
+ * \defgroup numeric numeric
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -66,10 +65,6 @@ T
 transform_reduce_index(ExecutionPolicy&& policy, IndexType size, T init, BinaryFunction reduce, UnaryFunction f);
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/numeric_detail.h>
 

--- a/src/stdgpu/platform.h
+++ b/src/stdgpu/platform.h
@@ -17,9 +17,8 @@
 #define STDGPU_PLATFORM_H
 
 /**
- * \addtogroup platform platform
+ * \defgroup platform platform
  * \ingroup system
- * @{
  */
 
 /**
@@ -133,9 +132,5 @@ namespace detail
 } // namespace detail
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #endif // STDGPU_PLATFORM_H

--- a/src/stdgpu/queue.cuh
+++ b/src/stdgpu/queue.cuh
@@ -19,9 +19,8 @@
 #include <stdgpu/impl/platform_check.h>
 
 /**
- * \addtogroup queue queue
+ * \defgroup queue queue
  * \ingroup data_structures
- * @{
  */
 
 /**
@@ -141,10 +140,6 @@ private:
 };
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/queue_detail.cuh>
 

--- a/src/stdgpu/queue_fwd
+++ b/src/stdgpu/queue_fwd
@@ -17,12 +17,6 @@
 #define STDGPU_QUEUE_FWD
 
 /**
- * \addtogroup queue queue
- * \ingroup data_structures
- * @{
- */
-
-/**
  * \file stdgpu/queue_fwd
  */
 
@@ -35,9 +29,5 @@ template <typename T, typename Container = deque<T>>
 class queue;
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #endif // STDGPU_QUEUE_FWD

--- a/src/stdgpu/ranges.h
+++ b/src/stdgpu/ranges.h
@@ -17,9 +17,8 @@
 #define STDGPU_RANGES_H
 
 /**
- * \addtogroup ranges ranges
+ * \defgroup ranges ranges
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -294,10 +293,6 @@ template <typename T>
 using host_indexed_range = transform_range<host_range<index_t>, detail::select<T>>;
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/ranges_detail.h>
 

--- a/src/stdgpu/stack.cuh
+++ b/src/stdgpu/stack.cuh
@@ -19,9 +19,8 @@
 #include <stdgpu/impl/platform_check.h>
 
 /**
- * \addtogroup stack stack
+ * \defgroup stack stack
  * \ingroup data_structures
- * @{
  */
 
 /**
@@ -141,10 +140,6 @@ private:
 };
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/stack_detail.cuh>
 

--- a/src/stdgpu/stack_fwd
+++ b/src/stdgpu/stack_fwd
@@ -17,12 +17,6 @@
 #define STDGPU_STACK_FWD
 
 /**
- * \addtogroup stack stack
- * \ingroup data_structures
- * @{
- */
-
-/**
  * \file stdgpu/stack_fwd
  */
 
@@ -35,9 +29,5 @@ template <typename T, typename Container = deque<T>>
 class stack;
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #endif // STDGPU_STACK_FWD

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -19,9 +19,8 @@
 #include <stdgpu/impl/platform_check.h>
 
 /**
- * \addtogroup unordered_map unordered_map
+ * \defgroup unordered_map unordered_map
  * \ingroup data_structures
- * @{
  */
 
 /**
@@ -392,10 +391,6 @@ private:
 };
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/unordered_map_detail.cuh>
 

--- a/src/stdgpu/unordered_map_fwd
+++ b/src/stdgpu/unordered_map_fwd
@@ -17,12 +17,6 @@
 #define STDGPU_UNORDEREDMAP_FWD
 
 /**
- * \addtogroup unordered_map unordered_map
- * \ingroup data_structures
- * @{
- */
-
-/**
  * \file stdgpu/unordered_map_fwd
  */
 
@@ -49,9 +43,5 @@ template <typename Key,
 class unordered_map;
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #endif // STDGPU_UNORDEREDMAP_FWD

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -19,9 +19,8 @@
 #include <stdgpu/impl/platform_check.h>
 
 /**
- * \addtogroup unordered_set unordered_set
+ * \defgroup unordered_set unordered_set
  * \ingroup data_structures
- * @{
  */
 
 /**
@@ -381,10 +380,6 @@ private:
 };
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/unordered_set_detail.cuh>
 

--- a/src/stdgpu/unordered_set_fwd
+++ b/src/stdgpu/unordered_set_fwd
@@ -17,12 +17,6 @@
 #define STDGPU_UNORDEREDSET_FWD
 
 /**
- * \addtogroup unordered_set unordered_set
- * \ingroup data_structures
- * @{
- */
-
-/**
  * \file stdgpu/unordered_set_fwd
  */
 
@@ -45,9 +39,5 @@ template <typename Key,
 class unordered_set;
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #endif // STDGPU_UNORDEREDSET_FWD

--- a/src/stdgpu/utility.h
+++ b/src/stdgpu/utility.h
@@ -17,9 +17,8 @@
 #define STDGPU_UTILITY_H
 
 /**
- * \addtogroup utility utility
+ * \defgroup utility utility
  * \ingroup utilities
- * @{
  */
 
 /**
@@ -77,10 +76,6 @@ constexpr STDGPU_HOST_DEVICE std::remove_reference_t<T>&&
 move(T&& t) noexcept;
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/utility_detail.h>
 

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -19,9 +19,8 @@
 #include <stdgpu/impl/platform_check.h>
 
 /**
- * \addtogroup vector vector
+ * \defgroup vector vector
  * \ingroup data_structures
- * @{
  */
 
 /**
@@ -396,10 +395,6 @@ private:
 };
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #include <stdgpu/impl/vector_detail.cuh>
 

--- a/src/stdgpu/vector_fwd
+++ b/src/stdgpu/vector_fwd
@@ -17,12 +17,6 @@
 #define STDGPU_VECTOR_FWD
 
 /**
- * \addtogroup vector vector
- * \ingroup data_structures
- * @{
- */
-
-/**
  * \file stdgpu/vector_fwd
  */
 
@@ -36,9 +30,5 @@ template <typename T, typename Allocator = safe_device_allocator<T>>
 class vector;
 
 } // namespace stdgpu
-
-/**
- * @}
- */
 
 #endif // STDGPU_VECTOR_FWD


### PR DESCRIPTION
Some elements like the stdgpu namespace as well as the header files were implicitly added to the module groups. However, as all relevant functionality is explicitly added to the respective groups, this automatic collection process only adds noise to the documentation. Remove the respective directive and replace them by a simple, empty definition of the groups.