### PR TITLE
execution: Expose host and device policy classes via aliases

### DIFF
--- a/src/stdgpu/execution.h
+++ b/src/stdgpu/execution.h
@@ -21,6 +21,8 @@
  * \ingroup utilities
  */
 
+#include <type_traits>
+
 /**
  * \file stdgpu/execution.h
  */
@@ -32,15 +34,27 @@ namespace stdgpu::execution
 
 /**
  * \ingroup execution
+ * \brief The device execution policy class
+ */
+using device_policy = std::remove_const_t<decltype(thrust::device)>;
+
+/**
+ * \ingroup execution
+ * \brief The host execution policy class
+ */
+using host_policy = std::remove_const_t<decltype(thrust::host)>;
+
+/**
+ * \ingroup execution
  * \brief The device execution policy
  */
-constexpr decltype(thrust::device) device;
+constexpr device_policy device;
 
 /**
  * \ingroup execution
  * \brief The host execution policy
  */
-constexpr decltype(thrust::host) host;
+constexpr host_policy host;
 
 } // namespace stdgpu::execution
 


### PR DESCRIPTION
The `host` and `device` execution policies have been defined in #305 as aliases to the objects defined by thrust. However, the respective classes are not provided and must currently be retrieved via `decltype` and some type casting. Expose the respective classes via alias typedefs and use them to simplify the definition of the objects.