### PR TITLE
execution: Add is_execution_policy trait and conditionally enable policy-based functions

### DIFF
--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -30,6 +30,7 @@
 #include <cstddef>
 #include <type_traits>
 
+#include <stdgpu/execution.h>
 #include <stdgpu/impl/type_traits.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
@@ -123,7 +124,7 @@ public:
      * \note The size is implicitly set to 1 (and not needed as a parameter) as the object only manages a single value
      */
     template <typename ExecutionPolicy,
-              STDGPU_DETAIL_OVERLOAD_IF(!std::is_same_v<std::remove_reference_t<ExecutionPolicy>, Allocator>)>
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static atomic
     createDeviceObject(ExecutionPolicy&& policy, const Allocator& allocator = Allocator());
 
@@ -140,7 +141,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \param[in] device_object The object allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static void
     destroyDeviceObject(ExecutionPolicy&& policy, atomic& device_object);
 

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -31,6 +31,7 @@
 #include <type_traits>
 
 #include <stdgpu/cstddef.h>
+#include <stdgpu/execution.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
 
@@ -171,7 +172,8 @@ public:
      * \param[in] allocator The allocator instance to use
      * \return A newly created object of this class allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static bitset
     createDeviceObject(ExecutionPolicy&& policy, const index_t& size, const Allocator& allocator = Allocator());
 
@@ -188,7 +190,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \param[in] device_object The object allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static void
     destroyDeviceObject(ExecutionPolicy&& policy, bitset& device_object);
 
@@ -210,7 +213,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \post count() == size()
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     void
     set(ExecutionPolicy&& policy);
 
@@ -244,7 +248,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \post count() == 0
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     void
     reset(ExecutionPolicy&& policy);
 
@@ -268,7 +273,8 @@ public:
      * \tparam ExecutionPolicy The type of the execution policy
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     void
     flip(ExecutionPolicy&& policy);
 
@@ -335,7 +341,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return The number of set bits
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     index_t
     count(ExecutionPolicy&& policy) const;
 
@@ -352,7 +359,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return True if all bits are set, false otherwise
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     bool
     all(ExecutionPolicy&& policy) const;
 
@@ -369,7 +377,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return True if any bits are set, false otherwise
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     bool
     any(ExecutionPolicy&& policy) const;
 
@@ -386,7 +395,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return True if none of the bits are set, false otherwise
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     bool
     none(ExecutionPolicy&& policy) const;
 

--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -30,6 +30,7 @@
 #include <stdgpu/atomic.cuh>
 #include <stdgpu/bitset.cuh>
 #include <stdgpu/cstddef.h>
+#include <stdgpu/execution.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/mutex.cuh>
@@ -90,7 +91,8 @@ public:
      * \param[in] allocator The allocator instance to use
      * \return A newly created object of this class allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static deque<T, Allocator>
     createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator = Allocator());
 
@@ -107,7 +109,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \param[in] device_object The object allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static void
     destroyDeviceObject(ExecutionPolicy&& policy, deque<T, Allocator>& device_object);
 
@@ -302,7 +305,8 @@ public:
      * \tparam ExecutionPolicy The type of the execution policy
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     void
     clear(ExecutionPolicy&& policy);
 
@@ -319,7 +323,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return True if the state is valid, false otherwise
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     bool
     valid(ExecutionPolicy&& policy) const;
 
@@ -336,7 +341,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return A range of the object
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     stdgpu::device_indexed_range<T>
     device_range(ExecutionPolicy&& policy);
 
@@ -353,7 +359,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return A const range of the object
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     stdgpu::device_indexed_range<const T>
     device_range(ExecutionPolicy&& policy) const;
 
@@ -361,7 +368,8 @@ private:
     STDGPU_DEVICE_ONLY bool
     occupied(const index_t n) const;
 
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     bool
     occupied_count_valid(ExecutionPolicy&& policy) const;
 

--- a/src/stdgpu/execution.h
+++ b/src/stdgpu/execution.h
@@ -23,14 +23,42 @@
 
 #include <type_traits>
 
+#include <stdgpu/impl/type_traits.h>
+
 /**
  * \file stdgpu/execution.h
  */
 
 #include <thrust/execution_policy.h>
 
