### PR TITLE
src: Move backend-internal error handling into separate files

### DIFF
--- a/src/stdgpu/cuda/CMakeLists.txt
+++ b/src/stdgpu/cuda/CMakeLists.txt
@@ -21,7 +21,8 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
     target_sources(stdgpu PUBLIC FILE_SET stdgpu_backend_header_implementations
                                  TYPE HEADERS
                                  BASE_DIRS ${STDGPU_INCLUDE_LOCAL_DIR}
-                                 FILES impl/atomic_detail.cuh)
+                                 FILES impl/atomic_detail.cuh
+                                       impl/error.h)
 endif()
 
 target_compile_features(stdgpu PUBLIC cuda_std_17)

--- a/src/stdgpu/cuda/impl/device.cpp
+++ b/src/stdgpu/cuda/impl/device.cpp
@@ -21,6 +21,8 @@
 #include <cuda_runtime_api.h>
 #include <string>
 
+#include <stdgpu/cuda/impl/error.h>
+
 namespace detail
 {
 float
@@ -62,7 +64,7 @@ print_device_information()
 
     std::size_t free_memory = 0;
     std::size_t total_memory = 0;
-    cudaMemGetInfo(&free_memory, &total_memory);
+    STDGPU_CUDA_SAFE_CALL(cudaMemGetInfo(&free_memory, &total_memory));
 
     std::string gpu_name = properties.name;
     const int gpu_name_total_width = 57;

--- a/src/stdgpu/cuda/impl/error.h
+++ b/src/stdgpu/cuda/impl/error.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2019 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_CUDA_ERROR_H
+#define STDGPU_CUDA_ERROR_H
+
+#include <cuda_runtime_api.h>
+#include <exception>
+
+#include <stdgpu/cstddef.h>
+
+namespace stdgpu::cuda
+{
+
+/**
+ * \brief A macro that automatically sets information about the caller
+ * \param[in] error A CUDA error object
+ */
+#define STDGPU_CUDA_SAFE_CALL(error) stdgpu::cuda::safe_call(error, __FILE__, __LINE__, STDGPU_FUNC)
+
+/**
+ * \brief Checks whether the CUDA call was successful and stops the whole program on failure
+ * \param[in] error An CUDA error object
+ * \param[in] file The file from which this function was called
+ * \param[in] line The line from which this function was called
+ * \param[in] function The function from which this function was called
+ */
+inline void
+safe_call(const cudaError_t error, const char* file, const int line, const char* function)
+{
+    if (error != cudaSuccess)
+    {
+        printf("stdgpu : CUDA ERROR :\n"
+               "  Error     : %s\n"
+               "  File      : %s:%d\n"
+               "  Function  : %s\n",
+               cudaGetErrorString(error),
+               file,
+               line,
+               function);
+        std::terminate();
+    }
+}
+} // namespace stdgpu::cuda
+
+#endif // STDGPU_CUDA_ERROR_H

--- a/src/stdgpu/cuda/impl/memory.cpp
+++ b/src/stdgpu/cuda/impl/memory.cpp
@@ -16,41 +16,11 @@
 #include <stdgpu/cuda/memory.h>
 
 #include <cstdio>
-#include <cuda_runtime_api.h> // Include after thrust to avoid redefinition warning for __host__ and __device__ in .cpp files
-#include <exception>
+
+#include <stdgpu/cuda/impl/error.h>
 
 namespace stdgpu::cuda
 {
-
-/**
- * \brief A macro that automatically sets information about the caller
- * \param[in] error A CUDA error object
- */
-#define STDGPU_CUDA_SAFE_CALL(error) stdgpu::cuda::safe_call(error, __FILE__, __LINE__, STDGPU_FUNC)
-
-/**
- * \brief Checks whether the CUDA call was successful and stops the whole program on failure
- * \param[in] error An CUDA error object
- * \param[in] file The file from which this function was called
- * \param[in] line The line from which this function was called
- * \param[in] function The function from which this function was called
- */
-void
-safe_call(const cudaError_t error, const char* file, const int line, const char* function)
-{
-    if (error != cudaSuccess)
-    {
-        printf("stdgpu : CUDA ERROR :\n"
-               "  Error     : %s\n"
-               "  File      : %s:%d\n"
-               "  Function  : %s\n",
-               cudaGetErrorString(error),
-               file,
-               line,
-               function);
-        std::terminate();
-    }
-}
 
 void
 dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes)

--- a/src/stdgpu/hip/CMakeLists.txt
+++ b/src/stdgpu/hip/CMakeLists.txt
@@ -31,7 +31,8 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
     target_sources(stdgpu PUBLIC FILE_SET stdgpu_backend_header_implementations
                                  TYPE HEADERS
                                  BASE_DIRS ${STDGPU_INCLUDE_LOCAL_DIR}
-                                 FILES impl/atomic_detail.h)
+                                 FILES impl/atomic_detail.h
+                                       impl/error.h)
 endif()
 
 target_compile_features(stdgpu PUBLIC hip_std_17)

