### PR TITLE
mutex: Add support for custom execution policies

### DIFF
--- a/src/stdgpu/impl/mutex_detail.cuh
+++ b/src/stdgpu/impl/mutex_detail.cuh
@@ -136,7 +136,15 @@ template <typename Block, typename Allocator>
 inline bool
 mutex_array<Block, Allocator>::valid() const
 {
-    return _lock_bits.count() == 0;
+    return valid(execution::device);
+}
+
+template <typename Block, typename Allocator>
+template <typename ExecutionPolicy>
+inline bool
+mutex_array<Block, Allocator>::valid(ExecutionPolicy&& policy) const
+{
+    return _lock_bits.count(std::forward<ExecutionPolicy>(policy)) == 0;
 }
 
 namespace detail

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -189,6 +189,16 @@ public:
     bool
     valid() const;
 
+    /**
+     * \brief Checks if the object is in valid state
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if the state is valid, false otherwise
+     */
+    template <typename ExecutionPolicy>
+    bool
+    valid(ExecutionPolicy&& policy) const;
+
 private:
     explicit mutex_array(const bitset<Block, Allocator>& lock_bits);
 


### PR DESCRIPTION
Whereas the containers operate in a sequential order and, hence, do not need custom execution policies, this lack of support becomes problematic for our GPU counterparts where aspects like controlling kernel synchronization play an important role. Add support for custom execution policies to all host functions of `mutex` running GPU kernels to allow greater control by the user.

Partially addresses https://github.com/stotko/stdgpu/issues/351