### PR TITLE
execution: Apply is_execution_policy to overload more algorithms conditionally

### DIFF
--- a/src/stdgpu/algorithm.h
+++ b/src/stdgpu/algorithm.h
@@ -25,9 +25,7 @@
  * \file stdgpu/algorithm.h
  */
 
-// For convenient calls of all policy-based algorithms
 #include <stdgpu/execution.h>
-
 #include <stdgpu/platform.h>
 
 namespace stdgpu
@@ -81,7 +79,10 @@ clamp(const T& v, const T& lower, const T& upper);
  * \param[in] size The number of indices, i.e. the upper bound of [0, size)
  * \param[in] f The unary function to call with an index i
  */
-template <typename IndexType, typename ExecutionPolicy, typename UnaryFunction>
+template <typename IndexType,
+          typename ExecutionPolicy,
+          typename UnaryFunction,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 for_each_index(ExecutionPolicy&& policy, IndexType size, UnaryFunction f);
 
@@ -96,7 +97,10 @@ for_each_index(ExecutionPolicy&& policy, IndexType size, UnaryFunction f);
  * \param[in] end The iterator pointing past to the last element
  * \param[in] value The value that will be written
  */
-template <typename ExecutionPolicy, typename Iterator, typename T>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const T& value);
 
@@ -113,7 +117,11 @@ fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const T& value);
  * \param[in] value The value that will be written
  * \return The iterator pointing to the last element
  */
-template <typename ExecutionPolicy, typename Iterator, typename Size, typename T>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename Size,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 Iterator
 fill_n(ExecutionPolicy&& policy, Iterator begin, Size n, const T& value);
 
@@ -129,7 +137,10 @@ fill_n(ExecutionPolicy&& policy, Iterator begin, Size n, const T& value);
  * \param[in] output_begin The output iterator pointing to the first element
  * \return The output iterator pointing to the last element
  */
-template <typename ExecutionPolicy, typename InputIt, typename OutputIt>
+template <typename ExecutionPolicy,
+          typename InputIt,
+          typename OutputIt,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 OutputIt
 copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputIt output_begin);
 
@@ -146,7 +157,11 @@ copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputIt output_begin
  * \param[in] output_begin The output iterator pointing to the first element
  * \return The output iterator pointing to the last element
  */
-template <typename ExecutionPolicy, typename InputIt, typename Size, typename OutputIt>
+template <typename ExecutionPolicy,
+          typename InputIt,
+          typename Size,
+          typename OutputIt,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 OutputIt
 copy_n(ExecutionPolicy&& policy, InputIt begin, Size n, OutputIt output_begin);
 

--- a/src/stdgpu/execution.h
+++ b/src/stdgpu/execution.h
@@ -36,7 +36,7 @@ namespace stdgpu
 
 /**
  * \ingroup execution
- * \brief Type traits to check whether the provided class is an execution policy
+ * \brief Type trait to check whether the provided class is an execution policy
  */
 template <typename T>
 struct is_execution_policy : std::is_base_of<thrust::execution_policy<T>, T>

--- a/src/stdgpu/impl/algorithm_detail.h
+++ b/src/stdgpu/impl/algorithm_detail.h
@@ -48,7 +48,10 @@ clamp(const T& v, const T& lower, const T& upper)
     return v < lower ? lower : upper < v ? upper : v;
 }
 
-template <typename IndexType, typename ExecutionPolicy, typename UnaryFunction>
+template <typename IndexType,
+          typename ExecutionPolicy,
+          typename UnaryFunction,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 for_each_index(ExecutionPolicy&& policy, IndexType size, UnaryFunction f)
 {
@@ -82,14 +85,21 @@ private:
 };
 } // namespace detail
 
-template <typename ExecutionPolicy, typename Iterator, typename T>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const T& value)
 {
     fill_n(std::forward<ExecutionPolicy>(policy), begin, static_cast<index_t>(end - begin), value);
 }
 
