### PR TITLE
src,test: Fix conversion warnings for 64-bit index_t

### DIFF
--- a/src/stdgpu/impl/vector_detail.cuh
+++ b/src/stdgpu/impl/vector_detail.cuh
@@ -346,7 +346,7 @@ vector_clear_iota(ExecutionPolicy&& policy, vector<T, Allocator>& v, const T& va
 {
     iota(std::forward<ExecutionPolicy>(policy), device_begin(v.data()), device_end(v.data()), value);
     v._occupied.set(std::forward<ExecutionPolicy>(policy));
-    v._size.store(v.capacity());
+    v._size.store(static_cast<int>(v.capacity()));
 }
 
 } // namespace detail
@@ -392,7 +392,7 @@ vector<T, Allocator>::insert(ExecutionPolicy&& policy,
                    N,
                    detail::vector_insert<T, Allocator, ValueIterator, true>(*this, size(), begin));
 
-    _size.store(new_size);
+    _size.store(static_cast<int>(new_size));
 }
 
 template <typename T, typename Allocator>
@@ -426,7 +426,7 @@ vector<T, Allocator>::erase(ExecutionPolicy&& policy, device_ptr<const T> begin,
 
     for_each_index(std::forward<ExecutionPolicy>(policy), N, detail::vector_erase<T, Allocator, true>(*this, new_size));
 
-    _size.store(new_size);
+    _size.store(static_cast<int>(new_size));
 }
 
 template <typename T, typename Allocator>
@@ -447,7 +447,7 @@ template <typename T, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
 vector<T, Allocator>::size() const
 {
-    index_t current_size = _size.load();
+    index_t current_size = static_cast<index_t>(_size.load());
 
     // Check boundary cases where the push/pop caused the pointers to be overful/underful
     if (current_size < 0)
@@ -536,7 +536,7 @@ vector<T, Allocator>::clear(ExecutionPolicy&& policy)
 
     _occupied.reset(std::forward<ExecutionPolicy>(policy));
 
-    _size.store(0);
+    _size.store(static_cast<int>(0));
 
     STDGPU_ENSURES(empty());
     STDGPU_ENSURES(valid(std::forward<ExecutionPolicy>(policy)));
@@ -646,8 +646,8 @@ template <typename T, typename Allocator>
 bool
 vector<T, Allocator>::size_valid() const
 {
-    int current_size = _size.load();
-    return (0 <= current_size && current_size <= static_cast<int>(capacity()));
+    index_t current_size = static_cast<index_t>(_size.load());
+    return (0 <= current_size && current_size <= capacity());
 }
 
 } // namespace stdgpu

--- a/test/stdgpu/deque.inc
+++ b/test/stdgpu/deque.inc
@@ -417,7 +417,10 @@ TEST_F(stdgpu_deque, push_back_some)
     stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
+    stdgpu::iota(stdgpu::execution::device,
+                 stdgpu::device_begin(values),
+                 stdgpu::device_end(values),
+                 1 + static_cast<int>(N_remaining));
 
     stdgpu::for_each_index(stdgpu::execution::device, N_push, push_back_deque<int>(pool, values));
 
@@ -566,7 +569,10 @@ TEST_F(stdgpu_deque, emplace_back_some)
     stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
+    stdgpu::iota(stdgpu::execution::device,
+                 stdgpu::device_begin(values),
+                 stdgpu::device_end(values),
+                 1 + static_cast<int>(N_remaining));
 
     stdgpu::for_each_index(stdgpu::execution::device, N_push, emplace_back_deque<int>(pool, values));
 
@@ -1264,7 +1270,10 @@ TEST_F(stdgpu_deque, push_back_circular)
     stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_front_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), N - N_pop + 1);
+    stdgpu::iota(stdgpu::execution::device,
+                 stdgpu::device_begin(values),
+                 stdgpu::device_end(values),
+                 static_cast<int>(N) - static_cast<int>(N_pop) + 1);
 
     stdgpu::for_each_index(stdgpu::execution::device, N_push, push_back_deque<int>(pool, values));
 
@@ -1301,7 +1310,10 @@ TEST_F(stdgpu_deque, push_front_circular)
     stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_front_deque<int>(pool));
 
     int* values = createDeviceArray<int>(N);
