### PR TITLE
memory: Add (de)allocatate_filled functions to allocator_traits

### DIFF
--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -676,6 +676,37 @@ allocator_traits<Allocator>::deallocate(Allocator& a,
 }
 
 template <typename Allocator>
+template <typename ExecutionPolicy>
+typename allocator_traits<Allocator>::pointer
+allocator_traits<Allocator>::allocate_filled(ExecutionPolicy&& policy,
+                                             Allocator& a,
+                                             typename allocator_traits<Allocator>::index_type n,
+                                             const typename allocator_traits<Allocator>::value_type& default_value)
+{
+    pointer p = allocate(a, n);
+    if (p != nullptr)
+    {
+        stdgpu::uninitialized_fill(std::forward<ExecutionPolicy>(policy), p, p + size(p), default_value);
+    }
+    return p;
+}
+
+template <typename Allocator>
+template <typename ExecutionPolicy>
+void
+allocator_traits<Allocator>::deallocate_filled(ExecutionPolicy&& policy,
+                                               Allocator& a,
+                                               typename allocator_traits<Allocator>::pointer p,
+                                               typename allocator_traits<Allocator>::index_type n)
+{
+    if (!detail::is_allocator_destroy_optimizable<value_type, allocator_type>())
+    {
+        stdgpu::destroy(std::forward<ExecutionPolicy>(policy), p, p + size(p));
+    }
+    return deallocate(a, p, n);
+}
+
+template <typename Allocator>
 template <typename T, class... Args>
 STDGPU_HOST_DEVICE void
 allocator_traits<Allocator>::construct([[maybe_unused]] Allocator& a, T* p, Args&&... args)

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -505,7 +505,7 @@ struct safe_device_allocator
 
     /**
      * \brief Allocates a memory block of the given size
-     * \param[in] n The size of the memory block in bytes
+     * \param[in] n The number of allocated elements
      * \return A pointer to the allocated memory block
      */
     [[nodiscard]] T*
@@ -514,7 +514,7 @@ struct safe_device_allocator
     /**
      * \brief Deallocates the given memory block
      * \param[in] p A pointer to the memory block
-     * \param[in] n The size of the memory block in bytes (must match the size during allocation)
+     * \param[in] n The number of allocated elements (must match the size during allocation)
      */
     void
     deallocate(T* p, index64_t n);
@@ -579,7 +579,7 @@ struct safe_host_allocator
 
     /**
      * \brief Allocates a memory block of the given size
-     * \param[in] n The size of the memory block in bytes
+     * \param[in] n The number of allocated elements
      * \return A pointer to the allocated memory block
      */
     [[nodiscard]] T*
@@ -588,7 +588,7 @@ struct safe_host_allocator
     /**
      * \brief Deallocates the given memory block
      * \param[in] p A pointer to the memory block
-     * \param[in] n The size of the memory block in bytes (must match the size during allocation)
+     * \param[in] n The number of allocated elements (must match the size during allocation)
      */
     void
     deallocate(T* p, index64_t n);
@@ -653,7 +653,7 @@ struct safe_managed_allocator
 
     /**
      * \brief Allocates a memory block of the given size
-     * \param[in] n The size of the memory block in bytes
+     * \param[in] n The number of allocated elements
      * \return A pointer to the allocated memory block
      */
     [[nodiscard]] T*
@@ -662,7 +662,7 @@ struct safe_managed_allocator
     /**
      * \brief Deallocates the given memory block
      * \param[in] p A pointer to the memory block
-     * \param[in] n The size of the memory block in bytes (must match the size during allocation)
+     * \param[in] n The number of allocated elements (must match the size during allocation)
      */
     void
     deallocate(T* p, index64_t n);
@@ -713,7 +713,7 @@ struct allocator_traits : public detail::allocator_traits_base<Allocator>
     /**
      * \brief Allocates a memory block of the given size
      * \param[in] a The allocator to use
-     * \param[in] n The size of the memory block in bytes
+     * \param[in] n The number of allocated elements
      * \return A pointer to the allocated memory block
      */
     [[nodiscard]] static pointer
@@ -722,7 +722,7 @@ struct allocator_traits : public detail::allocator_traits_base<Allocator>
     /**
      * \brief Allocates a memory block of the given size
      * \param[in] a The allocator to use
-     * \param[in] n The size of the memory block in bytes
+     * \param[in] n The number of allocated elements
      * \param[in] hint A pointer serving as a hint for the allocator
      * \return A pointer to the allocated memory block
      */
