### PR TITLE
unordered_map,unordered_set: Add support for custom execution policies

### DIFF
--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -116,6 +116,16 @@ public:
     valid() const;
 
     /**
+     * \brief Checks if the object is valid
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if the state is valid, false otherwise
+     */
+    template <typename ExecutionPolicy>
+    bool
+    valid(ExecutionPolicy&& policy) const;
+
+    /**
      * \brief An iterator to the begin of the internal value array
      * \return An iterator to the begin of the object
      */
@@ -163,6 +173,16 @@ public:
      */
     device_indexed_range<const value_type>
     device_range() const;
+
+    /**
+     * \brief Builds a range to the values in the container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return A range of the container
+     */
+    template <typename ExecutionPolicy>
+    device_indexed_range<const value_type>
+    device_range(ExecutionPolicy&& policy) const;
 
     /**
      * \brief Returns the bucket to which the given key is mapped
@@ -297,6 +317,19 @@ public:
     insert(ValueIterator begin, ValueIterator end);
 
     /**
+     * \brief Inserts the given range of elements into the container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] begin The begin of the range
+     * \param[in] end The end of the range
+     */
+    template <typename ExecutionPolicy,
+              typename ValueIterator,
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<ValueIterator>)>
+    void
+    insert(ExecutionPolicy&& policy, ValueIterator begin, ValueIterator end);
+
+    /**
      * \brief Deletes the value with the given key from the container
      * \param[in] key The key
      * \return 1 if there was a value with key and it got erased, 0 otherwise
@@ -314,10 +347,32 @@ public:
     erase(KeyIterator begin, KeyIterator end);
 
     /**
+     * \brief Deletes the values with the given range of keys from the container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] begin The begin of the range
+     * \param[in] end The end of the range
+     */
+    template <typename ExecutionPolicy,
+              typename KeyIterator,
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<KeyIterator>)>
+    void
+    erase(ExecutionPolicy&& policy, KeyIterator begin, KeyIterator end);
+
+    /**
      * \brief Clears the complete object
      */
     void
     clear();