+namespace stdgpu
+{
+
+/**
+ * \ingroup execution
+ * \brief Type traits to check whether the provided class is an execution policy
+ */
+template <typename T>
+struct is_execution_policy : std::is_base_of<thrust::execution_policy<T>, T>
+{
+};
+
+//! @cond Doxygen_Suppress
+template <typename T>
+inline constexpr bool is_execution_policy_v = is_execution_policy<T>::value;
+//! @endcond
+
+} // namespace stdgpu
+
 namespace stdgpu::execution
 {
+
+/**
+ * \ingroup execution
+ * \brief The base execution policy class from which all policies are derived and custom ones must be derived
+ */
+template <typename T>
+using execution_policy = thrust::execution_policy<T>;
 
 /**
  * \ingroup execution
@@ -38,11 +66,17 @@ namespace stdgpu::execution
  */
 using device_policy = std::remove_const_t<decltype(thrust::device)>;
 
+static_assert(is_execution_policy_v<remove_cvref_t<device_policy>>,
+              "stdgpu::execution::device_policy: Should be an execution policy but is not");
+
 /**
  * \ingroup execution
  * \brief The host execution policy class
  */
 using host_policy = std::remove_const_t<decltype(thrust::host)>;
+
+static_assert(is_execution_policy_v<remove_cvref_t<host_policy>>,
+              "stdgpu::execution::host_policy: Should be an execution policy but is not");
 
 /**
  * \ingroup execution

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -138,7 +138,7 @@ atomic<T, Allocator>::createDeviceObject(const Allocator& allocator)
 
 template <typename T, typename Allocator>
 template <typename ExecutionPolicy,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(!std::is_same_v<std::remove_reference_t<ExecutionPolicy>, Allocator>)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline atomic<T, Allocator>
 atomic<T, Allocator>::createDeviceObject(ExecutionPolicy&& policy, const Allocator& allocator)
 {
@@ -159,7 +159,8 @@ atomic<T, Allocator>::destroyDeviceObject(atomic<T, Allocator>& device_object)
 }
 
 template <typename T, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline void
 atomic<T, Allocator>::destroyDeviceObject(ExecutionPolicy&& policy, atomic<T, Allocator>& device_object)
 {

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -187,7 +187,8 @@ bitset<Block, Allocator>::createDeviceObject(const index_t& size, const Allocato
 }
 
 template <typename Block, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline bitset<Block, Allocator>
 bitset<Block, Allocator>::createDeviceObject(ExecutionPolicy&& policy, const index_t& size, const Allocator& allocator)
 {
@@ -209,7 +210,8 @@ bitset<Block, Allocator>::destroyDeviceObject(bitset<Block, Allocator>& device_o
 }
 
 template <typename Block, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline void
 bitset<Block, Allocator>::destroyDeviceObject(ExecutionPolicy&& policy, bitset<Block, Allocator>& device_object)
 {
@@ -249,7 +251,8 @@ bitset<Block, Allocator>::set()
 }
 
 template <typename Block, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline void
 bitset<Block, Allocator>::set(ExecutionPolicy&& policy)
 {
@@ -276,7 +279,8 @@ bitset<Block, Allocator>::reset()
 }
 
 template <typename Block, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline void
 bitset<Block, Allocator>::reset(ExecutionPolicy&& policy)
 {
@@ -303,7 +307,8 @@ bitset<Block, Allocator>::flip()
 }
 
 template <typename Block, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline void
 bitset<Block, Allocator>::flip(ExecutionPolicy&& policy)
 {
@@ -380,7 +385,8 @@ bitset<Block, Allocator>::count() const
 }
 
 template <typename Block, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline index_t
 bitset<Block, Allocator>::count(ExecutionPolicy&& policy) const
 {
@@ -404,7 +410,8 @@ bitset<Block, Allocator>::all() const
 }
 
 template <typename Block, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline bool
 bitset<Block, Allocator>::all(ExecutionPolicy&& policy) const
 {
@@ -424,7 +431,8 @@ bitset<Block, Allocator>::any() const
 }
 
 template <typename Block, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline bool
 bitset<Block, Allocator>::any(ExecutionPolicy&& policy) const
 {
@@ -444,7 +452,8 @@ bitset<Block, Allocator>::none() const
 }
 
 template <typename Block, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline bool
 bitset<Block, Allocator>::none(ExecutionPolicy&& policy) const
 {

--- a/src/stdgpu/impl/deque_detail.cuh
+++ b/src/stdgpu/impl/deque_detail.cuh
@@ -33,7 +33,8 @@ deque<T, Allocator>::createDeviceObject(const index_t& capacity, const Allocator
 }
 
 template <typename T, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 deque<T, Allocator>
 deque<T, Allocator>::createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator)
 {
@@ -69,7 +70,8 @@ deque<T, Allocator>::destroyDeviceObject(deque<T, Allocator>& device_object)
 }
 
 template <typename T, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 deque<T, Allocator>::destroyDeviceObject(ExecutionPolicy&& policy, deque<T, Allocator>& device_object)
 {
@@ -494,7 +496,8 @@ deque<T, Allocator>::clear()
 }
 
 template <typename T, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline void
 deque<T, Allocator>::clear(ExecutionPolicy&& policy)
 {
@@ -551,7 +554,8 @@ deque<T, Allocator>::valid() const
 }
 
 template <typename T, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline bool
 deque<T, Allocator>::valid(ExecutionPolicy&& policy) const
 {
@@ -573,7 +577,8 @@ deque<T, Allocator>::device_range()
 }
 
 template <typename T, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 stdgpu::device_indexed_range<T>
 deque<T, Allocator>::device_range(ExecutionPolicy&& policy)
 {
@@ -617,7 +622,8 @@ deque<T, Allocator>::device_range() const
 }
 
 template <typename T, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 stdgpu::device_indexed_range<const T>
 deque<T, Allocator>::device_range(ExecutionPolicy&& policy) const
 {
@@ -661,7 +667,8 @@ deque<T, Allocator>::occupied(const index_t n) const
 }
 
 template <typename T, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 bool
 deque<T, Allocator>::occupied_count_valid(ExecutionPolicy&& policy) const
 {

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -551,7 +551,8 @@ allocator_traits<Allocator>::deallocate(Allocator& a,
 }
 
 template <typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 typename allocator_traits<Allocator>::pointer
 allocator_traits<Allocator>::allocate_filled(ExecutionPolicy&& policy,
                                              Allocator& a,
@@ -567,7 +568,8 @@ allocator_traits<Allocator>::allocate_filled(ExecutionPolicy&& policy,
 }
 
 template <typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 allocator_traits<Allocator>::deallocate_filled(ExecutionPolicy&& policy,
                                                Allocator& a,

--- a/src/stdgpu/impl/mutex_detail.cuh
+++ b/src/stdgpu/impl/mutex_detail.cuh
@@ -60,7 +60,8 @@ mutex_array<Block, Allocator>::createDeviceObject(const index_t& size, const All
 }
 
 template <typename Block, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline mutex_array<Block, Allocator>
 mutex_array<Block, Allocator>::createDeviceObject(ExecutionPolicy&& policy,
                                                   const index_t& size,
@@ -80,7 +81,8 @@ mutex_array<Block, Allocator>::destroyDeviceObject(mutex_array<Block, Allocator>
 }
 
 template <typename Block, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline void
 mutex_array<Block, Allocator>::destroyDeviceObject(ExecutionPolicy&& policy,
                                                    mutex_array<Block, Allocator>& device_object)
@@ -140,7 +142,8 @@ mutex_array<Block, Allocator>::valid() const
 }
 
 template <typename Block, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline bool
 mutex_array<Block, Allocator>::valid(ExecutionPolicy&& policy) const
 {

--- a/src/stdgpu/impl/type_traits.h
+++ b/src/stdgpu/impl/type_traits.h
@@ -21,6 +21,20 @@
 
 #include <stdgpu/impl/preprocessor.h>
 
+namespace stdgpu
+{
+
+template <typename T>
+struct remove_cvref
+{
+    using type = std::remove_cv_t<std::remove_reference_t<T>>;
+};
+
+template <typename T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+
+} // namespace stdgpu
+
 namespace stdgpu::detail
 {
 

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -82,7 +82,8 @@ public:
      * \param[in] allocator The allocator instance to use
      * \return A newly created object of this class allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static unordered_base
     createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator);
 
@@ -92,7 +93,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \param[in] device_object The object allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static void
     destroyDeviceObject(ExecutionPolicy&& policy, unordered_base& device_object);
 
@@ -121,7 +123,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return True if the state is valid, false otherwise
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     bool
     valid(ExecutionPolicy&& policy) const;
 
@@ -180,7 +183,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return A range of the container
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     device_indexed_range<const value_type>
     device_range(ExecutionPolicy&& policy) const;
 
@@ -325,7 +329,8 @@ public:
      */
     template <typename ExecutionPolicy,
               typename ValueIterator,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<ValueIterator>)>
