### PR TITLE
deque: Add support for custom execution policies

### DIFF
--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -298,11 +298,30 @@ public:
     clear();
 
     /**
+     * \brief Clears the complete object
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     */
+    template <typename ExecutionPolicy>
+    void
+    clear(ExecutionPolicy&& policy);
+
+    /**
      * \brief Checks if the object is in a valid state
      * \return True if the state is valid, false otherwise
      */
     bool
     valid() const;
+
+    /**
+     * \brief Checks if the object is in a valid state
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if the state is valid, false otherwise
+     */
+    template <typename ExecutionPolicy>
+    bool
+    valid(ExecutionPolicy&& policy) const;
 
     /**
      * \brief Creates a range of the device container
@@ -313,17 +332,38 @@ public:
 
     /**
      * \brief Creates a range of the device container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return A range of the object
+     */
+    template <typename ExecutionPolicy>
+    stdgpu::device_indexed_range<T>
+    device_range(ExecutionPolicy&& policy);
+
+    /**
+     * \brief Creates a range of the device container
      * \return A const range of the object
      */
     stdgpu::device_indexed_range<const T>
     device_range() const;
 
+    /**
+     * \brief Creates a range of the device container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return A const range of the object
+     */
+    template <typename ExecutionPolicy>
+    stdgpu::device_indexed_range<const T>
+    device_range(ExecutionPolicy&& policy) const;
+
 private:
     STDGPU_DEVICE_ONLY bool
     occupied(const index_t n) const;
 
+    template <typename ExecutionPolicy>
     bool
-    occupied_count_valid() const;
+    occupied_count_valid(ExecutionPolicy&& policy) const;
 
     bool
     size_valid() const;

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -1341,6 +1341,26 @@ TEST_F(stdgpu_deque, clear)
     stdgpu::deque<int>::destroyDeviceObject(pool);
 }
 
+TEST_F(stdgpu_deque, clear_custom_execution_policy)
+{
+    stdgpu::execution::device_policy policy;
+
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N + 1);
+
+    fill_deque(pool, N);
+
+    pool.clear(policy);
+
+    ASSERT_EQ(pool.size(), 0);
+    ASSERT_TRUE(pool.empty());
+    ASSERT_FALSE(pool.full());
+    ASSERT_TRUE(pool.valid());
+
+    stdgpu::deque<int>::destroyDeviceObject(pool);
+}
+
 TEST_F(stdgpu_deque, clear_full)
 {
     const stdgpu::index_t N = 10000;
@@ -2360,6 +2380,38 @@ TEST_F(stdgpu_deque, non_const_device_range)
     stdgpu::deque<int>::destroyDeviceObject(pool);
 }
 
+TEST_F(stdgpu_deque, non_const_device_range_execution_policy)
+{
+    stdgpu::execution::device_policy policy;
+
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N + 1);
+
+    fill_deque(pool, N);
+
+    ASSERT_EQ(pool.size(), N);
+    ASSERT_EQ(pool.capacity(), N + 1);
+    ASSERT_TRUE(pool.valid());
+
+    int* numbers = createDeviceArray<int>(N);
+
+    auto range = pool.device_range(policy);
+    stdgpu::copy(policy, range.begin(), range.end(), stdgpu::device_begin(numbers));
+
+    int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(host_numbers[i], static_cast<int>(i + 1));
+    }
+
+    destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(numbers);
+    stdgpu::deque<int>::destroyDeviceObject(pool);
+}
+
 TEST_F(stdgpu_deque, non_const_device_range_full)
 {
     const stdgpu::index_t N = 10000;
@@ -2445,6 +2497,38 @@ TEST_F(stdgpu_deque, const_device_range)
 
     auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range();
     stdgpu::copy(stdgpu::execution::device, range.begin(), range.end(), stdgpu::device_begin(numbers));
+
+    int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
+    std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(host_numbers[i], static_cast<int>(i + 1));
+    }
+
+    destroyHostArray<int>(host_numbers);
+    destroyDeviceArray<int>(numbers);
+    stdgpu::deque<int>::destroyDeviceObject(pool);
+}
+
+TEST_F(stdgpu_deque, const_device_range_execution_policy)
+{
+    stdgpu::execution::device_policy policy;
+
+    const stdgpu::index_t N = 10000;
+
+    stdgpu::deque<int> pool = stdgpu::deque<int>::createDeviceObject(N + 1);
+
+    fill_deque(pool, N);
+
+    ASSERT_EQ(pool.size(), N);
+    ASSERT_EQ(pool.capacity(), N + 1);
+    ASSERT_TRUE(pool.valid());
+
+    int* numbers = createDeviceArray<int>(N);
+
+    auto range = static_cast<const stdgpu::deque<int>&>(pool).device_range(policy);
+    stdgpu::copy(policy, range.begin(), range.end(), stdgpu::device_begin(numbers));
 
     int* host_numbers = copyCreateDevice2HostArray<int>(numbers, N);
     std::sort(stdgpu::host_begin(host_numbers).get(), stdgpu::host_end(host_numbers).get());


### PR DESCRIPTION
Whereas the containers operate in a sequential order and, hence, do not need custom execution policies, this lack of support becomes problematic for our GPU counterparts where aspects like controlling kernel synchronization play an important role. Add support for custom execution policies to all host functions of `deque` running GPU kernels to allow greater control by the user.

Partially addresses https://github.com/stotko/stdgpu/issues/351