-template <typename ExecutionPolicy, typename Iterator, typename Size, typename T>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename Size,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 Iterator
 fill_n(ExecutionPolicy&& policy, Iterator begin, Size n, const T& value)
 {
@@ -121,14 +131,21 @@ private:
 };
 } // namespace detail
 
-template <typename ExecutionPolicy, typename InputIt, typename OutputIt>
+template <typename ExecutionPolicy,
+          typename InputIt,
+          typename OutputIt,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 OutputIt
 copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputIt output_begin)
 {
     return copy_n(std::forward<ExecutionPolicy>(policy), begin, static_cast<index_t>(end - begin), output_begin);
 }
 
-template <typename ExecutionPolicy, typename InputIt, typename Size, typename OutputIt>
+template <typename ExecutionPolicy,
+          typename InputIt,
+          typename Size,
+          typename OutputIt,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 OutputIt
 copy_n(ExecutionPolicy&& policy, InputIt begin, Size n, OutputIt output_begin)
 {

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -661,14 +661,21 @@ destroy_at(T* p)
     p->~T();
 }
 
-template <typename ExecutionPolicy, typename Iterator, typename T>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 uninitialized_fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const T& value)
 {
     uninitialized_fill_n(std::forward<ExecutionPolicy>(policy), begin, static_cast<index64_t>(end - begin), value);
 }
 
-template <typename ExecutionPolicy, typename Iterator, typename Size, typename T>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename Size,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 Iterator
 uninitialized_fill_n(ExecutionPolicy&& policy, Iterator begin, Size n, const T& value)
 {
@@ -678,7 +685,10 @@ uninitialized_fill_n(ExecutionPolicy&& policy, Iterator begin, Size n, const T& 
     return begin + n;
 }
 
-template <typename ExecutionPolicy, typename InputIt, typename OutputIt>
+template <typename ExecutionPolicy,
+          typename InputIt,
+          typename OutputIt,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 OutputIt
 uninitialized_copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputIt output_begin)
 {
@@ -688,7 +698,11 @@ uninitialized_copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputI
                                 output_begin);
 }
 
-template <typename ExecutionPolicy, typename InputIt, typename Size, typename OutputIt>
+template <typename ExecutionPolicy,
+          typename InputIt,
+          typename Size,
+          typename OutputIt,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 OutputIt
 uninitialized_copy_n(ExecutionPolicy&& policy, InputIt begin, Size n, OutputIt output_begin)
 {
@@ -698,7 +712,9 @@ uninitialized_copy_n(ExecutionPolicy&& policy, InputIt begin, Size n, OutputIt o
     return output_begin + n;
 }
 
-template <typename ExecutionPolicy, typename Iterator>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 destroy(ExecutionPolicy&& policy, Iterator first, Iterator last)
 {
@@ -708,7 +724,10 @@ destroy(ExecutionPolicy&& policy, Iterator first, Iterator last)
     }
 }
 
-template <typename ExecutionPolicy, typename Iterator, typename Size>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename Size,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 Iterator
 destroy_n(ExecutionPolicy&& policy, Iterator first, Size n)
 {

--- a/src/stdgpu/impl/numeric_detail.h
+++ b/src/stdgpu/impl/numeric_detail.h
@@ -49,7 +49,10 @@ private:
 };
 } // namespace detail
 
-template <typename ExecutionPolicy, typename Iterator, typename T>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value)
 {
@@ -58,7 +61,12 @@ iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value)
                    detail::iota_functor<Iterator, T>(begin, value));
 }
 
-template <typename IndexType, typename ExecutionPolicy, typename T, typename BinaryFunction, typename UnaryFunction>
+template <typename IndexType,
+          typename ExecutionPolicy,
+          typename T,
+          typename BinaryFunction,
+          typename UnaryFunction,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 T
 transform_reduce_index(ExecutionPolicy&& policy, IndexType size, T init, BinaryFunction reduce, UnaryFunction f)
 {

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -697,7 +697,10 @@ destroy_at(T* p);
  * \param[in] end The iterator pointing past to the last element
  * \param[in] value The value that will be written
  */
-template <typename ExecutionPolicy, typename Iterator, typename T>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 uninitialized_fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const T& value);
 