@@ -733,10 +733,35 @@ struct allocator_traits : public detail::allocator_traits_base<Allocator>
      * \brief Deallocates the given memory block
      * \param[in] a The allocator to use
      * \param[in] p A pointer to the memory block
-     * \param[in] n The size of the memory block in bytes (must match the size during allocation)
+     * \param[in] n The number of allocated elements (must match the size during allocation)
      */
     static void
     deallocate(Allocator& a, pointer p, index_type n);
+
+    /**
+     * \brief Allocates and fills a memory block of the given size
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] a The allocator to use
+     * \param[in] n The number of allocated elements
+     * \param[in] default_value A default value, that should be stored in every entry
+     * \return A pointer to the allocated memory block
+     */
+    template <typename ExecutionPolicy>
+    [[nodiscard]] static pointer
+    allocate_filled(ExecutionPolicy&& policy, Allocator& a, index_type n, const value_type& default_value);
+
+    /**
+     * \brief Deallocates the given filled memory block
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] a The allocator to use
+     * \param[in] p A pointer to the memory block
+     * \param[in] n The number of allocated elements (must match the size during allocation)
+     */
+    template <typename ExecutionPolicy>
+    static void
+    deallocate_filled(ExecutionPolicy&& policy, Allocator& a, pointer p, index_type n);
 
     /**
      * \brief Constructs an object value at the given pointer

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -1343,111 +1343,6 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, safe_managed_allocator)
     a.deallocate(array, size);
 }
 
-TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_deallocate)
-{
-    using Allocator = stdgpu::safe_host_allocator<int>;
-
-    Allocator a;
-    const stdgpu::index64_t size = 42;
-
-    int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
-
-    const int default_value = 10;
-    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
-
-    EXPECT_TRUE(
-            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
-
-    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
-}
-
-TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_hint_deallocate)
-{
-    using Allocator = stdgpu::safe_host_allocator<int>;
-
-    Allocator a;
-    const stdgpu::index64_t size = 42;
-
-    int* array_hint = stdgpu::allocator_traits<Allocator>::allocate(a, size);
-    int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size, array_hint);
-
-    const int default_value = 10;
-    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
-
-    EXPECT_TRUE(
-            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
-
-    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
-    stdgpu::allocator_traits<Allocator>::deallocate(a, array_hint, size);
-}
-
-TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_device)
-{
-    using Allocator_original = stdgpu::safe_device_allocator<float>;
-    Allocator_original ao;
-
-    using Allocator = typename stdgpu::allocator_traits<Allocator_original>::rebind_alloc<int>;
-    Allocator a(ao);
-
-    const stdgpu::index64_t size = 42;
-
-    int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
-
-#if STDGPU_DETAIL_IS_DEVICE_COMPILED
-    const int default_value = 10;
-    stdgpu::fill(stdgpu::execution::device, stdgpu::device_begin(array), stdgpu::device_end(array), default_value);
-
-    EXPECT_TRUE(equal_value(stdgpu::execution::device,
-                            stdgpu::device_cbegin(array),
-                            stdgpu::device_cend(array),
-                            default_value));
-#endif
-
-    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
-}
-
-TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_host)
-{
-    using Allocator_original = stdgpu::safe_host_allocator<float>;
-    Allocator_original ao;
-
-    using Allocator = typename stdgpu::allocator_traits<Allocator_original>::rebind_alloc<int>;
-    Allocator a(ao);
-
-    const stdgpu::index64_t size = 42;
-
-    int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
-
-    const int default_value = 10;
-    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
-
-    EXPECT_TRUE(
-            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
-
-    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
-}
-
-TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_managed)
-{
-    using Allocator_original = stdgpu::safe_managed_allocator<float>;
-    Allocator_original ao;
-
-    using Allocator = typename stdgpu::allocator_traits<Allocator_original>::rebind_alloc<int>;
-    Allocator a(ao);
-
-    const stdgpu::index64_t size = 42;
-
-    int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
-
-    const int default_value = 10;
-    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
-
-    EXPECT_TRUE(
-            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
-
-    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
-}
-
 namespace
 {
 class Counter
@@ -1522,6 +1417,141 @@ private:
     Allocator a;
 };
 } // namespace
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_deallocate)
+{
+    using Allocator = stdgpu::safe_host_allocator<int>;
+
+    Allocator a;
+    const stdgpu::index64_t size = 42;
+
+    int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
+
+    const int default_value = 10;
+    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+
+    EXPECT_TRUE(
+            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
+
+    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_hint_deallocate)
+{
+    using Allocator = stdgpu::safe_host_allocator<int>;
+
+    Allocator a;
+    const stdgpu::index64_t size = 42;
+
+    int* array_hint = stdgpu::allocator_traits<Allocator>::allocate(a, size);
+    int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size, array_hint);
+
+    const int default_value = 10;
+    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+
+    EXPECT_TRUE(
+            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
+
+    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
+    stdgpu::allocator_traits<Allocator>::deallocate(a, array_hint, size);
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_filled_deallocate_filled)
+{
+    using Allocator = stdgpu::safe_host_allocator<int>;
+
+    Allocator a;
+    const stdgpu::index64_t size = 42;
+    const int default_value = 10;
+
+    int* array = stdgpu::allocator_traits<Allocator>::allocate_filled(stdgpu::execution::host, a, size, default_value);
+
+    EXPECT_TRUE(
+            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
+
+    stdgpu::allocator_traits<Allocator>::deallocate_filled(stdgpu::execution::host, a, array, size);
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_allocate_filled_deallocate_filled_nontrivial)
+{
+    using Allocator = stdgpu::safe_host_allocator<Counter>;
+
+    Allocator a;
+    const stdgpu::index64_t size = 42;
+    const Counter default_value = Counter(nullptr, nullptr);
+
+    Counter* array =
+            stdgpu::allocator_traits<Allocator>::allocate_filled(stdgpu::execution::host, a, size, default_value);
+
+    stdgpu::allocator_traits<Allocator>::deallocate_filled(stdgpu::execution::host, a, array, size);
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_device)
+{
+    using Allocator_original = stdgpu::safe_device_allocator<float>;
+    Allocator_original ao;
+
+    using Allocator = typename stdgpu::allocator_traits<Allocator_original>::rebind_alloc<int>;
+    Allocator a(ao);
+
+    const stdgpu::index64_t size = 42;
+
+    int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
+
+#if STDGPU_DETAIL_IS_DEVICE_COMPILED
+    const int default_value = 10;
+    stdgpu::fill(stdgpu::execution::device, stdgpu::device_begin(array), stdgpu::device_end(array), default_value);
+
+    EXPECT_TRUE(equal_value(stdgpu::execution::device,
+                            stdgpu::device_cbegin(array),
+                            stdgpu::device_cend(array),
+                            default_value));
+#endif
+
+    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_host)
+{
+    using Allocator_original = stdgpu::safe_host_allocator<float>;
+    Allocator_original ao;
+
+    using Allocator = typename stdgpu::allocator_traits<Allocator_original>::rebind_alloc<int>;
+    Allocator a(ao);
+
+    const stdgpu::index64_t size = 42;
+
+    int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
+
+    const int default_value = 10;
+    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+
+    EXPECT_TRUE(
+            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
+
+    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
+}
+
+TEST_F(STDGPU_MEMORY_TEST_CLASS, allocator_traits_rebind_managed)
+{
+    using Allocator_original = stdgpu::safe_managed_allocator<float>;
+    Allocator_original ao;
+
+    using Allocator = typename stdgpu::allocator_traits<Allocator_original>::rebind_alloc<int>;
+    Allocator a(ao);
+
+    const stdgpu::index64_t size = 42;
+
+    int* array = stdgpu::allocator_traits<Allocator>::allocate(a, size);
+
+    const int default_value = 10;
+    stdgpu::fill(stdgpu::execution::host, stdgpu::host_begin(array), stdgpu::host_end(array), default_value);
+
+    EXPECT_TRUE(
+            equal_value(stdgpu::execution::host, stdgpu::host_cbegin(array), stdgpu::host_cend(array), default_value));
+
+    stdgpu::allocator_traits<Allocator>::deallocate(a, array, size);
+}
 
 TEST_F(STDGPU_MEMORY_TEST_CLASS, create_destroy_nontrivial)
 {


### PR DESCRIPTION
Although the `memory` module already supports custom allocators making it quite generic, the more advanced API related to automatically filled arrays still uses the default execution policies. Extend `allocator_traits` by `allocate_filled` and `deallocate_filled` functions that additionally take an execution policy as well as an initialization value as their arguments. This consolidates all required allocation functions in the traits and follows the recommended  usage from the C++ standard.

Issue: #351  