### PR TITLE
memory: Drop superseded allocator-based create/destroy functions

### DIFF
--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -61,21 +61,6 @@ createDeviceArray(const stdgpu::index64_t count, const T default_value = T());
 
 /**
  * \ingroup memory
- * \brief Creates a new device array and initializes (fills) it with the given default value
- * \tparam T The type of the array
- * \tparam Allocator An allocator for device memory
- * \param[in] device_allocator The device allocator to use
- * \param[in] count The number of elements of the new array
- * \param[in] default_value A default value, that should be stored in every array entry
- * \return The allocated device array if count > 0, nullptr otherwise
- * \note Must only be used in device-compiled code
- */
-template <typename T, typename Allocator>
-T*
-createDeviceArray(Allocator& device_allocator, const stdgpu::index64_t count, const T default_value);
-
-/**
- * \ingroup memory
  * \brief Creates a new host array and initializes (fills) it with the given default value
  * \tparam T The type of the array
  * \param[in] count The number of elements of the new array
@@ -86,20 +71,6 @@ createDeviceArray(Allocator& device_allocator, const stdgpu::index64_t count, co
 template <typename T>
 T*
 createHostArray(const stdgpu::index64_t count, const T default_value = T());
-
-/**
- * \ingroup memory
- * \brief Creates a new host array and initializes (fills) it with the given default value
- * \tparam T The type of the array
- * \tparam Allocator An allocator for host memory
- * \param[in] host_allocator The host allocator to use
- * \param[in] count The number of elements of the new array
- * \param[in] default_value A default value, that should be stored in every array entry
- * \return The allocated host array if count > 0, nullptr otherwise
- */
-template <typename T, typename Allocator>
-T*
-createHostArray(Allocator& host_allocator, const stdgpu::index64_t count, const T default_value);
 
 /**
  * \ingroup memory
@@ -119,24 +90,6 @@ createManagedArray(const stdgpu::index64_t count,
 
 /**
  * \ingroup memory
- * \brief Creates a new managed array and initializes (fills) it with the given default value
- * \tparam T The type of the array
- * \tparam Allocator An allocator for managed memory
- * \param[in] managed_allocator The managed allocator to use
- * \param[in] count The number of elements of the new array
- * \param[in] default_value A default value, that should be stored in every array entry
- * \param[in] initialize_on The device on which the fill operation is performed
- * \return The allocated managed array if count > 0, nullptr otherwise
- */
-template <typename T, typename Allocator>
-T*
-createManagedArray(Allocator& managed_allocator,
-                   const stdgpu::index64_t count,
-                   const T default_value,
-                   const Initialization initialize_on = Initialization::DEVICE);
-
-/**
- * \ingroup memory
  * \brief Destroys the given device array
  * \tparam T The type of the array
  * \param[in] device_array A device array
@@ -144,18 +97,6 @@ createManagedArray(Allocator& managed_allocator,
 template <typename T>
 void
 destroyDeviceArray(T*& device_array);
-
-/**
- * \ingroup memory
- * \brief Destroys the given device array
- * \tparam T The type of the array
- * \tparam Allocator An allocator for device memory
- * \param[in] device_allocator The device allocator to use
- * \param[in] device_array A device array
- */
-template <typename T, typename Allocator>
-void
-destroyDeviceArray(Allocator& device_allocator, T*& device_array);
 
 /**
  * \ingroup memory
@@ -169,18 +110,6 @@ destroyHostArray(T*& host_array);
 
 /**
  * \ingroup memory
- * \brief Destroys the given host array
- * \tparam T The type of the array
- * \tparam Allocator An allocator for host memory
- * \param[in] host_allocator The host allocator to use
- * \param[in] host_array A host array
- */
-template <typename T, typename Allocator>
-void
-destroyHostArray(Allocator& host_allocator, T*& host_array);
-
-/**
- * \ingroup memory
  * \brief Destroys the given managed array
  * \tparam T The type of the array
  * \param[in] managed_array A managed array
@@ -188,18 +117,6 @@ destroyHostArray(Allocator& host_allocator, T*& host_array);
 template <typename T>
 void
 destroyManagedArray(T*& managed_array);
-
-/**
- * \ingroup memory
- * \brief Destroys the given managed array
- * \tparam T The type of the array
- * \tparam Allocator An allocator for managed memory
- * \param[in] managed_allocator The managed allocator to use
- * \param[in] managed_array A managed array
- */
-template <typename T, typename Allocator>
-void
-destroyManagedArray(Allocator& managed_allocator, T*& managed_array);
 
 /**
  * \ingroup memory
@@ -230,25 +147,6 @@ copyCreateDevice2HostArray(const T* device_array,
 
 /**
  * \ingroup memory
- * \brief Creates and copies the given device array to the host
- * \tparam T The type of the array
- * \tparam Allocator An allocator for host memory
- * \param[in] host_allocator The host allocator to use
- * \param[in] device_array The device array
- * \param[in] count The number of elements of device_array
- * \param[in] check_safety True if this function should check whether copying is safe, false otherwise
- * \return The same array allocated on the host
- * \note The source array might also be a managed array
- */
-template <typename T, typename Allocator>
-T*
-copyCreateDevice2HostArray(Allocator& host_allocator,
-                           const T* device_array,
-                           const stdgpu::index64_t count,
-                           const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
-
-/**
- * \ingroup memory
  * \brief Creates and copies the given host array to the device
  * \tparam T The type of the array
  * \param[in] host_array The host array
@@ -260,25 +158,6 @@ copyCreateDevice2HostArray(Allocator& host_allocator,
 template <typename T>
 T*
 copyCreateHost2DeviceArray(const T* host_array,
-                           const stdgpu::index64_t count,
-                           const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
-
-/**
- * \ingroup memory
- * \brief Creates and copies the given host array to the device
- * \tparam T The type of the array
- * \tparam Allocator An allocator for device memory
- * \param[in] device_allocator The host allocator to use
- * \param[in] host_array The host array
- * \param[in] count The number of elements of host_array
- * \param[in] check_safety True if this function should check whether copying is safe, false otherwise
- * \return The same array allocated on the device
- * \note The source array might also be a managed array
- */
-template <typename T, typename Allocator>
-T*
-copyCreateHost2DeviceArray(Allocator& device_allocator,
-                           const T* host_array,
                            const stdgpu::index64_t count,
                            const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
 
@@ -300,25 +179,6 @@ copyCreateHost2HostArray(const T* host_array,
 
 /**
  * \ingroup memory
- * \brief Creates and copies the given host array to the host
- * \tparam T The type of the array
- * \tparam Allocator An allocator for host memory
- * \param[in] host_allocator The host allocator to use
- * \param[in] host_array The host array
- * \param[in] count The number of elements of host_array
- * \param[in] check_safety True if this function should check whether copying is safe, false otherwise
- * \return The same array allocated on the host
- * \note The source array might also be a managed array
- */
-template <typename T, typename Allocator>
-T*
-copyCreateHost2HostArray(Allocator& host_allocator,
-                         const T* host_array,
-                         const stdgpu::index64_t count,
-                         const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
-
-/**
- * \ingroup memory
  * \brief Creates and copies the given device array to the device
  * \tparam T The type of the array
  * \param[in] device_array The device array
@@ -330,25 +190,6 @@ copyCreateHost2HostArray(Allocator& host_allocator,
 template <typename T>
 T*
 copyCreateDevice2DeviceArray(const T* device_array,
-                             const stdgpu::index64_t count,
-                             const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
-
-/**
- * \ingroup memory
- * \brief Creates and copies the given device array to the device
- * \tparam T The type of the array
- * \tparam Allocator An allocator for device memory
- * \param[in] device_allocator The host allocator to use
- * \param[in] device_array The device array
- * \param[in] count The number of elements of device_array
- * \param[in] check_safety True if this function should check whether copying is safe, false otherwise
- * \return The same array allocated on the device
- * \note The source array might also be a managed array
- */
-template <typename T, typename Allocator>
-T*
-copyCreateDevice2DeviceArray(Allocator& device_allocator,
-                             const T* device_array,
                              const stdgpu::index64_t count,
                              const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
 

--- a/test/stdgpu/memory.inc
+++ b/test/stdgpu/memory.inc
@@ -408,22 +408,6 @@ createAndDestroyDeviceFunction(const stdgpu::index_t iterations)
         destroyDeviceArray<int>(array_device);
 
         EXPECT_EQ(array_device, nullptr);
-
-#if STDGPU_DETAIL_IS_DEVICE_COMPILED
-        using Allocator = stdgpu::safe_device_allocator<int>;
-        Allocator a;
-
-        int* array_device_2 = createDeviceArray<int, Allocator>(a, size, default_value);
-
-        EXPECT_TRUE(equal_value(stdgpu::execution::device,
-                                stdgpu::device_cbegin(array_device_2),
-                                stdgpu::device_cend(array_device_2),
-                                default_value));
-
-        destroyDeviceArray<int, Allocator>(a, array_device_2);
-
-        EXPECT_EQ(array_device_2, nullptr);
-#endif
     }
 }
 
@@ -435,26 +419,16 @@ createAndDestroyHostFunction(const stdgpu::index_t iterations)
         const stdgpu::index64_t size = 42;
         const int default_value = 10;
 
-        using Allocator = stdgpu::safe_host_allocator<int>;
-        Allocator a;
-
         int* array_host = createHostArray<int>(size, default_value);
-        int* array_host_2 = createHostArray<int, Allocator>(a, size, default_value);
 
         EXPECT_TRUE(equal_value(stdgpu::execution::host,
                                 stdgpu::host_cbegin(array_host),
                                 stdgpu::host_cend(array_host),
                                 default_value));
-        EXPECT_TRUE(equal_value(stdgpu::execution::host,
-                                stdgpu::host_cbegin(array_host_2),
-                                stdgpu::host_cend(array_host_2),
-                                default_value));
 
         destroyHostArray<int>(array_host);
-        destroyHostArray<int, Allocator>(a, array_host_2);
 
         EXPECT_EQ(array_host, nullptr);
-        EXPECT_EQ(array_host_2, nullptr);
     }
 }
 
@@ -466,12 +440,8 @@ createAndDestroyManagedFunction(const stdgpu::index_t iterations)
         const stdgpu::index64_t size = 42;
         const int default_value = 10;
 
-        using Allocator = stdgpu::safe_managed_allocator<int>;
-        Allocator a;
-
         int* array_managed_device = createManagedArray<int>(size, default_value, Initialization::DEVICE);
         int* array_managed_host = createManagedArray<int>(size, default_value, Initialization::HOST);
-        int* array_managed_host_2 = createManagedArray<int, Allocator>(a, size, default_value, Initialization::HOST);
 
 #if STDGPU_DETAIL_IS_DEVICE_COMPILED
         EXPECT_TRUE(equal_value(stdgpu::execution::device,
@@ -483,18 +453,12 @@ createAndDestroyManagedFunction(const stdgpu::index_t iterations)
                                 stdgpu::host_cbegin(array_managed_host),
                                 stdgpu::host_cend(array_managed_host),
                                 default_value));
-        EXPECT_TRUE(equal_value(stdgpu::execution::host,
-                                stdgpu::host_cbegin(array_managed_host_2),
-                                stdgpu::host_cend(array_managed_host_2),
-                                default_value));
 
         destroyManagedArray<int>(array_managed_device);
         destroyManagedArray<int>(array_managed_host);
-        destroyManagedArray<int, Allocator>(a, array_managed_host_2);
 
         EXPECT_EQ(array_managed_device, nullptr);
         EXPECT_EQ(array_managed_host, nullptr);
-        EXPECT_EQ(array_managed_host_2, nullptr);
     }
 }
 } // namespace
