### PR TITLE
memory: Remove allocator_traits specialization detection

### DIFF
--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -73,7 +73,7 @@ template <typename ExecutionPolicy>
 void
 deque<T, Allocator>::destroyDeviceObject(ExecutionPolicy&& policy, deque<T, Allocator>& device_object)
 {
-    if (!detail::is_allocator_destroy_optimizable<value_type, allocator_type>())
+    if (!detail::is_destroy_optimizable<value_type>())
     {
         device_object.clear();
     }
@@ -503,7 +503,7 @@ deque<T, Allocator>::clear(ExecutionPolicy&& policy)
         return;
     }
 
-    if (!detail::is_allocator_destroy_optimizable<value_type, allocator_type>())
+    if (!detail::is_destroy_optimizable<value_type>())
     {
         const index_t begin = static_cast<index_t>(_begin.load());
         const index_t end = static_cast<index_t>(_end.load());

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -32,23 +32,10 @@ namespace stdgpu::detail
 {
 
 template <typename T>
-struct allocator_traits_base
-{
-    using is_base = void;
-};
-
-template <typename T>
 bool
 is_destroy_optimizable()
 {
     return std::is_trivially_destructible_v<T>;
-}
-
-template <typename T, typename Allocator>
-bool
-is_allocator_destroy_optimizable()
-{
-    return std::is_trivially_destructible_v<T> && detail::is_base_v<allocator_traits<Allocator>>;
 }
 
 [[nodiscard]] void*
@@ -574,7 +561,7 @@ allocator_traits<Allocator>::deallocate_filled(ExecutionPolicy&& policy,
                                                typename allocator_traits<Allocator>::pointer p,
                                                typename allocator_traits<Allocator>::index_type n)
 {
-    if (!detail::is_allocator_destroy_optimizable<value_type, allocator_type>())
+    if (!detail::is_destroy_optimizable<value_type>())
     {
         stdgpu::destroy(std::forward<ExecutionPolicy>(policy), p, p + size(p));
     }

--- a/src/stdgpu/impl/type_traits.h
+++ b/src/stdgpu/impl/type_traits.h
@@ -63,8 +63,6 @@ STDGPU_DETAIL_DEFINE_TRAIT(is_iterator,
 
 STDGPU_DETAIL_DEFINE_TRAIT(is_transparent, typename T::is_transparent)
 
-STDGPU_DETAIL_DEFINE_TRAIT(is_base, typename T::is_base)
-
 STDGPU_DETAIL_DEFINE_TRAIT(has_get, decltype(std::declval<T>().get()))
 STDGPU_DETAIL_DEFINE_TRAIT(has_arrow_operator,
                            decltype(std::declval<T>()

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -1056,7 +1056,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::clear()
         return;
     }
 
-    if (!detail::is_allocator_destroy_optimizable<Value, allocator_type>())
+    if (!detail::is_destroy_optimizable<Value>())
     {
         for_each_index(execution::device,
                        total_count(),
@@ -1133,7 +1133,7 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::destroyDevi
         ExecutionPolicy&& policy,
         unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>& device_object)
 {
-    if (!detail::is_allocator_destroy_optimizable<value_type, allocator_type>())
+    if (!detail::is_destroy_optimizable<value_type>())
     {
         device_object.clear();
     }

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -69,7 +69,7 @@ template <typename ExecutionPolicy>
 void
 vector<T, Allocator>::destroyDeviceObject(ExecutionPolicy&& policy, vector<T, Allocator>& device_object)
 {
-    if (!detail::is_allocator_destroy_optimizable<value_type, allocator_type>())
+    if (!detail::is_destroy_optimizable<value_type>())
     {
         device_object.clear();
     }
@@ -520,7 +520,7 @@ vector<T, Allocator>::clear(ExecutionPolicy&& policy)
         return;
     }
 
-    if (!detail::is_allocator_destroy_optimizable<value_type, allocator_type>())
+    if (!detail::is_destroy_optimizable<value_type>())
     {
         const index_t current_size = size();
 

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -509,14 +509,6 @@ struct safe_managed_allocator
     deallocate(T* p, index64_t n);
 };
 
-namespace detail
-{
-
-template <typename T>
-struct allocator_traits_base;
-
-} // namespace detail
-
 /**
  * \ingroup memory
  * \brief A general allocator traitor
@@ -526,7 +518,7 @@ struct allocator_traits_base;
  *  - index_type instead of size_type
  */
 template <typename Allocator>
-struct allocator_traits : public detail::allocator_traits_base<Allocator>
+struct allocator_traits
 {
     using allocator_type = Allocator;                  /**< Allocator */
     using value_type = typename Allocator::value_type; /**< Allocator::value_type */


### PR DESCRIPTION
In order to safely skip calling `destroy` on trivial types, the `allocator_traits` class is also checked for specializations where the behavior of the `construct` and `destroy` functions could potentially be changed in an arbitrary and unpredictable way. As of C++23, such specializations have been forbidden. Thus, remove the check to reduce the maintenance burden.