### PR TITLE
bitset: Add support for custom execution policies

### DIFF
--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -206,6 +206,16 @@ public:
 
     /**
      * \brief Sets all bits
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \post count() == size()
+     */
+    template <typename ExecutionPolicy>
+    void
+    set(ExecutionPolicy&& policy);
+
+    /**
+     * \brief Sets all bits
      * \post count() == size()
      */
     void
@@ -229,6 +239,16 @@ public:
     reset();
 
     /**
+     * \brief Resets all bits
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \post count() == 0
+     */
+    template <typename ExecutionPolicy>
+    void
+    reset(ExecutionPolicy&& policy);
+
+    /**
      * \brief Resets the bit at the given position. Equivalent to : set(n, false)
      * \param[in] n The position that should be reset
      * \return The old value of the bit
@@ -242,6 +262,15 @@ public:
      */
     void
     flip();
+
+    /**
+     * \brief Flips all bits
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     */
+    template <typename ExecutionPolicy>
+    void
+    flip(ExecutionPolicy&& policy);
 
     /**
      * \brief Flips the bit at the given position
@@ -301,11 +330,31 @@ public:
     count() const;
 
     /**
+     * \brief The number of set bits
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return The number of set bits
+     */
+    template <typename ExecutionPolicy>
+    index_t
+    count(ExecutionPolicy&& policy) const;
+
+    /**
      * \brief Checks if all bits are set
      * \return True if all bits are set, false otherwise
      */
     bool
     all() const;
+
+    /**
+     * \brief Checks if all bits are set
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if all bits are set, false otherwise
+     */
+    template <typename ExecutionPolicy>
+    bool
+    all(ExecutionPolicy&& policy) const;
 
     /**
      * \brief Checks if any bits are set
@@ -315,11 +364,31 @@ public:
     any() const;
 
     /**
+     * \brief Checks if any bits are set
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if any bits are set, false otherwise
+     */
+    template <typename ExecutionPolicy>
+    bool
+    any(ExecutionPolicy&& policy) const;
+
+    /**
      * \brief Checks if none of the bits are set
      * \return True if none of the bits are set, false otherwise
      */
     bool
     none() const;
+
+    /**
+     * \brief Checks if none of the bits are set
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if none of the bits are set, false otherwise
+     */
+    template <typename ExecutionPolicy>
+    bool
+    none(ExecutionPolicy&& policy) const;
 
 private:
     explicit bitset(const Allocator& allocator) noexcept;

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -245,9 +245,17 @@ template <typename Block, typename Allocator>
 inline void
 bitset<Block, Allocator>::set()
 {
-    fill(execution::device, device_begin(_bit_blocks), device_end(_bit_blocks), ~block_type(0));
+    set(execution::device);
+}
 
-    STDGPU_ENSURES(count() == size());
+template <typename Block, typename Allocator>
+template <typename ExecutionPolicy>
+inline void
+bitset<Block, Allocator>::set(ExecutionPolicy&& policy)
+{
+    fill(std::forward<ExecutionPolicy>(policy), device_begin(_bit_blocks), device_end(_bit_blocks), ~block_type(0));
+
+    STDGPU_ENSURES(count(std::forward<ExecutionPolicy>(policy)) == size());
 }
 
 template <typename Block, typename Allocator>
@@ -264,9 +272,17 @@ template <typename Block, typename Allocator>
 inline void
 bitset<Block, Allocator>::reset()
 {
-    fill(execution::device, device_begin(_bit_blocks), device_end(_bit_blocks), block_type(0));
+    reset(execution::device);
+}
 
-    STDGPU_ENSURES(count() == 0);
+template <typename Block, typename Allocator>
+template <typename ExecutionPolicy>
+inline void
+bitset<Block, Allocator>::reset(ExecutionPolicy&& policy)
+{
+    fill(std::forward<ExecutionPolicy>(policy), device_begin(_bit_blocks), device_end(_bit_blocks), block_type(0));
+
+    STDGPU_ENSURES(count(std::forward<ExecutionPolicy>(policy)) == 0);
 }
 
 template <typename Block, typename Allocator>