+
+    /**
+     * \brief Clears the complete object
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     */
+    template <typename ExecutionPolicy>
+    void
+    clear(ExecutionPolicy&& policy);
 
     /**
      * \brief Checks if the object is empty

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -97,6 +97,14 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::device_range() const
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy>
+device_indexed_range<const typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::value_type>
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::device_range(ExecutionPolicy&& policy) const
+{
+    return _base.device_range(std::forward<ExecutionPolicy>(policy));
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_HOST_DEVICE typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::index_type
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::bucket(const key_type& key) const
 {
@@ -199,6 +207,18 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::insert(ValueIterator begin, Va
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          typename ValueIterator,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<ValueIterator>)>
+inline void
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::insert(ExecutionPolicy&& policy,
+                                                         ValueIterator begin,
+                                                         ValueIterator end)
+{
+    _base.insert(std::forward<ExecutionPolicy>(policy), begin, end);
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::index_type
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::erase(
         const unordered_map<Key, T, Hash, KeyEqual, Allocator>::key_type& key)
@@ -212,6 +232,16 @@ inline void
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::erase(KeyIterator begin, KeyIterator end)
 {
     _base.erase(begin, end);
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          typename KeyIterator,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<KeyIterator>)>
+inline void
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::erase(ExecutionPolicy&& policy, KeyIterator begin, KeyIterator end)
+{
+    _base.erase(std::forward<ExecutionPolicy>(policy), begin, end);
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
@@ -285,10 +315,26 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::valid() const
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy>
+bool
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::valid(ExecutionPolicy&& policy) const
+{
+    return _base.valid(std::forward<ExecutionPolicy>(policy));
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 void
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::clear()
 {
     _base.clear();
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy>
+void
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::clear(ExecutionPolicy&& policy)
+{
+    _base.clear(std::forward<ExecutionPolicy>(policy));
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -82,6 +82,14 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::device_range() const
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy>
+device_indexed_range<const typename unordered_set<Key, Hash, KeyEqual, Allocator>::value_type>
+unordered_set<Key, Hash, KeyEqual, Allocator>::device_range(ExecutionPolicy&& policy) const
+{
+    return _base.device_range(std::forward<ExecutionPolicy>(policy));
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_HOST_DEVICE typename unordered_set<Key, Hash, KeyEqual, Allocator>::index_type
 unordered_set<Key, Hash, KeyEqual, Allocator>::bucket(const key_type& key) const
 {
@@ -184,6 +192,16 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::insert(ValueIterator begin, Value
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          typename ValueIterator,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<ValueIterator>)>
+inline void
+unordered_set<Key, Hash, KeyEqual, Allocator>::insert(ExecutionPolicy&& policy, ValueIterator begin, ValueIterator end)
+{
+    _base.insert(std::forward<ExecutionPolicy>(policy), begin, end);
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_DEVICE_ONLY typename unordered_set<Key, Hash, KeyEqual, Allocator>::index_type
 unordered_set<Key, Hash, KeyEqual, Allocator>::erase(const unordered_set<Key, Hash, KeyEqual, Allocator>::key_type& key)
 {
@@ -196,6 +214,16 @@ inline void
 unordered_set<Key, Hash, KeyEqual, Allocator>::erase(KeyIterator begin, KeyIterator end)
 {
     _base.erase(begin, end);
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          typename KeyIterator,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<KeyIterator>)>
+inline void
+unordered_set<Key, Hash, KeyEqual, Allocator>::erase(ExecutionPolicy&& policy, KeyIterator begin, KeyIterator end)
+{
+    _base.erase(std::forward<ExecutionPolicy>(policy), begin, end);
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
@@ -269,10 +297,26 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::valid() const
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy>
+bool
+unordered_set<Key, Hash, KeyEqual, Allocator>::valid(ExecutionPolicy&& policy) const
+{
+    return _base.valid(std::forward<ExecutionPolicy>(policy));
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 void
 unordered_set<Key, Hash, KeyEqual, Allocator>::clear()
 {
     _base.clear();
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy>
+void
+unordered_set<Key, Hash, KeyEqual, Allocator>::clear(ExecutionPolicy&& policy)
+{
+    _base.clear(std::forward<ExecutionPolicy>(policy));
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -152,6 +152,16 @@ public:
     valid() const;
 
     /**
+     * \brief Checks if the object is valid
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if the state is valid, false otherwise
+     */
+    template <typename ExecutionPolicy>
+    bool
+    valid(ExecutionPolicy&& policy) const;
+
+    /**
      * \brief An iterator to the begin of the internal value array
      * \return An iterator to the begin of the object
      */
@@ -199,6 +209,16 @@ public:
      */
     device_indexed_range<const value_type>
     device_range() const;
+
+    /**
+     * \brief Builds a range to the values in the container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return A range of the container
+     */
+    template <typename ExecutionPolicy>
+    device_indexed_range<const value_type>
+    device_range(ExecutionPolicy&& policy) const;
 
     /**
      * \brief Returns the bucket to which the given key is mapped
@@ -316,6 +336,19 @@ public:
     insert(ValueIterator begin, ValueIterator end);
 
     /**
+     * \brief Inserts the given range of elements into the container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] begin The begin of the range
+     * \param[in] end The end of the range
+     */
+    template <typename ExecutionPolicy,
+              typename ValueIterator,
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<ValueIterator>)>
+    void
+    insert(ExecutionPolicy&& policy, ValueIterator begin, ValueIterator end);
+
+    /**
      * \brief Deletes the value with the given key from the container
      * \param[in] key The key
      * \return 1 if there was a value with key and it got erased, 0 otherwise
@@ -333,10 +366,32 @@ public:
     erase(KeyIterator begin, KeyIterator end);
 
     /**
+     * \brief Deletes the values with the given range of keys from the container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] begin The begin of the range
+     * \param[in] end The end of the range
+     */
+    template <typename ExecutionPolicy,
+              typename KeyIterator,
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<KeyIterator>)>
+    void
+    erase(ExecutionPolicy&& policy, KeyIterator begin, KeyIterator end);
+
+    /**
      * \brief Clears the complete object
      */
     void
     clear();