+              STDGPU_DETAIL_OVERLOAD_IF(
+                      is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<ValueIterator>)>
     void
     insert(ExecutionPolicy&& policy, ValueIterator begin, ValueIterator end);
 
@@ -355,7 +360,8 @@ public:
      */
     template <typename ExecutionPolicy,
               typename KeyIterator,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<KeyIterator>)>
+              STDGPU_DETAIL_OVERLOAD_IF(
+                      is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<KeyIterator>)>
     void
     erase(ExecutionPolicy&& policy, KeyIterator begin, KeyIterator end);
 
@@ -370,7 +376,8 @@ public:
      * \tparam ExecutionPolicy The type of the execution policy
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     void
     clear(ExecutionPolicy&& policy);
 

--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -164,7 +164,8 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::device_rang
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 device_indexed_range<const typename unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::value_type>
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::device_range(ExecutionPolicy&& policy) const
 {
@@ -962,7 +963,8 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::insert(Inpu
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 template <typename ExecutionPolicy,
           typename InputIt,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<InputIt>)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
+                  is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<InputIt>)>
 inline void
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::insert(ExecutionPolicy&& policy,
                                                                             InputIt begin,
@@ -1006,7 +1008,8 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::erase(KeyIt
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
 template <typename ExecutionPolicy,
           typename KeyIterator,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<KeyIterator>)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
+                  is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<KeyIterator>)>
 inline void
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::erase(ExecutionPolicy&& policy,
                                                                            KeyIterator begin,
@@ -1109,7 +1112,8 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::valid() con
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 bool
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::valid(ExecutionPolicy&& policy) const
 {
@@ -1136,7 +1140,8 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::clear()
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::clear(ExecutionPolicy&& policy)
 {
@@ -1162,7 +1167,8 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::clear(Execu
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::createDeviceObject(ExecutionPolicy&& policy,
                                                                                         const index_t& capacity,
@@ -1216,7 +1222,8 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::createDevic
 }
 
 template <typename Key, typename Value, typename KeyFromValue, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::destroyDeviceObject(
         ExecutionPolicy&& policy,

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -97,7 +97,8 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::device_range() const
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 device_indexed_range<const typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::value_type>
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::device_range(ExecutionPolicy&& policy) const
 {
@@ -209,7 +210,8 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::insert(ValueIterator begin, Va
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 template <typename ExecutionPolicy,
           typename ValueIterator,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<ValueIterator>)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
+                  is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<ValueIterator>)>
 inline void
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::insert(ExecutionPolicy&& policy,
                                                          ValueIterator begin,
@@ -237,7 +239,8 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::erase(KeyIterator begin, KeyIt
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 template <typename ExecutionPolicy,
           typename KeyIterator,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<KeyIterator>)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
+                  is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<KeyIterator>)>
 inline void
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::erase(ExecutionPolicy&& policy, KeyIterator begin, KeyIterator end)
 {
@@ -315,7 +318,8 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::valid() const
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 bool
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::valid(ExecutionPolicy&& policy) const
 {
@@ -330,7 +334,8 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::clear()
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::clear(ExecutionPolicy&& policy)
 {
@@ -346,7 +351,8 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::createDeviceObject(const index
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 unordered_map<Key, T, Hash, KeyEqual, Allocator>
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::createDeviceObject(ExecutionPolicy&& policy,
                                                                      const index_t& capacity,
@@ -369,7 +375,8 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::destroyDeviceObject(
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::destroyDeviceObject(
         ExecutionPolicy&& policy,

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -82,7 +82,8 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::device_range() const
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 device_indexed_range<const typename unordered_set<Key, Hash, KeyEqual, Allocator>::value_type>
 unordered_set<Key, Hash, KeyEqual, Allocator>::device_range(ExecutionPolicy&& policy) const
 {
@@ -194,7 +195,8 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::insert(ValueIterator begin, Value
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 template <typename ExecutionPolicy,
           typename ValueIterator,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<ValueIterator>)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
+                  is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<ValueIterator>)>
 inline void
 unordered_set<Key, Hash, KeyEqual, Allocator>::insert(ExecutionPolicy&& policy, ValueIterator begin, ValueIterator end)
 {
@@ -219,7 +221,8 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::erase(KeyIterator begin, KeyItera
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 template <typename ExecutionPolicy,
           typename KeyIterator,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<KeyIterator>)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
+                  is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<KeyIterator>)>
 inline void
 unordered_set<Key, Hash, KeyEqual, Allocator>::erase(ExecutionPolicy&& policy, KeyIterator begin, KeyIterator end)
 {
@@ -297,7 +300,8 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::valid() const
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 bool
 unordered_set<Key, Hash, KeyEqual, Allocator>::valid(ExecutionPolicy&& policy) const
 {
@@ -312,7 +316,8 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::clear()
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 unordered_set<Key, Hash, KeyEqual, Allocator>::clear(ExecutionPolicy&& policy)
 {
@@ -327,7 +332,8 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::createDeviceObject(const index_t&
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 unordered_set<Key, Hash, KeyEqual, Allocator>
 unordered_set<Key, Hash, KeyEqual, Allocator>::createDeviceObject(ExecutionPolicy&& policy,
                                                                   const index_t& capacity,
@@ -350,7 +356,8 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::destroyDeviceObject(
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 unordered_set<Key, Hash, KeyEqual, Allocator>::destroyDeviceObject(
         ExecutionPolicy&& policy,

--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -34,7 +34,8 @@ vector<T, Allocator>::createDeviceObject(const index_t& capacity, const Allocato
 }
 
 template <typename T, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 vector<T, Allocator>
 vector<T, Allocator>::createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator)
 {
@@ -65,7 +66,8 @@ vector<T, Allocator>::destroyDeviceObject(vector<T, Allocator>& device_object)
 }
 
 template <typename T, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 vector<T, Allocator>::destroyDeviceObject(ExecutionPolicy&& policy, vector<T, Allocator>& device_object)
 {
@@ -360,7 +362,8 @@ vector<T, Allocator>::insert(device_ptr<const T> position, ValueIterator begin, 
 template <typename T, typename Allocator>
 template <typename ExecutionPolicy,
           typename ValueIterator,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::is_iterator_v<ValueIterator>)>
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(
+                  is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<ValueIterator>)>
 inline void
 vector<T, Allocator>::insert(ExecutionPolicy&& policy,
                              device_ptr<const T> position,
@@ -400,7 +403,8 @@ vector<T, Allocator>::erase(device_ptr<const T> begin, device_ptr<const T> end)
 }
 
 template <typename T, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline void
 vector<T, Allocator>::erase(ExecutionPolicy&& policy, device_ptr<const T> begin, device_ptr<const T> end)
 {
@@ -511,7 +515,8 @@ vector<T, Allocator>::clear()
 }
 
 template <typename T, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline void
 vector<T, Allocator>::clear(ExecutionPolicy&& policy)
 {
@@ -545,7 +550,8 @@ vector<T, Allocator>::valid() const
 }
 
 template <typename T, typename Allocator>
-template <typename ExecutionPolicy>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 inline bool
 vector<T, Allocator>::valid(ExecutionPolicy&& policy) const
 {

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -28,11 +28,9 @@
 #include <memory>
 #include <type_traits>
 
-// For convenient calls of all policy-based algorithms
-#include <stdgpu/execution.h>
-
 #include <stdgpu/config.h>
 #include <stdgpu/cstddef.h>
+#include <stdgpu/execution.h>
 #include <stdgpu/impl/type_traits.h>
 #include <stdgpu/platform.h>
 
@@ -588,7 +586,8 @@ struct allocator_traits : public detail::allocator_traits_base<Allocator>
      * \param[in] default_value A default value, that should be stored in every entry
      * \return A pointer to the allocated memory block
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     [[nodiscard]] static pointer
     allocate_filled(ExecutionPolicy&& policy, Allocator& a, index_type n, const value_type& default_value);
 
@@ -600,7 +599,8 @@ struct allocator_traits : public detail::allocator_traits_base<Allocator>
      * \param[in] p A pointer to the memory block
      * \param[in] n The number of allocated elements (must match the size during allocation)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static void
     deallocate_filled(ExecutionPolicy&& policy, Allocator& a, pointer p, index_type n);
 

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -29,6 +29,7 @@
 
 #include <stdgpu/bitset.cuh>
 #include <stdgpu/cstddef.h>
+#include <stdgpu/execution.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
 
@@ -117,7 +118,8 @@ public:
      * \param[in] allocator The allocator instance to use
      * \return A newly created object of this class allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static mutex_array
     createDeviceObject(ExecutionPolicy&& policy, const index_t& size, const Allocator& allocator = Allocator());
 
@@ -134,7 +136,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \param[in] device_object The object allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static void
     destroyDeviceObject(ExecutionPolicy&& policy, mutex_array& device_object);
 
@@ -195,7 +198,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return True if the state is valid, false otherwise
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     bool
     valid(ExecutionPolicy&& policy) const;
 

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -27,6 +27,7 @@
  * \file stdgpu/unordered_map.cuh
  */
 
+#include <stdgpu/execution.h>
 #include <stdgpu/functional.h>
 #include <stdgpu/impl/type_traits.h>
 #include <stdgpu/impl/unordered_base.cuh>
@@ -111,7 +112,8 @@ public:
      * \param[in] allocator The allocator instance to use
      * \return A newly created object of this class allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static unordered_map
     createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator = Allocator());
 
@@ -128,7 +130,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \param[in] device_object The object allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static void
     destroyDeviceObject(ExecutionPolicy&& policy, unordered_map& device_object);
 
@@ -157,7 +160,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return True if the state is valid, false otherwise
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     bool
     valid(ExecutionPolicy&& policy) const;
 
@@ -216,7 +220,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return A range of the container
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     device_indexed_range<const value_type>
     device_range(ExecutionPolicy&& policy) const;
 
@@ -344,7 +349,8 @@ public:
      */
     template <typename ExecutionPolicy,
               typename ValueIterator,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<ValueIterator>)>
+              STDGPU_DETAIL_OVERLOAD_IF(
+                      is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<ValueIterator>)>
     void
     insert(ExecutionPolicy&& policy, ValueIterator begin, ValueIterator end);
 
@@ -374,7 +380,8 @@ public:
      */
     template <typename ExecutionPolicy,
               typename KeyIterator,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<KeyIterator>)>
+              STDGPU_DETAIL_OVERLOAD_IF(
+                      is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<KeyIterator>)>
     void
     erase(ExecutionPolicy&& policy, KeyIterator begin, KeyIterator end);
 
@@ -389,7 +396,8 @@ public:
      * \tparam ExecutionPolicy The type of the execution policy
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     void
     clear(ExecutionPolicy&& policy);
 

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -27,6 +27,7 @@
  * \file stdgpu/unordered_set.cuh
  */
 
+#include <stdgpu/execution.h>
 #include <stdgpu/functional.h>
 #include <stdgpu/impl/type_traits.h>
 #include <stdgpu/impl/unordered_base.cuh>
@@ -100,7 +101,8 @@ public:
      * \param[in] allocator The allocator instance to use
      * \return A newly created object of this class allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static unordered_set
     createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator = Allocator());
 
@@ -117,7 +119,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \param[in] device_object The object allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static void
     destroyDeviceObject(ExecutionPolicy&& policy, unordered_set& device_object);
 
@@ -146,7 +149,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return True if the state is valid, false otherwise
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     bool
     valid(ExecutionPolicy&& policy) const;
 
@@ -205,7 +209,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return A range of the container
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     device_indexed_range<const value_type>
     device_range(ExecutionPolicy&& policy) const;
 
@@ -324,7 +329,8 @@ public:
      */
     template <typename ExecutionPolicy,
               typename ValueIterator,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<ValueIterator>)>
+              STDGPU_DETAIL_OVERLOAD_IF(
+                      is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<ValueIterator>)>
     void
     insert(ExecutionPolicy&& policy, ValueIterator begin, ValueIterator end);
 
@@ -363,7 +369,8 @@ public:
      */
     template <typename ExecutionPolicy,
               typename KeyIterator,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<KeyIterator>)>
+              STDGPU_DETAIL_OVERLOAD_IF(
+                      is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<KeyIterator>)>
     void
     erase(ExecutionPolicy&& policy, KeyIterator begin, KeyIterator end);
 
@@ -378,7 +385,8 @@ public:
      * \tparam ExecutionPolicy The type of the execution policy
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     void
     clear(ExecutionPolicy&& policy);
 

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -30,6 +30,7 @@
 #include <stdgpu/atomic.cuh>
 #include <stdgpu/bitset.cuh>
 #include <stdgpu/cstddef.h>
+#include <stdgpu/execution.h>
 #include <stdgpu/impl/type_traits.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
@@ -110,7 +111,8 @@ public:
      * \param[in] allocator The allocator instance to use
      * \return A newly created object of this class allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static vector<T, Allocator>
     createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator = Allocator());
 
@@ -127,7 +129,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \param[in] device_object The object allocated on the GPU (device)
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     static void
     destroyDeviceObject(ExecutionPolicy&& policy, vector<T, Allocator>& device_object);
 
@@ -253,7 +256,8 @@ public:
      */
     template <typename ExecutionPolicy,
               typename ValueIterator,
-              STDGPU_DETAIL_OVERLOAD_IF(detail::is_iterator_v<ValueIterator>)>
+              STDGPU_DETAIL_OVERLOAD_IF(
+                      is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>&& detail::is_iterator_v<ValueIterator>)>
     void
     insert(ExecutionPolicy&& policy, device_ptr<const T> position, ValueIterator begin, ValueIterator end);
 
@@ -274,7 +278,8 @@ public:
      * \param[in] end The end of the range
      * \note end must be equal to device_end()
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     void
     erase(ExecutionPolicy&& policy, device_ptr<const T> begin, device_ptr<const T> end);
 
@@ -345,7 +350,8 @@ public:
      * \tparam ExecutionPolicy The type of the execution policy
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     void
     clear(ExecutionPolicy&& policy);
 
@@ -362,7 +368,8 @@ public:
      * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
      * \return True if the state is valid, false otherwise
      */
-    template <typename ExecutionPolicy>
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     bool
     valid(ExecutionPolicy&& policy) const;
 

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -99,9 +99,20 @@ for_each_concurrent_thread(F&& f, Args&&... args)
     }
 }
 
-class custom_device_policy : public stdgpu::execution::device_policy
+struct custom_device_policy : stdgpu::execution::device_policy
 {
 };
+
 } // namespace test_utils
+
+// Workaround: Need to specialize is_execution_policy since deriving from existing policies is currently not detected
+namespace stdgpu
+{
+template <>
+struct is_execution_policy<test_utils::custom_device_policy> : std::true_type
+{
+};
+} // namespace stdgpu
+static_assert(stdgpu::is_execution_policy_v<test_utils::custom_device_policy>);
 
 #endif // TEST_UTILS_H


### PR DESCRIPTION
All containers recently gained support for custom execution policies. However, a proper detection mechanism is still missing and also complicates proper overload resolution of member functions which may lead to confusing compilation errors. Add `is_execution_policy` traits to detect all policies defined by thrust and conditionally enable all policy-related member functions of the containers.

While this is a significant improvement, defining custom policies would now requires specializing `is_execution_policy` since the policy check does not properly detect them. However, only relying on the ones from thrust should be sufficient for now.