### PR TITLE
src: Add execution policy overload to all container creation and destruction functions

### DIFF
--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -115,11 +115,34 @@ public:
     createDeviceObject(const Allocator& allocator = Allocator());
 
     /**
+     * \brief Creates an object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] allocator The allocator instance to use
+     * \return A newly created object of this class allocated on the GPU (device)
+     * \note The size is implicitly set to 1 (and not needed as a parameter) as the object only manages a single value
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(!std::is_same_v<std::remove_reference_t<ExecutionPolicy>, Allocator>)>
+    static atomic
+    createDeviceObject(ExecutionPolicy&& policy, const Allocator& allocator = Allocator());
+
+    /**
      * \brief Destroys the given object of this class on the GPU (device)
      * \param[in] device_object The object allocated on the GPU (device)
      */
     static void
     destroyDeviceObject(atomic& device_object);
+
+    /**
+     * \brief Destroys the given object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] device_object The object allocated on the GPU (device)
+     */
+    template <typename ExecutionPolicy>
+    static void
+    destroyDeviceObject(ExecutionPolicy&& policy, atomic& device_object);
 
     /**
      * \brief Empty constructor

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -164,11 +164,33 @@ public:
     createDeviceObject(const index_t& size, const Allocator& allocator = Allocator());
 
     /**
+     * \brief Creates an object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] size The size of this object
+     * \param[in] allocator The allocator instance to use
+     * \return A newly created object of this class allocated on the GPU (device)
+     */
+    template <typename ExecutionPolicy>
+    static bitset
+    createDeviceObject(ExecutionPolicy&& policy, const index_t& size, const Allocator& allocator = Allocator());
+
+    /**
      * \brief Destroys the given object of this class on the GPU (device)
      * \param[in] device_object The object allocated on the GPU (device)
      */
     static void
     destroyDeviceObject(bitset& device_object);
+
+    /**
+     * \brief Destroys the given object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] device_object The object allocated on the GPU (device)
+     */
+    template <typename ExecutionPolicy>
+    static void
+    destroyDeviceObject(ExecutionPolicy&& policy, bitset& device_object);
 
     /**
      * \brief Empty constructor

--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -83,11 +83,33 @@ public:
     createDeviceObject(const index_t& capacity, const Allocator& allocator = Allocator());
 
     /**
+     * \brief Creates an object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] capacity The capacity of the object
+     * \param[in] allocator The allocator instance to use
+     * \return A newly created object of this class allocated on the GPU (device)
+     */
+    template <typename ExecutionPolicy>
+    static deque<T, Allocator>
+    createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator = Allocator());
+
+    /**
      * \brief Destroys the given object of this class on the GPU (device)
      * \param[in] device_object The object allocated on the GPU (device)
      */
     static void
     destroyDeviceObject(deque<T, Allocator>& device_object);
+
+    /**
+     * \brief Destroys the given object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] device_object The object allocated on the GPU (device)
+     */
+    template <typename ExecutionPolicy>
+    static void
+    destroyDeviceObject(ExecutionPolicy&& policy, deque<T, Allocator>& device_object);
 
     /**
      * \brief Empty constructor

--- a/src/stdgpu/impl/mutex_detail.cuh
+++ b/src/stdgpu/impl/mutex_detail.cuh
@@ -56,7 +56,18 @@ template <typename Block, typename Allocator>
 inline mutex_array<Block, Allocator>
 mutex_array<Block, Allocator>::createDeviceObject(const index_t& size, const Allocator& allocator)
 {
-    mutex_array<Block, Allocator> result(bitset<Block, Allocator>::createDeviceObject(size, allocator));
+    return createDeviceObject(execution::device, size, allocator);
+}
+
+template <typename Block, typename Allocator>
+template <typename ExecutionPolicy>
+inline mutex_array<Block, Allocator>
+mutex_array<Block, Allocator>::createDeviceObject(ExecutionPolicy&& policy,
+                                                  const index_t& size,
+                                                  const Allocator& allocator)
+{
+    mutex_array<Block, Allocator> result(
+            bitset<Block, Allocator>::createDeviceObject(std::forward<ExecutionPolicy>(policy), size, allocator));
 
     return result;
 }
@@ -65,7 +76,16 @@ template <typename Block, typename Allocator>
 inline void
 mutex_array<Block, Allocator>::destroyDeviceObject(mutex_array<Block, Allocator>& device_object)
 {
-    bitset<Block, Allocator>::destroyDeviceObject(device_object._lock_bits);
+    destroyDeviceObject(execution::device, device_object);
+}
+
+template <typename Block, typename Allocator>
+template <typename ExecutionPolicy>
+inline void
+mutex_array<Block, Allocator>::destroyDeviceObject(ExecutionPolicy&& policy,
+                                                   mutex_array<Block, Allocator>& device_object)
+{
+    bitset<Block, Allocator>::destroyDeviceObject(std::forward<ExecutionPolicy>(policy), device_object._lock_bits);
 }
 
 template <typename Block, typename Allocator>

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -76,20 +76,25 @@ public:
 
     /**
      * \brief Creates an object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \param[in] capacity The capacity of the object
      * \param[in] allocator The allocator instance to use
-     * \pre capacity > 0
      * \return A newly created object of this class allocated on the GPU (device)
      */
