### PR TITLE
config: Apply formatting and remove unnecessary namespace documentation

### DIFF
--- a/cmake/setup_clang_format.cmake
+++ b/cmake/setup_clang_format.cmake
@@ -9,7 +9,7 @@ function(stdgpu_setup_clang_format)
         return()
     endif()
 
-    foreach(FILE_EXT IN ITEMS "_fwd" ".h" ".cuh" ".cpp" ".cu" ".hip" ".inc")
+    foreach(FILE_EXT IN ITEMS ".h" ".cuh" ".cpp" ".cu" ".hip" ".inc")
         foreach(FILE_DIR IN ITEMS "src/stdgpu" "examples" "benchmark/stdgpu" "test/stdgpu" "test/install_test")
             file(GLOB_RECURSE SOURCE_FILES_PART LIST_DIRECTORIES FALSE "${FILE_DIR}/*${FILE_EXT}")
             list(APPEND SOURCE_FILES ${SOURCE_FILES_PART})

--- a/src/stdgpu/config.h.in
+++ b/src/stdgpu/config.h.in
@@ -28,11 +28,6 @@
  * \brief This file serves as a template for CMake which configures the corresponding config.h file.
  */
 
-
-
-/**
- * \brief Namespace containing all defined classes and functions
- */
 namespace stdgpu
 {
 
@@ -57,7 +52,6 @@ namespace stdgpu
  */
 #define STDGPU_VERSION_STRING "@stdgpu_VERSION@"
 
-
 //! @cond Doxygen_Suppress
 #define STDGPU_BACKEND @STDGPU_BACKEND@
 #define STDGPU_BACKEND_DIRECTORY @STDGPU_BACKEND_DIRECTORY@
@@ -65,13 +59,13 @@ namespace stdgpu
 #define STDGPU_BACKEND_MACRO_NAMESPACE @STDGPU_BACKEND_MACRO_NAMESPACE@
 //! @endcond
 
-
 /**
  * \ingroup config
  * \def STDGPU_ENABLE_CONTRACT_CHECKS
  * \brief Library option to enable contract checks
  */
-// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
+// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize
+// #cmakedefine01
 #ifdef STDGPU_RUN_DOXYGEN
     #define STDGPU_ENABLE_CONTRACT_CHECKS
 #endif
@@ -82,16 +76,13 @@ namespace stdgpu
  * \def STDGPU_USE_32_BIT_INDEX
  * \brief Library option to use 32-bit integers rather than 64-bit to define index_t
  */
-// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize #cmakedefine01
+// Workaround: Provide a define only for the purpose of creating the documentation since Doxygen does not recognize
+// #cmakedefine01
 #ifdef STDGPU_RUN_DOXYGEN
     #define STDGPU_USE_32_BIT_INDEX
 #endif
 #cmakedefine01 STDGPU_USE_32_BIT_INDEX
 
 } // namespace stdgpu
-
-
-
-
 
 #endif // STDGPU_CONFIG_H


### PR DESCRIPTION
The `config.h.in` file is a placeholder for the auto-generated config file and has so far been not considered to be formatted by `clang-format`. Since the special replacement syntax of CMake breaks the automatic formatting, perform a manual correction afterwards and keep the file still excluded.

While at it, also clean up the `_fwd` extension from the file detection and also remove the unnecessary documentation of the `stdgpu` namespace which generates a bloated page in the documentation that is not referenced anywhere.