+
+    /**
+     * \brief Clears the complete object
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     */
+    template <typename ExecutionPolicy>
+    void
+    clear(ExecutionPolicy&& policy);
 
     /**
      * \brief Checks if the object is empty

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -141,6 +141,16 @@ public:
     valid() const;
 
     /**
+     * \brief Checks if the object is valid
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if the state is valid, false otherwise
+     */
+    template <typename ExecutionPolicy>
+    bool
+    valid(ExecutionPolicy&& policy) const;
+
+    /**
      * \brief An iterator to the begin of the internal value array
      * \return An iterator to the begin of the object
      */
@@ -188,6 +198,16 @@ public:
      */
     device_indexed_range<const value_type>
     device_range() const;
+
+    /**
+     * \brief Builds a range to the values in the container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return A range of the container
+     */
+    template <typename ExecutionPolicy>
+    device_indexed_range<const value_type>
+    device_range(ExecutionPolicy&& policy) const;
 
     /**
      * \brief Returns the bucket to which the given key is mapped
@@ -297,6 +317,19 @@ public:
 
     /**
      * \brief Inserts the given range of elements into the container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] begin The begin of the range
+     * \param[in] end The end of the range
+     */
+    template <typename ExecutionPolicy,
+              typename ValueIterator,
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<ValueIterator>)>
+    void
+    insert(ExecutionPolicy&& policy, ValueIterator begin, ValueIterator end);
+
+    /**
+     * \brief Inserts the given range of elements into the container
      * \param[in] begin The begin of the range
      * \param[in] end The end of the range
      */
@@ -322,10 +355,32 @@ public:
     erase(KeyIterator begin, KeyIterator end);
 
     /**
+     * \brief Deletes the values with the given range of keys from the container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \param[in] begin The begin of the range
+     * \param[in] end The end of the range
+     */
+    template <typename ExecutionPolicy,
+              typename KeyIterator,
+              STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<KeyIterator>)>
+    void
+    erase(ExecutionPolicy&& policy, KeyIterator begin, KeyIterator end);
+
+    /**
      * \brief Clears the complete object
      */
     void
     clear();
