### PR TITLE
CI: Update coverage upload step

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,7 +46,8 @@ jobs:
           bash scripts/ci/run_coverage.sh
 
       - name: Upload coverage report
-        shell: bash
-        run: |
-          set -e
-          bash <(curl -s https://codecov.io/bash) -Z -f build/stdgpu_coverage.info
+        uses: codecov/codecov-action@v3
+        with:
+          files: build/stdgpu_coverage.info
+          fail_ci_if_error: true
+          verbose: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ endif()
 if(STDGPU_BUILD_TESTS AND STDGPU_BUILD_TEST_COVERAGE)
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/code_coverage.cmake")
     append_coverage_compiler_flags()
-    set(COVERAGE_EXCLUDES '*CMake*' '*benchmark/*' '*examples/*' '*external/*' '*test/*' '/usr/*')
+    set(COVERAGE_EXCLUDES '*CMake*' '*build/*' '*benchmark/*' '*examples/*' '*external/*' '*test/*' '/usr/*')
 endif()
 
 


### PR DESCRIPTION
The currently used bash-based uploading script to codecov has been deprecated for a while. Since uploading also seems to recently become a bit unstable, this way is not future-proof anymore. Update the upload step using the more modern GitHub action provided by codecov to solve these issues.

Furthermore, add the `build` directory to the list of excluded directories to filter out googletest which is now downloaded on-the-fly and hence, does not lie within the `test` directory anymore. 