@@ -641,22 +605,6 @@ copyCreateDevice2DeviceFunction(const stdgpu::index_t iterations)
                                 stdgpu::device_begin(array_copy)));
 #endif
 
-#if STDGPU_DETAIL_IS_DEVICE_COMPILED
-        using Allocator = stdgpu::safe_device_allocator<int>;
-        Allocator a;
-
-        int* array_copy_2 = copyCreateDevice2DeviceArray<int, Allocator>(a, array, size);
-
-        EXPECT_TRUE(equal_range(stdgpu::execution::device,
-                                stdgpu::device_begin(array),
-                                stdgpu::device_end(array),
-                                stdgpu::device_begin(array_copy_2)));
-
-        destroyDeviceArray<int, Allocator>(a, array_copy_2);
-
-        EXPECT_EQ(array_copy_2, nullptr);
-#endif
-
         destroyDeviceArray<int>(array);
         destroyDeviceArray<int>(array_copy);
 
@@ -697,22 +645,6 @@ copyCreateHost2DeviceFunction(const stdgpu::index_t iterations)
                                 stdgpu::device_cbegin(array),
                                 stdgpu::device_cend(array),
                                 stdgpu::device_cbegin(array_copy)));
-#endif
-
-#if STDGPU_DETAIL_IS_DEVICE_COMPILED
-        using Allocator = stdgpu::safe_device_allocator<int>;
-        Allocator a;
-
-        int* array_copy_2 = copyCreateHost2DeviceArray<int, Allocator>(a, array_host, size);
-
-        EXPECT_TRUE(equal_range(stdgpu::execution::device,
-                                stdgpu::device_begin(array),
-                                stdgpu::device_end(array),
-                                stdgpu::device_begin(array_copy_2)));
-
-        destroyDeviceArray<int, Allocator>(a, array_copy_2);
-
-        EXPECT_EQ(array_copy_2, nullptr);
 #endif
 
         destroyDeviceArray<int>(array);