+
+    /**
+     * \brief Clears the complete object
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     */
+    template <typename ExecutionPolicy>
+    void
+    clear(ExecutionPolicy&& policy);
 
     /**
      * \brief Checks if the object is empty

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -1908,6 +1908,32 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_range_unique_parallel)
     destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
 }
 
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_range_unique_parallel_custom_execution_policy)
+{
+    stdgpu::execution::device_policy policy;
+
+    const stdgpu::index_t N = 100000;
+
+    test_unordered_datastructure::key_type* host_positions = create_unique_random_host_keys(N);
+    test_unordered_datastructure::key_type* positions =
+            copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
+    test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
+
+    stdgpu::for_each_index(stdgpu::execution::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
+
+    stdgpu::device_ptr<test_unordered_datastructure::value_type> values_begin = stdgpu::device_begin(values);
+    stdgpu::device_ptr<test_unordered_datastructure::value_type> values_end = stdgpu::device_end(values);
+    hash_datastructure.insert(policy, values_begin, values_end);
+
+    EXPECT_FALSE(hash_datastructure.empty());
+    EXPECT_EQ(hash_datastructure.size(), N);
+    EXPECT_TRUE(hash_datastructure.valid(policy));
+
+    destroyDeviceArray<test_unordered_datastructure::value_type>(values);
+    destroyDeviceArray<test_unordered_datastructure::key_type>(positions);
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
+}
+
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_const_range_unique_parallel)
 {
     const stdgpu::index_t N = 100000;
@@ -1958,6 +1984,40 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_range_unique_parallel)
     EXPECT_TRUE(hash_datastructure.empty());
     EXPECT_EQ(hash_datastructure.size(), 0);
     EXPECT_TRUE(hash_datastructure.valid());
+
+    destroyDeviceArray<test_unordered_datastructure::value_type>(values);
+    destroyDeviceArray<test_unordered_datastructure::key_type>(positions);
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
+}
+
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_range_unique_parallel_custom_execution_policy)
+{
+    stdgpu::execution::device_policy policy;
+
+    const stdgpu::index_t N = 100000;
+
+    test_unordered_datastructure::key_type* host_positions = create_unique_random_host_keys(N);
+    test_unordered_datastructure::key_type* positions =
+            copyCreateHost2DeviceArray<test_unordered_datastructure::key_type>(host_positions, N);
+    test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
+
+    stdgpu::for_each_index(stdgpu::execution::device, N, Key2ValueFunctor(hash_datastructure, positions, values));
+
+    stdgpu::device_ptr<test_unordered_datastructure::value_type> values_begin = stdgpu::device_begin(values);
+    stdgpu::device_ptr<test_unordered_datastructure::value_type> values_end = stdgpu::device_end(values);
+    hash_datastructure.insert(policy, values_begin, values_end);
+
+    EXPECT_FALSE(hash_datastructure.empty());
+    EXPECT_EQ(hash_datastructure.size(), N);
+    EXPECT_TRUE(hash_datastructure.valid());
+
+    stdgpu::device_ptr<test_unordered_datastructure::key_type> positions_begin = stdgpu::device_begin(positions);
+    stdgpu::device_ptr<test_unordered_datastructure::key_type> positions_end = stdgpu::device_end(positions);
+    hash_datastructure.erase(policy, positions_begin, positions_end);
+
+    EXPECT_TRUE(hash_datastructure.empty());
+    EXPECT_EQ(hash_datastructure.size(), 0);
+    EXPECT_TRUE(hash_datastructure.valid(policy));
 
     destroyDeviceArray<test_unordered_datastructure::value_type>(values);
     destroyDeviceArray<test_unordered_datastructure::key_type>(positions);
@@ -2248,6 +2308,44 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_keys_same)
     destroyDeviceArray<test_unordered_datastructure::value_type>(values);
 }
 
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_keys_same_custom_execution_policy)
+{
+    stdgpu::execution::device_policy policy;
+
+    const stdgpu::index_t N = 100000;
+
+    test_unordered_datastructure::key_type* host_positions = insert_unique_parallel(hash_datastructure, N);
+
+    test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
+
+    auto range = hash_datastructure.device_range(policy);
+    // unordered_map's value_type cannot be copied using copy(), so use uninitialized_copy() instead
+    stdgpu::uninitialized_copy(stdgpu::execution::device, range.begin(), range.end(), values);
+
+    test_unordered_datastructure::value_type* host_values =
+            copyCreateDevice2HostArray<test_unordered_datastructure::value_type>(values, N);
+    test_unordered_datastructure::key_type* host_positions_copied =
+            createHostArray<test_unordered_datastructure::key_type>(N);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        host_positions_copied[i] = STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(host_values[i]);
+    }
+
+    std::sort(host_positions, host_positions + N, less());
+    std::sort(host_positions_copied, host_positions_copied + N, less());
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(host_positions[i], host_positions_copied[i]);
+    }
+
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions_copied);
+    destroyHostArray<test_unordered_datastructure::value_type>(host_values);
+    destroyDeviceArray<test_unordered_datastructure::value_type>(values);
+}
+
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, clear_empty)
 {
     EXPECT_EQ(hash_datastructure.size(), 0);
@@ -2288,6 +2386,22 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, clear)
 
     EXPECT_EQ(hash_datastructure.size(), 0);
     EXPECT_TRUE(hash_datastructure.valid());
+
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
+}
+
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, clear_custom_execution_policy)
+{
+    stdgpu::execution::device_policy policy;
+
+    const stdgpu::index_t N = 100000;
+
+    test_unordered_datastructure::key_type* host_positions = insert_unique_parallel(hash_datastructure, N);
+
+    hash_datastructure.clear(policy);
+
+    EXPECT_EQ(hash_datastructure.size(), 0);
+    EXPECT_TRUE(hash_datastructure.valid(policy));
 
     destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
 }


### PR DESCRIPTION
Whereas the containers operate in a sequential order and, hence, do not need custom execution policies, this lack of support becomes problematic for our GPU counterparts where aspects like controlling kernel synchronization play an important role. Add support for custom execution policies to all host functions of `unordered_map` and `unordered_set` running GPU kernels to allow greater control by the user.

Partially addresses https://github.com/stotko/stdgpu/issues/351