### PR TITLE
doc: Port to Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,16 @@ At its heart, stdgpu offers the following GPU data structures and containers:
 </tr>
 </table>
 
-In addition, stdgpu also provides commonly required functionality in <a href="https://stotko.github.io/stdgpu/algorithm_8h.html">`algorithm`</a>, <a href="https://stotko.github.io/stdgpu/bit_8h.html">`bit`</a>, <a href="https://stotko.github.io/stdgpu/cmath_8h.html">`cmath`</a>, <a href="https://stotko.github.io/stdgpu/contract_8h.html">`contract`</a>, <a href="https://stotko.github.io/stdgpu/cstddef_8h.html">`cstddef`</a>, <a href="https://stotko.github.io/stdgpu/functional_8h.html">`functional`</a>, <a href="https://stotko.github.io/stdgpu/iterator_8h.html">`iterator`</a>, <a href="https://stotko.github.io/stdgpu/limits_8h.html">`limits`</a>, <a href="https://stotko.github.io/stdgpu/memory_8h.html">`memory`</a>, <a href="https://stotko.github.io/stdgpu/mutex_8cuh.html">`mutex`</a>, <a href="https://stotko.github.io/stdgpu/ranges_8h.html">`ranges`</a>, <a href="https://stotko.github.io/stdgpu/utility_8h.html">`utility`</a> to complement the GPU data structures and to increase their usability and interoperability.
+In addition, stdgpu also provides commonly required functionality in [`algorithm`](https://stotko.github.io/stdgpu/algorithm_8h.html), [`bit`](https://stotko.github.io/stdgpu/bit_8h.html), [`cmath`](https://stotko.github.io/stdgpu/cmath_8h.html), [`contract`](https://stotko.github.io/stdgpu/contract_8h.html), [`cstddef`](https://stotko.github.io/stdgpu/cstddef_8h.html), [`functional`](https://stotko.github.io/stdgpu/functional_8h.html), [`iterator`](https://stotko.github.io/stdgpu/iterator_8h.html), [`limits`](https://stotko.github.io/stdgpu/limits_8h.html), [`memory`](https://stotko.github.io/stdgpu/memory_8h.html), [`mutex`](https://stotko.github.io/stdgpu/mutex_8cuh.html), [`ranges`](https://stotko.github.io/stdgpu/ranges_8h.html), [`utility`](https://stotko.github.io/stdgpu/utility_8h.html) to complement the GPU data structures and to increase their usability and interoperability.
 
 
 ## Examples
 
 In order to reliably perform complex tasks on the GPU, stdgpu offers flexible interfaces that can be used in both **agnostic code**, e.g. via the algorithms provided by thrust, as well as in **native code**, e.g. in custom CUDA kernels.
 
-For instance, stdgpu is extensively used in <a href="https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence">SLAMCast</a>, a scalable live telepresence system, to implement real-time, large-scale 3D scene reconstruction as well as real-time 3D data streaming between a server and an arbitrary number of remote clients.
+For instance, stdgpu is extensively used in [SLAMCast](https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence), a scalable live telepresence system, to implement real-time, large-scale 3D scene reconstruction as well as real-time 3D data streaming between a server and an arbitrary number of remote clients.
 
-<b>Agnostic code</b>. In the context of <a href="https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence">SLAMCast</a>, a simple task is the integration of a range of updated blocks into the duplicate-free set of queued blocks for data streaming which can be expressed very conveniently:
+**Agnostic code**. In the context of [SLAMCast](https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence), a simple task is the integration of a range of updated blocks into the duplicate-free set of queued blocks for data streaming which can be expressed very conveniently:
 
 ```cpp
 #include <stdgpu/cstddef.h>             // stdgpu::index_t
@@ -114,7 +114,7 @@ private:
 };
 ```
 
-<b>Native code</b>. More complex operations such as the creation of the duplicate-free set of updated blocks or other algorithms can be implemented natively, e.g. in custom CUDA kernels with stdgpu's CUDA backend enabled:
+**Native code**. More complex operations such as the creation of the duplicate-free set of updated blocks or other algorithms can be implemented natively, e.g. in custom CUDA kernels with stdgpu's CUDA backend enabled:
 
 ```cpp
 #include <stdgpu/cstddef.h>             // stdgpu::index_t
@@ -157,25 +157,25 @@ compute_update_set(const short3* blocks,
 }
 ```
 
-More examples can be found in the <a href="https://github.com/stotko/stdgpu/tree/master/examples">`examples`</a> directory.
+More examples can be found in the [`examples`](https://github.com/stotko/stdgpu/tree/master/examples) directory.
 
 
 ## Documentation
 
 A comprehensive introduction into the design and API of stdgpu can be found here:
 
-- <a href="https://stotko.github.io/stdgpu">stdgpu API documentation</a>
-- <a href="https://thrust.github.io/doc/group__algorithms.html">thrust algorithms documentation</a>
-- <a href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">Research paper</a>
+- [stdgpu API documentation](https://stotko.github.io/stdgpu)
+- [thrust algorithms documentation](https://thrust.github.io/doc/group__algorithms.html)
+- [Research paper](https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU)
 
-Since a core feature and design goal of stdgpu is its **interoperability** with thrust, it offers **full support for all thrust algorithms** instead of reinventing the wheel. More information about the design can be found in the related <a href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">research paper</a>.
+Since a core feature and design goal of stdgpu is its **interoperability** with thrust, it offers **full support for all thrust algorithms** instead of reinventing the wheel. More information about the design can be found in the related [research paper](https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU).
 
 
 ## Building
 
 Before building the library, please make sure that all required tools and dependencies are installed on your system. Newer versions are supported as well.
 
-<b>Required</b>
+**Required**
 
 - C++17 compiler
     - GCC 9
@@ -192,7 +192,7 @@ Before building the library, please make sure that all required tools and depend
     - (Ubuntu/Windows) https://github.com/NVIDIA/thrust
     - May already be installed by backend dependencies
 
-<b>Required for CUDA backend</b>
+**Required for CUDA backend**
 
 - CUDA compiler
     - NVCC
@@ -203,7 +203,7 @@ Before building the library, please make sure that all required tools and depend
     - (Ubuntu/Windows) https://developer.nvidia.com/cuda-downloads
     - Includes thrust
 
-<b>Required for OpenMP backend</b>
+**Required for OpenMP backend**
 
 - OpenMP 2.0
     - GCC 9
@@ -213,7 +213,7 @@ Before building the library, please make sure that all required tools and depend
     - MSVC 19.20
         - (Windows) Already installed
 
-<b>Required for HIP backend (experimental)</b>
+**Required for HIP backend (experimental)**
 
 - ROCm 5.1
     - (Ubuntu) https://github.com/RadeonOpenCompute/ROCm
@@ -231,11 +231,11 @@ In addition, we also provide cross-platform scripts to make the build process mo
 
 Command | Effect
 --- | ---
-<code>bash&nbsp;scripts/setup.sh [&lt;build_type&gt;]</code> | Performs a full clean build of the project. Removes old build, configures the project (build path: `./build`, default build type: `Release`), builds the project, and runs the unit tests.
-<code>bash&nbsp;scripts/build.sh [&lt;build_type&gt;]</code> | (Re-)Builds the project. Requires that the project is set up (default build type: `Release`).
-<code>bash&nbsp;scripts/run_tests.sh [&lt;build_type&gt;]</code> | Runs the unit tests. Requires that the project is built (default build type: `Release`).
-<code>bash&nbsp;scripts/install.sh [&lt;build_type&gt;]</code> | Installs the project to the configured install path (default install dir: `./bin`, default build type: `Release`).
-<code>bash&nbsp;scripts/uninstall.sh [&lt;build_type&gt;]</code> | Uninstalls the project from the configured install path (default build type: `Release`).
+`bash scripts/setup.sh [<build_type>]` | Performs a full clean build of the project. Removes old build, configures the project (build path: `./build`, default build type: `Release`), builds the project, and runs the unit tests.
+`bash scripts/build.sh [<build_type>]` | (Re-)Builds the project. Requires that the project is set up (default build type: `Release`).
+`bash scripts/run_tests.sh [<build_type>]` | Runs the unit tests. Requires that the project is built (default build type: `Release`).
+`bash scripts/install.sh [<build_type>]` | Installs the project to the configured install path (default install dir: `./bin`, default build type: `Release`).
+`bash scripts/uninstall.sh [<build_type>]` | Uninstalls the project from the configured install path (default build type: `Release`).
 
 
 ## Integration
@@ -243,7 +243,7 @@ Command | Effect
 In the following, we show some examples on how the library can be integrated into and used in a project.
 
 
-<b>CMake Integration</b>. To use the library in your project, you can either install it externally first and then include it using `find_package`:
+**CMake Integration**. To use the library in your project, you can either install it externally first and then include it using `find_package`:
 
 ```cmake
 find_package(stdgpu 1.0.0 REQUIRED)
@@ -273,7 +273,7 @@ target_link_libraries(foo PUBLIC stdgpu::stdgpu)
 ```
 
 
-<b>CMake Options</b>. To configure the library, two sets of options are provided. The following build options control the build process:
+**CMake Options**. To configure the library, two sets of options are provided. The following build options control the build process:
 
 Build Option | Effect | Default
 --- | --- | ---
@@ -299,16 +299,16 @@ Configuration Option | Effect | Default
 
 ## Contributing
 
-For detailed information on how to contribute, see <a href="https://github.com/stotko/stdgpu/blob/master/CONTRIBUTING.md">`CONTRIBUTING`</a>.
+For detailed information on how to contribute, see [`CONTRIBUTING`](https://github.com/stotko/stdgpu/blob/master/CONTRIBUTING.md).
 
 
 ## License
 
-Distributed under the Apache 2.0 License. See <a href="https://github.com/stotko/stdgpu/blob/master/LICENSE">`LICENSE`</a> for more information.
+Distributed under the Apache 2.0 License. See [`LICENSE`](https://github.com/stotko/stdgpu/blob/master/LICENSE) for more information.
 
 If you use stdgpu in one of your projects, please cite the following publications:
 
-<b><a style="font-weight:bold" href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">stdgpu: Efficient STL-like Data Structures on the GPU</a></b>
+[**stdgpu: Efficient STL-like Data Structures on the GPU**](https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU)
 
 ```
 @UNPUBLISHED{stotko2019stdgpu,
@@ -321,7 +321,7 @@ If you use stdgpu in one of your projects, please cite the following publication
 }
 ```
 
-<b><a style="font-weight:bold" href="https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence">SLAMCast: Large-Scale, Real-Time 3D Reconstruction and Streaming for Immersive Multi-Client Live Telepresence</a></b>
+[**SLAMCast: Large-Scale, Real-Time 3D Reconstruction and Streaming for Immersive Multi-Client Live Telepresence**](https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence)
 
 ```
 @article{stotko2019slamcast,
@@ -339,4 +339,4 @@ If you use stdgpu in one of your projects, please cite the following publication
 
 ## Contact
 
-Patrick Stotko - <a href="mailto:stotko@cs.uni-bonn.de">stotko@cs.uni-bonn.de</a>
+Patrick Stotko - [stotko@cs.uni-bonn.de](mailto:stotko@cs.uni-bonn.de)

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -961,6 +961,7 @@ INPUT_FILE_ENCODING    =
 # *.vhdl, *.ucf, *.qsf and *.ice.
 
 FILE_PATTERNS          = *.doxy \
+                         *.md \
                          *.cuh \
                          *.h \
                          *.hpp \

--- a/doc/stdgpu/chapters.md
+++ b/doc/stdgpu/chapters.md
@@ -1,11 +1,8 @@
-/**
-
-\page chapters Chapters
+Chapters {#chapters}
+========
 
 Here is a list of all chapters:
 
 - \subpage memory
 - \subpage iterator
 - \subpage object
-
-*/

--- a/doc/stdgpu/index.md
+++ b/doc/stdgpu/index.md
@@ -1,6 +1,5 @@
-/**
-
-\mainpage Overview
+Overview {#mainpage}
+========
 
 <p align="center">
 <a href="https://github.com/stotko/stdgpu/actions?query=workflow%3A%22Ubuntu+OpenMP%22" alt="Ubuntu">
@@ -51,7 +50,8 @@
 </p>
 </b>
 
-\section features Features
+
+## Features {#features}
 
 stdgpu is an open-source library providing several generic GPU data structures for fast and reliable data management. Multiple platforms such as **CUDA**, **OpenMP**, and **HIP** are supported allowing you to rapidly write highly complex **agnostic** and **native** algorithms that look like sequential CPU code but are executed in parallel on the GPU.
 
@@ -76,18 +76,18 @@ At its heart, stdgpu offers the following GPU data structures and containers:
 </tr>
 </table>
 
-In addition, stdgpu also provides commonly required functionality in <a href="https://stotko.github.io/stdgpu/algorithm_8h.html">`algorithm`</a>, <a href="https://stotko.github.io/stdgpu/bit_8h.html">`bit`</a>, <a href="https://stotko.github.io/stdgpu/cmath_8h.html">`cmath`</a>, <a href="https://stotko.github.io/stdgpu/contract_8h.html">`contract`</a>, <a href="https://stotko.github.io/stdgpu/cstddef_8h.html">`cstddef`</a>, <a href="https://stotko.github.io/stdgpu/functional_8h.html">`functional`</a>, <a href="https://stotko.github.io/stdgpu/iterator_8h.html">`iterator`</a>, <a href="https://stotko.github.io/stdgpu/limits_8h.html">`limits`</a>, <a href="https://stotko.github.io/stdgpu/memory_8h.html">`memory`</a>, <a href="https://stotko.github.io/stdgpu/mutex_8cuh.html">`mutex`</a>, <a href="https://stotko.github.io/stdgpu/ranges_8h.html">`ranges`</a>, <a href="https://stotko.github.io/stdgpu/utility_8h.html">`utility`</a> to complement the GPU data structures and to increase their usability and interoperability.
+In addition, stdgpu also provides commonly required functionality in [`algorithm`](https://stotko.github.io/stdgpu/algorithm_8h.html), [`bit`](https://stotko.github.io/stdgpu/bit_8h.html), [`cmath`](https://stotko.github.io/stdgpu/cmath_8h.html), [`contract`](https://stotko.github.io/stdgpu/contract_8h.html), [`cstddef`](https://stotko.github.io/stdgpu/cstddef_8h.html), [`functional`](https://stotko.github.io/stdgpu/functional_8h.html), [`iterator`](https://stotko.github.io/stdgpu/iterator_8h.html), [`limits`](https://stotko.github.io/stdgpu/limits_8h.html), [`memory`](https://stotko.github.io/stdgpu/memory_8h.html), [`mutex`](https://stotko.github.io/stdgpu/mutex_8cuh.html), [`ranges`](https://stotko.github.io/stdgpu/ranges_8h.html), [`utility`](https://stotko.github.io/stdgpu/utility_8h.html) to complement the GPU data structures and to increase their usability and interoperability.
 
 
-\section examples Examples
+## Examples {#examples}
 
 In order to reliably perform complex tasks on the GPU, stdgpu offers flexible interfaces that can be used in both **agnostic code**, e.g. via the algorithms provided by thrust, as well as in **native code**, e.g. in custom CUDA kernels.
 
-For instance, stdgpu is extensively used in <a href="https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence">SLAMCast</a>, a scalable live telepresence system, to implement real-time, large-scale 3D scene reconstruction as well as real-time 3D data streaming between a server and an arbitrary number of remote clients.
+For instance, stdgpu is extensively used in [SLAMCast](https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence), a scalable live telepresence system, to implement real-time, large-scale 3D scene reconstruction as well as real-time 3D data streaming between a server and an arbitrary number of remote clients.
 
-<b>Agnostic code</b>. In the context of <a href="https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence">SLAMCast</a>, a simple task is the integration of a range of updated blocks into the duplicate-free set of queued blocks for data streaming which can be expressed very conveniently:
+**Agnostic code**. In the context of [SLAMCast](https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence), a simple task is the integration of a range of updated blocks into the duplicate-free set of queued blocks for data streaming which can be expressed very conveniently:
 
-\code{.cpp}
+```cpp
 #include <stdgpu/cstddef.h>             // stdgpu::index_t
 #include <stdgpu/iterator.h>            // stdgpu::make_device
 #include <stdgpu/unordered_set.cuh>     // stdgpu::unordered_set
@@ -109,11 +109,11 @@ private:
     stdgpu::unordered_set<short3> set;
     // Further members
 };
-\endcode
+```
 
-<b>Native code</b>. More complex operations such as the creation of the duplicate-free set of updated blocks or other algorithms can be implemented natively, e.g. in custom CUDA kernels with stdgpu's CUDA backend enabled:
+**Native code**. More complex operations such as the creation of the duplicate-free set of updated blocks or other algorithms can be implemented natively, e.g. in custom CUDA kernels with stdgpu's CUDA backend enabled:
 
-\code{.cpp}
+```cpp
 #include <stdgpu/cstddef.h>             // stdgpu::index_t
 #include <stdgpu/unordered_map.cuh>     // stdgpu::unordered_map
 #include <stdgpu/unordered_set.cuh>     // stdgpu::unordered_set
@@ -152,27 +152,27 @@ compute_update_set(const short3* blocks,
         }
     }
 }
-\endcode
+```
 
-More examples can be found in the <a href="https://github.com/stotko/stdgpu/tree/master/examples">`examples`</a> directory.
+More examples can be found in the [`examples`](https://github.com/stotko/stdgpu/tree/master/examples) directory.
 
 
-\section documentation Documentation
+## Documentation {#documentation}
 
 A comprehensive introduction into the design and API of stdgpu can be found here:
 
-- <a href="https://stotko.github.io/stdgpu">stdgpu API documentation</a>
-- <a href="https://thrust.github.io/doc/group__algorithms.html">thrust algorithms documentation</a>
-- <a href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">Research paper</a>
+- [stdgpu API documentation](https://stotko.github.io/stdgpu)
+- [thrust algorithms documentation](https://thrust.github.io/doc/group__algorithms.html)
+- [Research paper](https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU)
 
-Since a core feature and design goal of stdgpu is its **interoperability** with thrust, it offers **full support for all thrust algorithms** instead of reinventing the wheel. More information about the design can be found in the related <a href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">research paper</a>.
+Since a core feature and design goal of stdgpu is its **interoperability** with thrust, it offers **full support for all thrust algorithms** instead of reinventing the wheel. More information about the design can be found in the related [research paper](https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU).
 
 
-\section building Building
+## Building {#building}
 
 Before building the library, please make sure that all required tools and dependencies are installed on your system. Newer versions are supported as well.
 
-<b>Required</b>
+**Required**
 
 - C++17 compiler
     - GCC 9
@@ -189,7 +189,7 @@ Before building the library, please make sure that all required tools and depend
     - (Ubuntu/Windows) https://github.com/NVIDIA/thrust
     - May already be installed by backend dependencies
 
-<b>Required for CUDA backend</b>
+**Required for CUDA backend**
 
 - CUDA compiler
     - NVCC
@@ -200,7 +200,7 @@ Before building the library, please make sure that all required tools and depend
     - (Ubuntu/Windows) https://developer.nvidia.com/cuda-downloads
     - Includes thrust
 
-<b>Required for OpenMP backend</b>
+**Required for OpenMP backend**
 
 - OpenMP 2.0
     - GCC 9
@@ -210,7 +210,7 @@ Before building the library, please make sure that all required tools and depend
     - MSVC 19.20
         - (Windows) Already installed
 
-<b>Required for HIP backend (experimental)</b>
+**Required for HIP backend (experimental)**
 
 - ROCm 5.1
     - (Ubuntu) https://github.com/RadeonOpenCompute/ROCm
@@ -228,30 +228,31 @@ In addition, we also provide cross-platform scripts to make the build process mo
 
 Command | Effect
 --- | ---
-<code>bash&nbsp;scripts/setup.sh [&lt;build_type&gt;]</code> | Performs a full clean build of the project. Removes old build, configures the project (build path: `./build`, default build type: `Release`), builds the project, and runs the unit tests.
-<code>bash&nbsp;scripts/build.sh [&lt;build_type&gt;]</code> | (Re-)Builds the project. Requires that the project is set up (default build type: `Release`).
-<code>bash&nbsp;scripts/run_tests.sh [&lt;build_type&gt;]</code> | Runs the unit tests. Requires that the project is built (default build type: `Release`).
-<code>bash&nbsp;scripts/install.sh [&lt;build_type&gt;]</code> | Installs the project to the configured install path (default install dir: `./bin`, default build type: `Release`).
-<code>bash&nbsp;scripts/uninstall.sh [&lt;build_type&gt;]</code> | Uninstalls the project from the configured install path (default build type: `Release`).
+`bash scripts/setup.sh [<build_type>]` | Performs a full clean build of the project. Removes old build, configures the project (build path: `./build`, default build type: `Release`), builds the project, and runs the unit tests.
+`bash scripts/build.sh [<build_type>]` | (Re-)Builds the project. Requires that the project is set up (default build type: `Release`).
+`bash scripts/run_tests.sh [<build_type>]` | Runs the unit tests. Requires that the project is built (default build type: `Release`).
+`bash scripts/install.sh [<build_type>]` | Installs the project to the configured install path (default install dir: `./bin`, default build type: `Release`).
+`bash scripts/uninstall.sh [<build_type>]` | Uninstalls the project from the configured install path (default build type: `Release`).
 
-\section integration Integration
+
+## Integration {#integration}
 
 In the following, we show some examples on how the library can be integrated into and used in a project.
 
 
-<b>CMake Integration</b>. To use the library in your project, you can either install it externally first and then include it using `find_package`:
+**CMake Integration**. To use the library in your project, you can either install it externally first and then include it using `find_package`:
 
-\code{.cmake}
+```cmake
 find_package(stdgpu 1.0.0 REQUIRED)
 
 add_library(foo ...)
 
 target_link_libraries(foo PUBLIC stdgpu::stdgpu)
-\endcode
+```
 
 Or you can embed it into your project and build it from a subdirectory:
 
-\code{.cmake}
+```cmake
 # Exclude the examples from the build
 set(STDGPU_BUILD_EXAMPLES OFF CACHE INTERNAL "")
 
@@ -266,10 +267,10 @@ add_subdirectory(stdgpu)
 add_library(foo ...)
 
 target_link_libraries(foo PUBLIC stdgpu::stdgpu)
-\endcode
+```
 
 
-<b>CMake Options</b>. To configure the library, two sets of options are provided. The following build options control the build process:
+**CMake Options**. To configure the library, two sets of options are provided. The following build options control the build process:
 
 Build Option | Effect | Default
 --- | --- | ---
@@ -284,6 +285,7 @@ Build Option | Effect | Default
 `STDGPU_ANALYZE_WITH_CLANG_TIDY` | Analyzes the code with clang-tidy | `OFF`
 `STDGPU_ANALYZE_WITH_CPPCHECK` | Analyzes the code with cppcheck | `OFF`
 
+
 In addition, the implementation of some functionality can be controlled via configuration options:
 
 Configuration Option | Effect | Default
@@ -292,20 +294,20 @@ Configuration Option | Effect | Default
 `STDGPU_USE_32_BIT_INDEX` | Use 32-bit instead of 64-bit signed integer for `index_t` | `ON`
 
 
-\section contributing Contributing
+## Contributing {#contributing}
 
-For detailed information on how to contribute, see <a href="https://github.com/stotko/stdgpu/blob/master/CONTRIBUTING.md">`CONTRIBUTING`</a>.
+For detailed information on how to contribute, see [`CONTRIBUTING`](https://github.com/stotko/stdgpu/blob/master/CONTRIBUTING.md).
 
 
-\section license License
+## License {#license}
 
-Distributed under the Apache 2.0 License. See <a href="https://github.com/stotko/stdgpu/blob/master/LICENSE">`LICENSE`</a> for more information.
+Distributed under the Apache 2.0 License. See [`LICENSE`](https://github.com/stotko/stdgpu/blob/master/LICENSE) for more information.
 
 If you use stdgpu in one of your projects, please cite the following publications:
 
-<b><a style="font-weight:bold" href="https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU">stdgpu: Efficient STL-like Data Structures on the GPU</a></b>
+[**stdgpu: Efficient STL-like Data Structures on the GPU**](https://www.researchgate.net/publication/335233070_stdgpu_Efficient_STL-like_Data_Structures_on_the_GPU)
 
-\code{.bib}
+```
 @UNPUBLISHED{stotko2019stdgpu,
     author = {Stotko, P.},
      title = {{stdgpu: Efficient STL-like Data Structures on the GPU}},
@@ -314,11 +316,11 @@ If you use stdgpu in one of your projects, please cite the following publication
       note = {arXiv:1908.05936},
        url = {https://arxiv.org/abs/1908.05936}
 }
-\endcode
+```
 
-<b><a style="font-weight:bold" href="https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence">SLAMCast: Large-Scale, Real-Time 3D Reconstruction and Streaming for Immersive Multi-Client Live Telepresence</a></b>
+[**SLAMCast: Large-Scale, Real-Time 3D Reconstruction and Streaming for Immersive Multi-Client Live Telepresence**](https://www.researchgate.net/publication/331303359_SLAMCast_Large-Scale_Real-Time_3D_Reconstruction_and_Streaming_for_Immersive_Multi-Client_Live_Telepresence)
 
-\code{.bib}
+```
 @article{stotko2019slamcast,
     author = {Stotko, P. and Krumpen, S. and Hullin, M. B. and Weinmann, M. and Klein, R.},
      title = {{SLAMCast: Large-Scale, Real-Time 3D Reconstruction and Streaming for Immersive Multi-Client Live Telepresence}},
@@ -329,11 +331,9 @@ If you use stdgpu in one of your projects, please cite the following publication
       year = {2019},
      month = may
 }
-\endcode
+```
 
 
-\section Contact
+## Contact {#contact}
 
-Patrick Stotko - <a href="mailto:stotko@cs.uni-bonn.de">stotko@cs.uni-bonn.de</a>
-
-*/
+Patrick Stotko - [stotko@cs.uni-bonn.de](mailto:stotko@cs.uni-bonn.de)

--- a/doc/stdgpu/iterator.md
+++ b/doc/stdgpu/iterator.md
@@ -1,13 +1,12 @@
-/**
+Iterating over Arrays and Containers {#iterator}
+====================================
 
-\page iterator Iterating over arrays and containers
 
-
-\section iterator_overview Motivation
+# Motivation {#iterator_overview}
 
 The iterator concept is one of the core aspects of the Standard Template Library (STL). Most C++ programmers are familiar with this concept and can easily write algorithms with it. The thrust library aims to provide the STL functionality also for device arrays and vectors. This includes the convenient iterator syntax. Consider the following STL example:
 
-\code{.cpp}
+```cpp
     #include <algortihm>
     #include <functional>
     #include <vector>
@@ -18,11 +17,11 @@ The iterator concept is one of the core aspects of the Standard Template Library
 
     std::sort(vector.begin(), vector.end());            // C++98
     std::sort(std::begin(vector), std::end(vector));    // C++11
-\endcode
+```
 
 In modern C++, the latter more recent version of begin and end should be used. Semantically, they are identical. thrust provides a similar syntax for its containers:
 
-\code{.cpp}
+```cpp
     #include <thrust/device_vector.h>
     #include <thrust/sort.h>
 
@@ -31,13 +30,13 @@ In modern C++, the latter more recent version of begin and end should be used. S
     // Fill it with something useful
 
     thrust::sort(thrust::device, vector.begin(), vector.end());
-\endcode
+```
 
 The differences to the STL are mostly related to the more generic setting. Although thrust is able to automatically infer whether the vector is allocated on the host or device, it is advisable to clearly state that sorting should be done on the device.
 
 It is also possible to pass raw pointers to thrust algorithms, but the syntax gets intrusive:
 
-\code{.cpp}
+```cpp
     #include <thrust/device_ptr.h>
     #include <thrust/sort.h>
 
@@ -50,16 +49,16 @@ It is also possible to pass raw pointers to thrust algorithms, but the syntax ge
     thrust::sort(thrust::device, thrust::device_pointer_cast(device_array), thrust::device_pointer_cast(device_array + 1000));
 
     destroyDeviceArray<float>(device_array);
-\endcode
+```
 
 The intent of casting to the thrust API is clear, but very verbose. Furthermore, the size of the array must be known and explicitly stated to compute the iterator pointing to the end of the array.
 
 
-\section iterator_api Iterator API
+# Iterator API {#iterator_api}
 
-Similar to what the memory managemente API provides (see \ref memory), there is also an API to avoid boilerplate code such as in the example above. It can be considered as a natural extension to how thrust and STL perform in C++11:
+Similar to what the [memory management API](#memory) provides, there is also an API to avoid boilerplate code such as in the example above. It can be considered as a natural extension to how thrust and STL perform in C++11:
 
-\code{.cpp}
+```cpp
     #include <thrust/sort.h>
 
     #include <stdgpu/memory.h>
@@ -72,11 +71,11 @@ Similar to what the memory managemente API provides (see \ref memory), there is 
     thrust::sort(stdgpu::device_begin(device_array), stdgpu::device_end(device_array));
 
     destroyDeviceArray<float>(device_array);
-\endcode
+```
 
 Compare this systax to the C++11 version of the STL call. This becomes possible by the internal leak check which now provides the required size information. Therefore, stdgpu::device_end can query the size of the given array and return a pointer to the end. Furthermore, the functions check whether the array is allocated on the host or device to avoid mismatches. Iterators are defined for both host and device arrays. In addition, the const versions of them are also defined. Consider the following C++14 STL example:
 
-\code{.cpp}
+```cpp
     #include <algortihm>
     #include <vector>
 
@@ -86,11 +85,11 @@ Compare this systax to the C++11 version of the STL call. This becomes possible 
     // Fill it with something useful
 
     std::transform(std::cbegin(vector), std::cend(vector), std::begin(vector_out), std::negate<float>());  // C++14
-\endcode
+```
 
 The device version with the memory management API is almost identical:
 
-\code{.cpp}
+```cpp
     #include <thrust/transform.h>
     #include <thrust/functional.h>
 
@@ -106,8 +105,6 @@ The device version with the memory management API is almost identical:
 
     destroyDeviceArray<float>(device_array);
     destroyDeviceArray<float>(device_array_out);
-\endcode
+```
 
 The combination of both the memory management and the iterator API provides a very powerful interface to interact with thrust as well as kernels in a fast, safe and intuitive way.
-
-*/

--- a/doc/stdgpu/memory.md
+++ b/doc/stdgpu/memory.md
@@ -1,9 +1,8 @@
-/**
+Memory Management {#memory}
+=================
 
-\page memory Memory management
 
-
-\section memory_overview Motivation
+# Motivation {#memory_overview}
 
 Memory management in C and C++ is one of the main aspects a developer should care about. Usually, containers such as std::vector are sufficient for most use cases. However, all these convenient containers are unfortunately not directly supported on the GPU side. There has been some effort to provide a GPU version of the Standard Template Library (STL), but the solutions are still quite limited. For instance, the thrust library (which is delivered with CUDA by default) has the following limitations:
 
@@ -14,34 +13,34 @@ Memory management in C and C++ is one of the main aspects a developer should car
 Typically, applications involving the GPU are performance critical and should be well optimized. On the other hand, thrust allows to develop code at a fast pace when sticking to their API. Therefore, most developers use raw pointers to achieve maximum performance. The drawback is that this requires a C-like API to allocate and free host and device memory which is quite intrusive and prone to errors.
 
 
-\section memory_api Memory API
+# Memory API {#memory_api}
 
 In order to solve this problem, a simple and consistent wrapper API around the memory management functions is defined. The goal is to reduce boilerplate code and give the user strong guarantees about the requested operations.
 
 
-\subsection memory_create_destroy Creating and Destroying Arrays
+## Creating and Destroying Arrays {#memory_create_destroy}
 
 The simplest operation when dealing with dynamically allocated arrays is to create such an array. This can be done in the following way:
 
-\code{.cpp}
+```cpp
     #include <stdgpu/memory.h>
 
     float* device_float_vector = createDeviceArray<float>(1000, 42.0f);
     float* host_float_vector = createHostArray<float>(1000, 42.0f);
-\endcode
+```
 
 Here, two arrays of length 1000 are created, one on the host and one on the device, and filled with the value 42.0f. Compared to traditional C and C++ allocations, these functions guarantee that the allocated memory is initialized with a well-defined state. The value parameter is optional. In case, no value is given, a default constructed object is used, i.e. float() which equals to 0.0f.
 
 When memory is allocated, it must be freed later at some time:
 
-\code{.cpp}
+```cpp
     #include <stdgpu/memory.h>
 
     // Define device_float_vector and host_float_vector
 
     destroyDeviceArray<float>(device_float_vector);
     destroyHostArray<float>(host_float_vector);
-\endcode
+```
 
 Although these functions are a bit more consistent than the usual memory management functions, the additional overhead of defining this wrapper might not be worth the effort. However, there are several more implicit guarantees:
 
@@ -50,11 +49,11 @@ Although these functions are a bit more consistent than the usual memory managem
 - Internally, a leak checker maintains a list of allocated arrays. If the user forgets to free an array, a warning can be prompted that some memory is leaking, so that the user can fix this problem easily.
 
 
-\subsection memory_copy Copying Arrays between Host and Device
+## Copying Arrays between Host and Device {#memory_copy}
 
 Creating and destroying arrays is only one step to efficiently handle memory. Data usually become available on the host, but should be processed on the device for performance reasons, and in the end stored on the host again. Consequently, copying arrays between the host and the device is necessary. This can be done by:
 
-\code{.cpp}
+```cpp
     #include <stdgpu/memory.h>
 
     float* host_float_vector;   // Create this and set some values
@@ -65,30 +64,28 @@ Creating and destroying arrays is only one step to efficiently handle memory. Da
     // Do something useful with device_float_vector
 
     copyDevice2HostArray<float>(device_float_vector, 1000, host_float_vector);
-\endcode
+```
 
 Here, the first 1000 values of host_float_vector are copyied to device_float_vector and later on vice versa. If the array to which should be copied is not allocated so far, then one can use these functions to unify allocation and copy:
 
-\code{.cpp}
+```cpp
     #include <stdgpu/memory.h>
 
     float* host_float_vector;   // Create this and set some values
 
     float* device_float_vector = copyCreateHost2DeviceArray<float>(host_float_vector, 1000);
-\endcode
+```
 
 All of these copy functions share strong guarantees. Having the internal leak checker, the copy functions check if the arrays are indeed allocated on the host or device. This avoids accidental mismatches. Furthermore, the size of the arrays are checked to prevent copying elements out of the allocated bounds of both arrays.
 
 It is very important to note that these guarantees can only be fulfilled if the arrays have been allocated by this API. External arrays or pointers to stack objects can also be used with this API. However, the checks need to be disabled in this situation:
 
-\code{.cpp}
+```cpp
     #include <stdgpu/memory.h>
 
     float host_value = 42.0f;
 
     float* device_value_pointer = copyCreateHost2DeviceArray<float>(&host_value, 1, MemoryCopy::NO_CHECK);
-\endcode
+```
 
 Please keep in mind, that if the functions are called in this way, it is then your responsibility to make sure that this operation succeeds.
-
-*/

--- a/doc/stdgpu/object.md
+++ b/doc/stdgpu/object.md
@@ -1,18 +1,16 @@
-/**
+Container Objects {#object}
+=================
 
-\page object Container objects
-
-
-\section object_overview Motivation
+# Motivation {#object_overview}
 
 In order to bridge the gap between GPU and CPU programming, the memory management API allows to handle arrays in an efficient and reliable way (see \ref memory). However, this is not sufficient even for most projects which require at least one layer hiding all the computations and memory management operations. Therefore, semantically coherent data (e.g. arrays) should be packed together into a class and processed by the public interface of the class. One category of such classes are containers including std::vector. In the context of GPU programming, array-based data structures are prefered and easier to implement. The thrust library for example only provides a thrust::host_vector and thrust::device_vector class because other structures such as std::unordered_map, std::list, etc. are very difficult to port to the GPU without sacrificing some important properties. While the containers defined in this library also have some limitations, they are still easy to use and robust.
 
 
-\section object_api Defining host and device container objects
+# Defining Host and Device Container Objects {#object_api}
 
 As mentioned above, a further abstraction layer to simplify data management is needed. This requires another API to avoid boilerplate code and redudancy. So far, host and device arrays has been defined as the generalization of arrays to CPU and GPU memory. Consequently, host device objects now generalize the traditional class objects. Consider the following class:
 
-\code{.cpp}
+```cpp
     class MyClass
     {
         public:
@@ -43,11 +41,11 @@ As mentioned above, a further abstraction layer to simplify data management is n
             float* array;
             int size;
     };
-\endcode
+```
 
 It wraps an array of type float including the size and provides some interaction interface through the member function. There are two constructors for this class. The first is simply the default constructor which should set the object to an empty state. The other constructor allocates the array with the given size. Finally, the destructor cleans them up. This design is quite problematic since copy and move constructors are not considered here which can result to double free errors and memory leaks. Furthermore, this design does not scale to the GPU and a new API must be used. Consider this API on the aforementioned example:
 
-\code{.cpp}
+```cpp
     class MyHostDeviceObjectClass
     {
         public:
@@ -98,11 +96,11 @@ It wraps an array of type float including the size and provides some interaction
             float* _array;
             int _size;
     };
-\endcode
+```
 
-Note that this interface is very similar to the host device array interface (see \ref memory). An object can now be easily created and destroyed as follows:
+Note that this interface is very similar to the [host device array interface](#memory). An object can now be easily created and destroyed as follows:
 
-\code{.cpp}
+```cpp
     MyClass device_object = MyClass::createDeviceObject(1000);
     MyClass hoste_object = MyClass::createHostObject(1000);
 
@@ -110,11 +108,11 @@ Note that this interface is very similar to the host device array interface (see
 
     MyClass::destroyDeviceObject(device_object);
     MyClass::destroyHostObject(host_object);
-\endcode
+```
 
 In order to match the capabilities of the host device arrays, copy functions can defined in the same manner and used as:
 
-\code{.cpp}
+```cpp
     MyClass device_object = MyClass::createDeviceObject(1000);
 
     // Do something with device_object
@@ -125,8 +123,6 @@ In order to match the capabilities of the host device arrays, copy functions can
 
     MyClass::destroyDeviceObject(device_object);
     MyClass::destroyHostObject(host_object);
-\endcode
+```
 
 Compared to arrays, an object always knows its size, so it is not necessary to also pass it as a parameter. This design is used to define the containers in this library.
-
-*/


### PR DESCRIPTION
Although Doxygen supports Markdown since version 1.8.0, this feature has not been used yet in the documentation. However, this greatly simplifies the required syntax for more complex formatting. Thus, port all additional documentation files to Markdown and additionally simplify the `README` file.