### PR TITLE
doc: Fix extraction of static members

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -525,7 +525,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,
@@ -626,7 +626,7 @@ HIDE_SCOPE_NAMES       = NO
 # YES the compound reference will be hidden.
 # The default value is: NO.
 
-HIDE_COMPOUND_REFERENCE= NO
+HIDE_COMPOUND_REFERENCE= YES
 
 # If the SHOW_HEADERFILE tag is set to YES then the documentation for a class
 # will show which file needs to be included to use the class.


### PR DESCRIPTION
Although static member functions like `createDeviceObject` and `destroyDeviceObject`  were documented and respective entries are generated, these are currently not linked in the tree view. Fix this missing linking by telling Doxygen to properly extract them. While at it, also hide the additional reference text added in the header of classes to make the documentation's look cleaner.