+    template <typename ExecutionPolicy>
     static unordered_base
-    createDeviceObject(const index_t& capacity, const Allocator& allocator);
+    createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator);
 
     /**
      * \brief Destroys the given object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \param[in] device_object The object allocated on the GPU (device)
      */
+    template <typename ExecutionPolicy>
     static void
-    destroyDeviceObject(unordered_base& device_object);
+    destroyDeviceObject(ExecutionPolicy&& policy, unordered_base& device_object);
 
     /**
      * \brief Empty constructor

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -296,9 +296,20 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::createDeviceObject(const index_t& capacity,
                                                                      const Allocator& allocator)
 {
+    return createDeviceObject(execution::device, capacity, allocator);
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy>
+unordered_map<Key, T, Hash, KeyEqual, Allocator>
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::createDeviceObject(ExecutionPolicy&& policy,
+                                                                     const index_t& capacity,
+                                                                     const Allocator& allocator)
+{
     STDGPU_EXPECTS(capacity > 0);
 
-    unordered_map<Key, T, Hash, KeyEqual, Allocator> result(base_type::createDeviceObject(capacity, allocator));
+    unordered_map<Key, T, Hash, KeyEqual, Allocator> result(
+            base_type::createDeviceObject(std::forward<ExecutionPolicy>(policy), capacity, allocator));
 
     return result;
 }
@@ -308,7 +319,17 @@ void
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::destroyDeviceObject(
         unordered_map<Key, T, Hash, KeyEqual, Allocator>& device_object)
 {
-    base_type::destroyDeviceObject(device_object._base);
+    destroyDeviceObject(execution::device, device_object);
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy>
+void
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::destroyDeviceObject(
+        ExecutionPolicy&& policy,
+        unordered_map<Key, T, Hash, KeyEqual, Allocator>& device_object)
+{
+    base_type::destroyDeviceObject(std::forward<ExecutionPolicy>(policy), device_object._base);
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -279,9 +279,20 @@ template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 unordered_set<Key, Hash, KeyEqual, Allocator>
 unordered_set<Key, Hash, KeyEqual, Allocator>::createDeviceObject(const index_t& capacity, const Allocator& allocator)
 {
+    return createDeviceObject(execution::device, capacity, allocator);
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy>
+unordered_set<Key, Hash, KeyEqual, Allocator>
+unordered_set<Key, Hash, KeyEqual, Allocator>::createDeviceObject(ExecutionPolicy&& policy,
+                                                                  const index_t& capacity,
+                                                                  const Allocator& allocator)
+{
     STDGPU_EXPECTS(capacity > 0);
 
-    unordered_set<Key, Hash, KeyEqual, Allocator> result(base_type::createDeviceObject(capacity, allocator));
+    unordered_set<Key, Hash, KeyEqual, Allocator> result(
+            base_type::createDeviceObject(std::forward<ExecutionPolicy>(policy), capacity, allocator));
 
     return result;
 }
@@ -291,7 +302,17 @@ void
 unordered_set<Key, Hash, KeyEqual, Allocator>::destroyDeviceObject(
         unordered_set<Key, Hash, KeyEqual, Allocator>& device_object)
 {
-    base_type::destroyDeviceObject(device_object._base);
+    destroyDeviceObject(execution::device, device_object);
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy>
+void
+unordered_set<Key, Hash, KeyEqual, Allocator>::destroyDeviceObject(
+        ExecutionPolicy&& policy,
+        unordered_set<Key, Hash, KeyEqual, Allocator>& device_object)
+{
+    base_type::destroyDeviceObject(std::forward<ExecutionPolicy>(policy), device_object._base);
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -110,11 +110,33 @@ public:
     createDeviceObject(const index_t& size, const Allocator& allocator = Allocator());
 
     /**
+     * \brief Creates an object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] size The size of this object
+     * \param[in] allocator The allocator instance to use
+     * \return A newly created object of this class allocated on the GPU (device)
+     */
+    template <typename ExecutionPolicy>
+    static mutex_array
+    createDeviceObject(ExecutionPolicy&& policy, const index_t& size, const Allocator& allocator = Allocator());
+
+    /**
      * \brief Destroys the given object of this class on the GPU (device)
      * \param[in] device_object The object allocated on the GPU (device)
      */
     static void
     destroyDeviceObject(mutex_array& device_object);