@@ -714,7 +717,11 @@ uninitialized_fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const
  * \param[in] value The value that will be written
  * \return The iterator pointing to the last element
  */
-template <typename ExecutionPolicy, typename Iterator, typename Size, typename T>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename Size,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 Iterator
 uninitialized_fill_n(ExecutionPolicy&& policy, Iterator begin, Size n, const T& value);
 
@@ -730,7 +737,10 @@ uninitialized_fill_n(ExecutionPolicy&& policy, Iterator begin, Size n, const T& 
  * \param[in] output_begin The output iterator pointing to the first element
  * \return The output iterator pointing to the last element
  */
-template <typename ExecutionPolicy, typename InputIt, typename OutputIt>
+template <typename ExecutionPolicy,
+          typename InputIt,
+          typename OutputIt,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 OutputIt
 uninitialized_copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputIt output_begin);
 
@@ -747,7 +757,11 @@ uninitialized_copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputI
  * \param[in] output_begin The output iterator pointing to the first element
  * \return The output iterator pointing to the last element
  */
-template <typename ExecutionPolicy, typename InputIt, typename Size, typename OutputIt>
+template <typename ExecutionPolicy,
+          typename InputIt,
+          typename Size,
+          typename OutputIt,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 OutputIt
 uninitialized_copy_n(ExecutionPolicy&& policy, InputIt begin, Size n, OutputIt output_begin);
 
@@ -760,7 +774,9 @@ uninitialized_copy_n(ExecutionPolicy&& policy, InputIt begin, Size n, OutputIt o
  * \param[in] first An iterator to the begin of the value range
  * \param[in] last An iterator to the end of the value range
  */
-template <typename ExecutionPolicy, typename Iterator>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 destroy(ExecutionPolicy&& policy, Iterator first, Iterator last);
 
@@ -775,7 +791,10 @@ destroy(ExecutionPolicy&& policy, Iterator first, Iterator last);
  * \param[in] n The number of elements in the value range
  * \return An iterator to the end of the value range
  */
-template <typename ExecutionPolicy, typename Iterator, typename Size>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename Size,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 Iterator
 destroy_n(ExecutionPolicy&& policy, Iterator first, Size n);
 

--- a/src/stdgpu/numeric.h
+++ b/src/stdgpu/numeric.h
@@ -25,7 +25,6 @@
  * \file stdgpu/numeric.h
  */
 
-// For convenient calls of all policy-based algorithms
 #include <stdgpu/execution.h>
 
 namespace stdgpu
@@ -42,7 +41,10 @@ namespace stdgpu
  * \param[in] end The iterator pointing past to the last element
  * \param[in] value The starting value that will be incremented
  */
-template <typename ExecutionPolicy, typename Iterator, typename T>
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value);
 
@@ -60,7 +62,12 @@ iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value);
  * \param[in] f The unary function to call with an index i
  * \return The result of the reduction of f(i) over the index range [0, size) along with the initial value
  */
-template <typename IndexType, typename ExecutionPolicy, typename T, typename BinaryFunction, typename UnaryFunction>
+template <typename IndexType,
+          typename ExecutionPolicy,
+          typename T,
+          typename BinaryFunction,
+          typename UnaryFunction,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 T
 transform_reduce_index(ExecutionPolicy&& policy, IndexType size, T init, BinaryFunction reduce, UnaryFunction f);
 


### PR DESCRIPTION
While #377 improved the overload resolution situation with the containers, the same issue also applies to the free functions defined in `algorithm`, `memory`, and `numeric`. Conditionally enable the involved functions like in the case of the containers to closer adhere to the C++ standard.