-    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), N - N_pop + 1);
+    stdgpu::iota(stdgpu::execution::device,
+                 stdgpu::device_begin(values),
+                 stdgpu::device_end(values),
+                 static_cast<int>(N) - static_cast<int>(N_pop) + 1);
 
     stdgpu::for_each_index(stdgpu::execution::device, N_push, push_front_deque<int>(pool, values));
 

--- a/test/stdgpu/vector.inc
+++ b/test/stdgpu/vector.inc
@@ -415,7 +415,10 @@ TEST_F(stdgpu_vector, push_back_some)
     stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_vector<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
+    stdgpu::iota(stdgpu::execution::device,
+                 stdgpu::device_begin(values),
+                 stdgpu::device_end(values),
+                 1 + static_cast<int>(N_remaining));
 
     stdgpu::for_each_index(stdgpu::execution::device, N_push, push_back_vector<int>(pool, values));
 
@@ -564,7 +567,10 @@ TEST_F(stdgpu_vector, emplace_back_some)
     stdgpu::for_each_index(stdgpu::execution::device, N_pop, pop_back_vector<int>(pool));
 
     int* values = createDeviceArray<int>(N_push);
-    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), 1 + N_remaining);
+    stdgpu::iota(stdgpu::execution::device,
+                 stdgpu::device_begin(values),
+                 stdgpu::device_end(values),
+                 1 + static_cast<int>(N_remaining));
 
     stdgpu::for_each_index(stdgpu::execution::device, N_push, push_back_vector<int>(pool, values));
 
@@ -710,7 +716,10 @@ TEST_F(stdgpu_vector, insert)
     fill_vector(pool, N_init);
 
     int* values = createDeviceArray<int>(N_insert);
-    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), N_init + 1);
+    stdgpu::iota(stdgpu::execution::device,
+                 stdgpu::device_begin(values),
+                 stdgpu::device_end(values),
+                 static_cast<int>(N_init) + 1);
 
     pool.insert(pool.device_end(), stdgpu::device_begin(values), stdgpu::device_end(values));
 
@@ -743,7 +752,7 @@ TEST_F(stdgpu_vector, insert_custom_execution_policy)
     fill_vector(pool, N_init);
 
     int* values = createDeviceArray<int>(N_insert);
-    stdgpu::iota(policy, stdgpu::device_begin(values), stdgpu::device_end(values), N_init + 1);
+    stdgpu::iota(policy, stdgpu::device_begin(values), stdgpu::device_end(values), static_cast<int>(N_init) + 1);
 
     pool.insert(policy, pool.device_end(), stdgpu::device_begin(values), stdgpu::device_end(values));
 
@@ -774,7 +783,10 @@ TEST_F(stdgpu_vector, insert_non_end)
     fill_vector(pool, N_init);
 
     int* values = createDeviceArray<int>(N_insert);
-    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), N_init + 1);
+    stdgpu::iota(stdgpu::execution::device,
+                 stdgpu::device_begin(values),
+                 stdgpu::device_end(values),
+                 static_cast<int>(N_init) + 1);
 
     pool.insert(pool.device_end() - 1, stdgpu::device_begin(values), stdgpu::device_end(values));
 
@@ -798,7 +810,10 @@ TEST_F(stdgpu_vector, insert_too_many)
     fill_vector(pool, N_init);
 
     int* values = createDeviceArray<int>(N_insert);
-    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(values), stdgpu::device_end(values), N_init + 1);
+    stdgpu::iota(stdgpu::execution::device,
+                 stdgpu::device_begin(values),
+                 stdgpu::device_end(values),
+                 static_cast<int>(N_init) + 1);
 
     pool.insert(pool.device_end(), stdgpu::device_begin(values), stdgpu::device_end(values));
 


### PR DESCRIPTION
By default, `index_t` resolves to a 32-bit integer, which on the supported platforms resolves to `int`. While the complementary 64-bit mode, where it typically resolves to `long int` is also supported, the code is less frequently tested against a high warning level. Fix the conversion warnings that appeared after manual analysis and compilation in 64-bit index mode.