@@ -773,32 +705,22 @@ copyCreateDevice2HostFunction(const stdgpu::index_t iterations)
         const stdgpu::index64_t size = 42;
         const int default_value = 10;
 
-        using Allocator = stdgpu::safe_host_allocator<int>;
-        Allocator a;
-
         int* array = createDeviceArray<int>(size, default_value);
         int* array_host = createHostArray<int>(size, default_value);
         int* array_copy = copyCreateDevice2HostArray<int>(array, size);
-        int* array_copy_2 = copyCreateDevice2HostArray<int, Allocator>(a, array, size);
 
         EXPECT_TRUE(equal_range(stdgpu::execution::host,
                                 stdgpu::host_cbegin(array_host),
                                 stdgpu::host_cend(array_host),
                                 stdgpu::host_cbegin(array_copy)));
-        EXPECT_TRUE(equal_range(stdgpu::execution::host,
-                                stdgpu::host_cbegin(array_host),
-                                stdgpu::host_cend(array_host),
-                                stdgpu::host_cbegin(array_copy_2)));
 
         destroyDeviceArray<int>(array);
         destroyHostArray<int>(array_host);
         destroyHostArray<int>(array_copy);
-        destroyHostArray<int>(array_copy_2);
 
         EXPECT_EQ(array, nullptr);
         EXPECT_EQ(array_host, nullptr);
         EXPECT_EQ(array_copy, nullptr);