+
+    /**
+     * \brief Destroys the given object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] device_object The object allocated on the GPU (device)
+     */
+    template <typename ExecutionPolicy>
+    static void
+    destroyDeviceObject(ExecutionPolicy&& policy, mutex_array& device_object);
 
     /**
      * \brief Empty constructor

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -104,11 +104,33 @@ public:
     createDeviceObject(const index_t& capacity, const Allocator& allocator = Allocator());
 
     /**
+     * \brief Creates an object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] capacity The capacity of the object
+     * \param[in] allocator The allocator instance to use
+     * \return A newly created object of this class allocated on the GPU (device)
+     */
+    template <typename ExecutionPolicy>
+    static unordered_map
+    createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator = Allocator());
+
+    /**
      * \brief Destroys the given object of this class on the GPU (device)
      * \param[in] device_object The object allocated on the GPU (device)
      */
     static void
     destroyDeviceObject(unordered_map& device_object);
+
+    /**
+     * \brief Destroys the given object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] device_object The object allocated on the GPU (device)
+     */
+    template <typename ExecutionPolicy>
+    static void
+    destroyDeviceObject(ExecutionPolicy&& policy, unordered_map& device_object);
 
     /**
      * \brief Empty constructor

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -93,11 +93,33 @@ public:
     createDeviceObject(const index_t& capacity, const Allocator& allocator = Allocator());
 
     /**
+     * \brief Creates an object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] capacity The capacity of the object
+     * \param[in] allocator The allocator instance to use
+     * \return A newly created object of this class allocated on the GPU (device)
+     */
+    template <typename ExecutionPolicy>
+    static unordered_set
+    createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator = Allocator());
+
+    /**
      * \brief Destroys the given object of this class on the GPU (device)
      * \param[in] device_object The object allocated on the GPU (device)
      */
     static void
     destroyDeviceObject(unordered_set& device_object);
+
+    /**
+     * \brief Destroys the given object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] device_object The object allocated on the GPU (device)
+     */
+    template <typename ExecutionPolicy>
+    static void
+    destroyDeviceObject(ExecutionPolicy&& policy, unordered_set& device_object);
 
     /**
      * \brief Empty constructor

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -103,11 +103,33 @@ public:
     createDeviceObject(const index_t& capacity, const Allocator& allocator = Allocator());
 
     /**
+     * \brief Creates an object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] capacity The capacity of the object
+     * \param[in] allocator The allocator instance to use
+     * \return A newly created object of this class allocated on the GPU (device)
+     */
+    template <typename ExecutionPolicy>
+    static vector<T, Allocator>
+    createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator = Allocator());
+
+    /**
      * \brief Destroys the given object of this class on the GPU (device)
      * \param[in] device_object The object allocated on the GPU (device)
      */
     static void
     destroyDeviceObject(vector<T, Allocator>& device_object);
