### PR TITLE
cmake: Add option to enable building the documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(STDGPU_BUILD_EXAMPLES "Build the examples, default: ON" ON)
 option(STDGPU_BUILD_BENCHMARKS "Build the benchmarks, default: ON" ON)
 option(STDGPU_BUILD_TESTS "Build the unit tests, default: ON" ON)
 option(STDGPU_BUILD_TEST_COVERAGE "Build a test coverage report, default: OFF" OFF)
+option(STDGPU_BUILD_DOCUMENTATION "Build the documenation, default: OFF" OFF)
 option(STDGPU_ANALYZE_WITH_CLANG_TIDY "Analyzes the code with clang-tidy, default: OFF" OFF)
 option(STDGPU_ANALYZE_WITH_CPPCHECK "Analyzes the code with cppcheck, default: OFF" OFF)
 
@@ -158,8 +159,6 @@ set(STDGPU_EXTERNAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external")
 
 add_subdirectory(src)
 
-add_subdirectory(doc)
-
 
 # Install exported targets and cmake files
 install(EXPORT stdgpu-targets
@@ -206,6 +205,10 @@ if(STDGPU_BUILD_TESTS)
                                   DEPENDENCIES teststdgpu)
     endif()
 
+endif()
+
+if(STDGPU_BUILD_DOCUMENTATION)
+    add_subdirectory(doc)
 endif()
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/config_summary.cmake")

--- a/cmake/config_summary.cmake
+++ b/cmake/config_summary.cmake
@@ -49,6 +49,9 @@ function(stdgpu_print_configuration_summary)
 
     message(STATUS "")
 
+    message(STATUS "Documentation:")
+    message(STATUS "  STDGPU_BUILD_DOCUMENTATION                :   ${STDGPU_BUILD_DOCUMENTATION}")
+
     message(STATUS "")
     message(STATUS "*******************************************************************************")
     message(STATUS "")

--- a/scripts/ci/configure_openmp_documentation.sh
+++ b/scripts/ci/configure_openmp_documentation.sh
@@ -5,4 +5,4 @@ set -e
 sh scripts/utils/create_empty_directory.sh build
 
 # Configure project
-sh scripts/utils/configure.sh Release -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/thrust
+sh scripts/utils/configure.sh Release -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_BUILD_DOCUMENTATION=ON -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/thrust


### PR DESCRIPTION
Documentation building is optional and excluded by default, so the actual build must be explicitly run via a respective CMake target. However, the corresponding CMake code is always parsed which includes downloading the modern doxygen theme and setting up all targets. Add a CMake option `STDGPU_BUILD_DOCUMENTATION`  to allow for completely disabling all of these steps. Furthermore, since users typically do not attempt building the documentation, set its default value to `OFF`.