### PR TITLE
bitset: Fix ignored annotation warning for defaulted copy constructor

### DIFF
--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -81,7 +81,6 @@ public:
          * \brief Default copy constructor
          * \param[in] x The reference object to copy
          */
-        STDGPU_HOST_DEVICE
         reference(const reference& x) noexcept = default;
 
         /**


### PR DESCRIPTION
NVCC ignores host and device annotation on defaulted functions. While this has been properly handled for default constructors, a respective warning for the copy constructor of `bitset::reference` is only thrown on Windows with the CUDA backend. Thus, remove the offending annotation to silence the warning.