### PR TITLE
cmake,scripts: Clean up doxygen detection

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-find_package(Doxygen 1.9.6 EXACT)
+find_package(Doxygen 1.9.6 EXACT QUIET)
 
 if(NOT Doxygen_FOUND)
     include(ExternalProject)

--- a/scripts/ci/configure_openmp_documentation.sh
+++ b/scripts/ci/configure_openmp_documentation.sh
@@ -5,4 +5,4 @@ set -e
 sh scripts/utils/create_empty_directory.sh build
 
 # Configure project
-sh scripts/utils/configure.sh Release -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/thrust -DDoxygen_ROOT=external/doxygen/bin
+sh scripts/utils/configure.sh Release -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/thrust


### PR DESCRIPTION
The detection of Doxygen has been improved in #342. Since Doxygen will now be always available, the package detection message is not needed anymore. Suppress it by passing `QUIET` to `find_package`. Furthermore, remove the obsolete root path specification in the respective configure call script.