+
+    /**
+     * \brief Destroys the given object of this class on the GPU (device)
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] device_object The object allocated on the GPU (device)
+     */
+    template <typename ExecutionPolicy>
+    static void
+    destroyDeviceObject(ExecutionPolicy&& policy, vector<T, Allocator>& device_object);
 
     /**
      * \brief Empty constructor

--- a/test/stdgpu/atomic.inc
+++ b/test/stdgpu/atomic.inc
@@ -2300,3 +2300,12 @@ TEST_F(stdgpu_atomic, custom_allocator)
 
     test_utils::get_allocator_statistics().reset();
 }
+
+TEST_F(stdgpu_atomic, custom_execution_policy)
+{
+    test_utils::custom_device_policy policy;
+
+    stdgpu::atomic<int> value = stdgpu::atomic<int>::createDeviceObject(policy);
+
+    stdgpu::atomic<int>::destroyDeviceObject(policy, value);
+}

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -718,3 +718,13 @@ TEST_F(stdgpu_bitset, custom_allocator)
 
     test_utils::get_allocator_statistics().reset();
 }
+
+TEST_F(stdgpu_bitset, custom_execution_policy)
+{
+    test_utils::custom_device_policy policy;
+
+    const stdgpu::index_t N = 10000;
+    stdgpu::bitset<> bits = stdgpu::bitset<>::createDeviceObject(policy, N);
+
+    stdgpu::bitset<>::destroyDeviceObject(policy, bits);
+}

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -25,6 +25,7 @@
 #include <stdgpu/numeric.h>
 #include <stdgpu/utility.h>
 #include <test_memory_utils.h>
+#include <test_utils.h>
 
 class stdgpu_deque : public ::testing::Test
 {
@@ -2569,4 +2570,14 @@ TEST_F(stdgpu_deque, custom_allocator)
     EXPECT_LE(test_utils::get_allocator_statistics().destructions, 33);
 
     test_utils::get_allocator_statistics().reset();
+}
+
+TEST_F(stdgpu_deque, custom_execution_policy)
+{
+    test_utils::custom_device_policy policy;
+
+    const stdgpu::index_t N = 10000;
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(policy, N);
+
+    stdgpu::deque<int>::destroyDeviceObject(policy, pool);
 }

--- a/test/stdgpu/mutex.inc
+++ b/test/stdgpu/mutex.inc
@@ -22,6 +22,7 @@
 #include <stdgpu/mutex.cuh>
 #include <stdgpu/numeric.h>
 #include <test_memory_utils.h>
+#include <test_utils.h>
 
 class stdgpu_mutex : public ::testing::Test
 {
@@ -393,4 +394,14 @@ TEST_F(stdgpu_mutex, custom_allocator)
     EXPECT_LE(test_utils::get_allocator_statistics().destructions, 6);
 
     test_utils::get_allocator_statistics().reset();
+}
+
+TEST_F(stdgpu_mutex, custom_execution_policy)
+{
+    test_utils::custom_device_policy policy;
+
+    const stdgpu::index_t N = 10000;
+    stdgpu::mutex_array<> lock2 = stdgpu::mutex_array<>::createDeviceObject(policy, N);
+
+    stdgpu::mutex_array<>::destroyDeviceObject(policy, lock2);
 }

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -2332,3 +2332,13 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, custom_allocator)
 
     test_utils::get_allocator_statistics().reset();
 }
+
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, custom_execution_policy)
+{
+    test_utils::custom_device_policy policy;
+
+    const stdgpu::index_t N = 10000;
+    test_unordered_datastructure hash_datastructure2 = test_unordered_datastructure::createDeviceObject(policy, N);
+
+    test_unordered_datastructure::destroyDeviceObject(policy, hash_datastructure2);
+}

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -25,6 +25,7 @@
 #include <stdgpu/utility.h>
 #include <stdgpu/vector.cuh>
 #include <test_memory_utils.h>
+#include <test_utils.h>
 
 class stdgpu_vector : public ::testing::Test
 {
@@ -1697,4 +1698,14 @@ TEST_F(stdgpu_vector, custom_allocator)
     EXPECT_LE(test_utils::get_allocator_statistics().destructions, 21);
 
     test_utils::get_allocator_statistics().reset();
+}
+
+TEST_F(stdgpu_vector, custom_execution_policy)
+{
+    test_utils::custom_device_policy policy;
+
+    const stdgpu::index_t N = 10000;
+    stdgpu::vector<int> pool = stdgpu::vector<int>::createDeviceObject(policy, N);
+
+    stdgpu::vector<int>::destroyDeviceObject(policy, pool);
 }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include <stdgpu/cstddef.h>
+#include <stdgpu/execution.h>
 
 namespace test_utils
 {
@@ -97,6 +98,10 @@ for_each_concurrent_thread(F&& f, Args&&... args)
         }
     }
 }
+
+class custom_device_policy : public stdgpu::execution::device_policy
+{
+};
 } // namespace test_utils
 
 #endif // TEST_UTILS_H


### PR DESCRIPTION
Currently, all containers allow for custom allocators, but lack support custom execution policies. Add overloads to the `createDeviceObject` and `destroyDeviceObject` static member functions that additionally take an execution policy object and port the respective implementations to uniformly use `allocator_traits` for memory (de)allocation.

Partially addresses #351 