-        EXPECT_EQ(array_copy_2, nullptr);
     }
 }
 } // namespace
@@ -825,29 +747,19 @@ copyCreateHost2HostFunction(const stdgpu::index_t iterations)
         const stdgpu::index64_t size = 42;
         const int default_value = 10;
 
-        using Allocator = stdgpu::safe_host_allocator<int>;
-        Allocator a;
-
         int* array_host = createHostArray<int>(size, default_value);
         int* array_copy = copyCreateHost2HostArray<int>(array_host, size);
-        int* array_copy_2 = copyCreateHost2HostArray<int, Allocator>(a, array_host, size);
 
         EXPECT_TRUE(equal_range(stdgpu::execution::host,
                                 stdgpu::host_cbegin(array_host),
                                 stdgpu::host_cend(array_host),
                                 stdgpu::host_cbegin(array_copy)));
-        EXPECT_TRUE(equal_range(stdgpu::execution::host,
-                                stdgpu::host_cbegin(array_host),
-                                stdgpu::host_cend(array_host),
-                                stdgpu::host_cbegin(array_copy_2)));
 
         destroyHostArray<int>(array_host);
         destroyHostArray<int>(array_copy);
-        destroyHostArray<int>(array_copy_2);
 
         EXPECT_EQ(array_host, nullptr);
         EXPECT_EQ(array_copy, nullptr);
-        EXPECT_EQ(array_copy_2, nullptr);
     }
 }
 } // namespace


### PR DESCRIPTION
In #251, new allocator-based overloads to the create/destroy `memory` functions have been added to support custom allocators throughout all containers of the library. Since `allocator_traits` has been extended and adopted by the containers, these older functions are not used anymore and primarily only point to `allocator_traits` anyways. Drop them to streamline the `memory` API and reduce the maintenance burden.