@@ -283,7 +299,17 @@ template <typename Block, typename Allocator>
 inline void
 bitset<Block, Allocator>::flip()
 {
-    for_each_index(execution::device, number_bit_blocks(size()), detail::flip_bits<Block>(_bit_blocks));
+    flip(execution::device);
+}
+
+template <typename Block, typename Allocator>
+template <typename ExecutionPolicy>
+inline void
+bitset<Block, Allocator>::flip(ExecutionPolicy&& policy)
+{
+    for_each_index(std::forward<ExecutionPolicy>(policy),
+                   number_bit_blocks(size()),
+                   detail::flip_bits<Block>(_bit_blocks));
 }
 
 template <typename Block, typename Allocator>
@@ -350,12 +376,20 @@ template <typename Block, typename Allocator>
 inline index_t
 bitset<Block, Allocator>::count() const
 {
+    return count(execution::device);
+}
+
+template <typename Block, typename Allocator>
+template <typename ExecutionPolicy>
+inline index_t
+bitset<Block, Allocator>::count(ExecutionPolicy&& policy) const
+{
     if (size() == 0)
     {
         return 0;
     }
 
-    return transform_reduce_index(execution::device,
+    return transform_reduce_index(std::forward<ExecutionPolicy>(policy),
                                   number_bit_blocks(size()),
                                   0,
                                   plus<index_t>(),
@@ -366,36 +400,60 @@ template <typename Block, typename Allocator>
 inline bool
 bitset<Block, Allocator>::all() const
 {
+    return all(execution::device);
+}
+
+template <typename Block, typename Allocator>
+template <typename ExecutionPolicy>
+inline bool
+bitset<Block, Allocator>::all(ExecutionPolicy&& policy) const
+{
     if (size() == 0)
     {
         return false;
     }
 
-    return count() == size();
+    return count(std::forward<ExecutionPolicy>(policy)) == size();
 }
 
 template <typename Block, typename Allocator>
 inline bool
 bitset<Block, Allocator>::any() const
 {
-    if (size() == 0)
-    {
-        return false;
-    }
-
-    return count() > 0;
+    return any(execution::device);
 }
 
 template <typename Block, typename Allocator>
+template <typename ExecutionPolicy>
 inline bool
-bitset<Block, Allocator>::none() const
+bitset<Block, Allocator>::any(ExecutionPolicy&& policy) const
 {
     if (size() == 0)
     {
         return false;
     }
 
-    return count() == 0;
+    return count(std::forward<ExecutionPolicy>(policy)) > 0;
+}
+
+template <typename Block, typename Allocator>
+inline bool
+bitset<Block, Allocator>::none() const
+{
+    return none(execution::device);
+}
+
+template <typename Block, typename Allocator>
+template <typename ExecutionPolicy>
+inline bool
+bitset<Block, Allocator>::none(ExecutionPolicy&& policy) const
+{
+    if (size() == 0)
+    {
+        return false;
+    }
+
+    return count(std::forward<ExecutionPolicy>(policy)) == 0;
 }
 
 } // namespace stdgpu

--- a/test/stdgpu/bitset.inc
+++ b/test/stdgpu/bitset.inc
@@ -314,6 +314,29 @@ TEST_F(stdgpu_bitset, set_all_bits)
     destroyDeviceArray<std::uint8_t>(set);
 }
 
+TEST_F(stdgpu_bitset, set_all_bits_custom_execution_policy)
+{
+    stdgpu::execution::device_policy policy;
+
+    std::uint8_t* set = createDeviceArray<std::uint8_t>(bitset.size());
+
+    bitset.set(policy);
+
+    stdgpu::for_each_index(policy, bitset.size(), read_all_bits(bitset, set));
+
+    ASSERT_EQ(bitset.count(policy), bitset.size());
+
+    std::uint8_t* host_set = copyCreateDevice2HostArray<std::uint8_t>(set, bitset.size());
+
+    for (stdgpu::index_t i = 0; i < bitset.size(); ++i)
+    {
+        EXPECT_TRUE(static_cast<bool>(host_set[i]));
+    }
+
+    destroyHostArray<std::uint8_t>(host_set);
+    destroyDeviceArray<std::uint8_t>(set);
+}
+
 TEST_F(stdgpu_bitset, reset_all_bits)
 {
     std::uint8_t* set = createDeviceArray<std::uint8_t>(bitset.size());
@@ -327,6 +350,33 @@ TEST_F(stdgpu_bitset, reset_all_bits)
     stdgpu::for_each_index(stdgpu::execution::device, bitset.size(), read_all_bits(bitset, set));
 
     ASSERT_EQ(bitset.count(), 0);
+
+    std::uint8_t* host_set = copyCreateDevice2HostArray<std::uint8_t>(set, bitset.size());
+
+    for (stdgpu::index_t i = 0; i < bitset.size(); ++i)
+    {
+        EXPECT_FALSE(static_cast<bool>(host_set[i]));
+    }
+
+    destroyHostArray<std::uint8_t>(host_set);
+    destroyDeviceArray<std::uint8_t>(set);
+}
+
+TEST_F(stdgpu_bitset, reset_all_bits_custom_execution_policy)
+{
+    stdgpu::execution::device_policy policy;
+
+    std::uint8_t* set = createDeviceArray<std::uint8_t>(bitset.size());
+
+    bitset.set(policy);
+
+    ASSERT_EQ(bitset.count(policy), bitset.size());
+
+    bitset.reset(policy);
+
+    stdgpu::for_each_index(policy, bitset.size(), read_all_bits(bitset, set));
+
+    ASSERT_EQ(bitset.count(policy), 0);
 
     std::uint8_t* host_set = copyCreateDevice2HostArray<std::uint8_t>(set, bitset.size());
 
@@ -363,6 +413,32 @@ TEST_F(stdgpu_bitset, flip_all_bits_previously_reset)
     destroyDeviceArray<std::uint8_t>(set);
 }
 
+TEST_F(stdgpu_bitset, flip_all_bits_previously_reset_custom_execution_policy)
+{
+    stdgpu::execution::device_policy policy;
+
+    std::uint8_t* set = createDeviceArray<std::uint8_t>(bitset.size());
+
+    // Previously reset
+    bitset.reset(policy);
+
+    bitset.flip(policy);
+
+    stdgpu::for_each_index(policy, bitset.size(), read_all_bits(bitset, set));
+
+    ASSERT_EQ(bitset.count(policy), bitset.size());
+
+    std::uint8_t* host_set = copyCreateDevice2HostArray<std::uint8_t>(set, bitset.size());
+
+    for (stdgpu::index_t i = 0; i < bitset.size(); ++i)
+    {
+        EXPECT_TRUE(static_cast<bool>(host_set[i]));
+    }
+
+    destroyHostArray<std::uint8_t>(host_set);
+    destroyDeviceArray<std::uint8_t>(set);
+}
+
 TEST_F(stdgpu_bitset, flip_all_bits_previously_set)
 {
     std::uint8_t* set = createDeviceArray<std::uint8_t>(bitset.size());
@@ -373,6 +449,30 @@ TEST_F(stdgpu_bitset, flip_all_bits_previously_set)
     bitset.flip();
 
     ASSERT_EQ(bitset.count(), 0);
+
+    std::uint8_t* host_set = copyCreateDevice2HostArray<std::uint8_t>(set, bitset.size());
+
+    for (stdgpu::index_t i = 0; i < bitset.size(); ++i)
+    {
+        EXPECT_FALSE(static_cast<bool>(host_set[i]));
+    }
+
+    destroyHostArray<std::uint8_t>(host_set);
+    destroyDeviceArray<std::uint8_t>(set);
+}
+
+TEST_F(stdgpu_bitset, flip_all_bits_previously_set_custom_execution_policy)
+{
+    stdgpu::execution::device_policy policy;
+
+    std::uint8_t* set = createDeviceArray<std::uint8_t>(bitset.size());
+
+    // Previously set
+    bitset.set(policy);
+
+    bitset.flip(policy);
+
+    ASSERT_EQ(bitset.count(policy), 0);
 
     std::uint8_t* host_set = copyCreateDevice2HostArray<std::uint8_t>(set, bitset.size());
 


### PR DESCRIPTION
Whereas the containers operate in a sequential order and, hence, do not need custom execution policies, this lack of support becomes problematic for our GPU counterparts where aspects like controlling kernel synchronization play an important role. Add support for custom execution policies to all host functions of `bitset` running GPU kernels to allow greater control by the user.

Partially addresses #351 