### PR TITLE
CI: Add jobs for 64-bit indexing

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,6 +17,7 @@ jobs:
         CXX: [g++, clang++]
         BuildType: [Debug, Release]
         SharedLibs: [ON, OFF]
+        Use32BitIndex: [ON, OFF]
         include:
           - CXX: g++
             CC: gcc
@@ -44,7 +45,7 @@ jobs:
       - name: Configure project
         shell: bash
         run: |
-          bash scripts/ci/configure_openmp.sh ${{ matrix.BuildType }} -DSTDGPU_BUILD_SHARED_LIBS=${{ matrix.SharedLibs }}
+          bash scripts/ci/configure_openmp.sh ${{ matrix.BuildType }} -DSTDGPU_BUILD_SHARED_LIBS=${{ matrix.SharedLibs }} -DSTDGPU_USE_32_BIT_INDEX=${{ matrix.Use32BitIndex }}
 
       - name: Build project
         shell: bash
@@ -84,6 +85,7 @@ jobs:
         CXX: [g++, clang++]
         BuildType: [Debug, Release]
         SharedLibs: [ON, OFF]
+        Use32BitIndex: [ON, OFF]
         include:
           - CXX: g++
             CC: gcc
@@ -111,7 +113,7 @@ jobs:
       - name: Configure project
         shell: bash
         run: |
-          bash scripts/ci/configure_openmp.sh ${{ matrix.BuildType }} -DSTDGPU_BUILD_SHARED_LIBS=${{ matrix.SharedLibs }}
+          bash scripts/ci/configure_openmp.sh ${{ matrix.BuildType }} -DSTDGPU_BUILD_SHARED_LIBS=${{ matrix.SharedLibs }} -DSTDGPU_USE_32_BIT_INDEX=${{ matrix.Use32BitIndex }}
 
       - name: Build project
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         BuildType: [Debug, Release]
         SharedLibs: [ON, OFF]
+        Use32BitIndex: [ON, OFF]
 
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +29,7 @@ jobs:
       - name: Configure project
         shell: bash
         run: |
-          bash scripts/ci/configure_openmp.sh ${{ matrix.BuildType }} -DSTDGPU_BUILD_SHARED_LIBS=${{ matrix.SharedLibs }} -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE
+          bash scripts/ci/configure_openmp.sh ${{ matrix.BuildType }} -DSTDGPU_BUILD_SHARED_LIBS=${{ matrix.SharedLibs }} -DSTDGPU_USE_32_BIT_INDEX=${{ matrix.Use32BitIndex }} -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE
 
       - name: Build project
         shell: bash
@@ -67,6 +68,7 @@ jobs:
       matrix:
         BuildType: [Debug, Release]
         SharedLibs: [ON, OFF]
+        Use32BitIndex: [ON, OFF]
 
     steps:
       - uses: actions/checkout@v3
@@ -79,7 +81,7 @@ jobs:
       - name: Configure project
         shell: bash
         run: |
-          bash scripts/ci/configure_openmp.sh ${{ matrix.BuildType }} -DSTDGPU_BUILD_SHARED_LIBS=${{ matrix.SharedLibs }} -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE
+          bash scripts/ci/configure_openmp.sh ${{ matrix.BuildType }} -DSTDGPU_BUILD_SHARED_LIBS=${{ matrix.SharedLibs }} -DSTDGPU_USE_32_BIT_INDEX=${{ matrix.Use32BitIndex }} -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE
 
       - name: Build project
         shell: bash


### PR DESCRIPTION
Our CI currently tests for various platforms and configurations. Regarding the library options, the default 32-bit indexing is only tested while the optional 64-bit indexing is not considered so far. Add the respective CI jobs to test 64-bit indexing on Ubuntu and Windows. This will reduce the likelihood of regressions in the future.  