### PR TITLE
type_traits: Move to public module and add documentation

### DIFF
--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -60,6 +60,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
                                        queue.cuh
                                        ranges.h
                                        stack.cuh
+                                       type_traits.h
                                        unordered_map.cuh
                                        unordered_set.cuh
                                        utility.h

--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -31,9 +31,9 @@
 #include <type_traits>
 
 #include <stdgpu/execution.h>
-#include <stdgpu/impl/type_traits.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
+#include <stdgpu/type_traits.h>
 
 namespace stdgpu
 {

--- a/src/stdgpu/bit.h
+++ b/src/stdgpu/bit.h
@@ -27,8 +27,8 @@
 
 #include <type_traits>
 
-#include <stdgpu/impl/type_traits.h>
 #include <stdgpu/platform.h>
+#include <stdgpu/type_traits.h>
 
 namespace stdgpu
 {

--- a/src/stdgpu/cuda/atomic.cuh
+++ b/src/stdgpu/cuda/atomic.cuh
@@ -18,7 +18,7 @@
 
 #include <type_traits>
 
-#include <stdgpu/impl/type_traits.h>
+#include <stdgpu/type_traits.h>
 
 namespace stdgpu::cuda
 {

--- a/src/stdgpu/execution.h
+++ b/src/stdgpu/execution.h
@@ -23,7 +23,7 @@
 
 #include <type_traits>
 
-#include <stdgpu/impl/type_traits.h>
+#include <stdgpu/type_traits.h>
 
 /**
  * \file stdgpu/execution.h

--- a/src/stdgpu/hip/atomic.h
+++ b/src/stdgpu/hip/atomic.h
@@ -18,7 +18,7 @@
 
 #include <type_traits>
 
-#include <stdgpu/impl/type_traits.h>
+#include <stdgpu/type_traits.h>
 
 namespace stdgpu::hip
 {

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -22,10 +22,10 @@
 
 #include <stdgpu/algorithm.h>
 #include <stdgpu/cstddef.h>
-#include <stdgpu/impl/type_traits.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/limits.h>
 #include <stdgpu/platform.h>
+#include <stdgpu/type_traits.h>
 #include <stdgpu/utility.h>
 
 namespace stdgpu::detail

--- a/src/stdgpu/impl/type_traits.h
+++ b/src/stdgpu/impl/type_traits.h
@@ -13,27 +13,13 @@
  *  limitations under the License.
  */
 
-#ifndef STDGPU_TYPE_TRAITS_H
-#define STDGPU_TYPE_TRAITS_H
+#ifndef STDGPU_TYPE_TRAITS_DETAIL_H
+#define STDGPU_TYPE_TRAITS_DETAIL_H
 
 #include <type_traits>
 #include <utility>
 
 #include <stdgpu/impl/preprocessor.h>
-
-namespace stdgpu
-{
-
-template <typename T>
-struct remove_cvref
-{
-    using type = std::remove_cv_t<std::remove_reference_t<T>>;
-};
-
-template <typename T>
-using remove_cvref_t = typename remove_cvref<T>::type;
-
-} // namespace stdgpu
 
 namespace stdgpu::detail
 {
@@ -93,4 +79,4 @@ inline constexpr bool dependent_false_v = dependent_false<T>::value;
 
 } // namespace stdgpu::detail
 
-#endif // STDGPU_TYPE_TRAITS_H
+#endif // STDGPU_TYPE_TRAITS_DETAIL_H

--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -20,12 +20,12 @@
 #include <stdgpu/bitset.cuh>
 #include <stdgpu/cstddef.h>
 #include <stdgpu/functional.h>
-#include <stdgpu/impl/type_traits.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/mutex.cuh>
 #include <stdgpu/platform.h>
 #include <stdgpu/ranges.h>
+#include <stdgpu/type_traits.h>
 #include <stdgpu/utility.h>
 #include <stdgpu/vector.cuh>
 

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -31,8 +31,8 @@
 #include <stdgpu/config.h>
 #include <stdgpu/cstddef.h>
 #include <stdgpu/execution.h>
-#include <stdgpu/impl/type_traits.h>
 #include <stdgpu/platform.h>
+#include <stdgpu/type_traits.h>
 
 /**
  * \ingroup memory

--- a/src/stdgpu/openmp/atomic.h
+++ b/src/stdgpu/openmp/atomic.h
@@ -18,7 +18,7 @@
 
 #include <type_traits>
 
-#include <stdgpu/impl/type_traits.h>
+#include <stdgpu/type_traits.h>
 
 namespace stdgpu::openmp
 {

--- a/src/stdgpu/type_traits.h
+++ b/src/stdgpu/type_traits.h
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2021 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef STDGPU_TYPE_TRAITS_H
+#define STDGPU_TYPE_TRAITS_H
+
+/**
+ * \defgroup type_traits type_traits
+ * \ingroup utilities
+ */
+
+/**
+ * \file stdgpu/type_traits.h
+ */
+
+#include <type_traits>
+
+namespace stdgpu
+{
+
+/**
+ * \ingroup type_traits
+ * \brief Type trait to remove const, volative, and reference qualifiers from the given type
+ * \tparam T The input type
+ */
+template <typename T>
+struct remove_cvref
+{
+    using type = std::remove_cv_t<std::remove_reference_t<T>>; /**< type */
+};
+
+//! @cond Doxygen_Suppress
+template <typename T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+//! @endcond
+
+} // namespace stdgpu
+
+#include <stdgpu/impl/type_traits.h>
+
+#endif // STDGPU_TYPE_TRAITS_H

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -29,10 +29,10 @@
 
 #include <stdgpu/execution.h>
 #include <stdgpu/functional.h>
-#include <stdgpu/impl/type_traits.h>
 #include <stdgpu/impl/unordered_base.cuh>
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
+#include <stdgpu/type_traits.h>
 #include <stdgpu/utility.h>
 
 namespace stdgpu

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -29,10 +29,10 @@
 
 #include <stdgpu/execution.h>
 #include <stdgpu/functional.h>
-#include <stdgpu/impl/type_traits.h>
 #include <stdgpu/impl/unordered_base.cuh>
 #include <stdgpu/memory.h>
 #include <stdgpu/platform.h>
+#include <stdgpu/type_traits.h>
 #include <stdgpu/utility.h>
 
 namespace stdgpu

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -31,12 +31,12 @@
 #include <stdgpu/bitset.cuh>
 #include <stdgpu/cstddef.h>
 #include <stdgpu/execution.h>
-#include <stdgpu/impl/type_traits.h>
 #include <stdgpu/iterator.h>
 #include <stdgpu/memory.h>
 #include <stdgpu/mutex.cuh>
 #include <stdgpu/platform.h>
 #include <stdgpu/ranges.h>
+#include <stdgpu/type_traits.h>
 #include <stdgpu/utility.h>
 
 namespace stdgpu


### PR DESCRIPTION
So far, `type_traits` only contained types and macros only intended for internal usage. With the addition of `remove_cvref`, it now contains a publicly facing API. Move it out from the internal implementation directory and add respective documentation for it.