--- a/src/stdgpu/hip/impl/device.cpp
+++ b/src/stdgpu/hip/impl/device.cpp
@@ -21,6 +21,8 @@
 #include <hip/hip_runtime_api.h>
 #include <string>
 
+#include <stdgpu/hip/impl/error.h>
+
 namespace detail
 {
 float
@@ -62,7 +64,7 @@ print_device_information()
 
     std::size_t free_memory = 0;
     std::size_t total_memory = 0;
-    hipMemGetInfo(&free_memory, &total_memory);
+    STDGPU_HIP_SAFE_CALL(hipMemGetInfo(&free_memory, &total_memory));
 
     std::string gpu_name = properties.name;
     const int gpu_name_total_width = 57;

--- a/src/stdgpu/hip/impl/error.h
+++ b/src/stdgpu/hip/impl/error.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2020 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_HIP_ERROR_H
+#define STDGPU_HIP_ERROR_H
+
+#include <exception>
+#include <hip/hip_runtime_api.h>
+
+#include <stdgpu/cstddef.h>
+
+namespace stdgpu::hip
+{
+
+/**
+ * \brief A macro that automatically sets information about the caller
+ * \param[in] error A HIP error object
+ */
+#define STDGPU_HIP_SAFE_CALL(error) stdgpu::hip::safe_call(error, __FILE__, __LINE__, STDGPU_FUNC)
+
+/**
+ * \brief Checks whether the HIP call was successful and stops the whole program on failure
+ * \param[in] error An HIP error object
+ * \param[in] file The file from which this function was called
+ * \param[in] line The line from which this function was called
+ * \param[in] function The function from which this function was called
+ */
+inline void
+safe_call(const hipError_t error, const char* file, const int line, const char* function)
+{
+    if (error != hipSuccess)
+    {
+        printf("stdgpu : HIP ERROR :\n"
+               "  Error     : %s\n"
+               "  File      : %s:%d\n"
+               "  Function  : %s\n",
+               hipGetErrorString(error),
+               file,
+               line,
+               function);
+        std::terminate();
+    }
+}
+} // namespace stdgpu::hip
+
+#endif // STDGPU_HIP_ERROR_H

--- a/src/stdgpu/hip/impl/memory.cpp
+++ b/src/stdgpu/hip/impl/memory.cpp
@@ -16,41 +16,11 @@
 #include <stdgpu/hip/memory.h>
 
 #include <cstdio>
-#include <exception>
-#include <hip/hip_runtime_api.h>
+
+#include <stdgpu/hip/impl/error.h>
 
 namespace stdgpu::hip
 {
-
-/**
- * \brief A macro that automatically sets information about the caller
- * \param[in] error A HIP error object
- */
-#define STDGPU_HIP_SAFE_CALL(error) stdgpu::hip::safe_call(error, __FILE__, __LINE__, STDGPU_FUNC)
-
-/**
- * \brief Checks whether the HIP call was successful and stops the whole program on failure
- * \param[in] error An HIP error object
- * \param[in] file The file from which this function was called
- * \param[in] line The line from which this function was called
- * \param[in] function The function from which this function was called
- */
-void
-safe_call(const hipError_t error, const char* file, const int line, const char* function)
-{
-    if (error != hipSuccess)
-    {
-        printf("stdgpu : HIP ERROR :\n"
-               "  Error     : %s\n"
-               "  File      : %s:%d\n"
-               "  Function  : %s\n",
-               hipGetErrorString(error),
-               file,
-               line,
-               function);
-        std::terminate();
-    }
-}
 
 void
 dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes)


### PR DESCRIPTION
The internal error handling in the CUDA and HIP backends was previously an internal detail of the `memory` backend implementation. However, this functionality is also required in the `device` implementations and currently causes a compiler warning in the HIP backend due to an unhandled return variable.  Move the error handling code to a dedicated backend-specific file and use it in both the `memory` and the `device` modules.