### PR TITLE
functional: Make hash more SFINAE-friendly and improve error messages

### DIFF
--- a/src/stdgpu/functional.h
+++ b/src/stdgpu/functional.h
@@ -34,10 +34,24 @@
 namespace stdgpu
 {
 
-//! @cond Doxygen_Suppress
-template <typename Key>
-struct hash;
-//! @endcond
+namespace detail
+{
+
+template <typename T, bool>
+struct hash_base;
+
+} // namespace detail
+
+/**
+ * \ingroup functional
+ * \tparam T The type of the key values
+ * \brief A function object to compute hash values of provided keys
+ * \note This base class implements the specialization for all enums and scoped enums
+ */
+template <typename T>
+struct hash : detail::hash_base<T, std::is_enum_v<T>>
+{
+};
 
 /**
  * \ingroup functional
@@ -325,30 +339,6 @@ struct hash<long double>
      */
     STDGPU_HOST_DEVICE std::size_t
     operator()(const long double& key) const;
-};
-
-/**
- * \ingroup functional
- * \brief A specialization for all kinds of enums
- * \tparam E An enumeration
- */
-template <typename E>
-struct hash
-{
-public:
-    /**
-     * \brief Computes a hash value for the given key
-     * \param[in] key The key
-     * \return The corresponding hash value
-     */
-    STDGPU_HOST_DEVICE std::size_t
-    operator()(const E& key) const;
-
-private:
-    /**
-     * \brief Restrict specializations to enumerations
-     */
-    using sfinae = std::enable_if_t<std::is_enum_v<E>, E>;
 };
 
 /**

--- a/src/stdgpu/impl/functional_detail.h
+++ b/src/stdgpu/impl/functional_detail.h
@@ -25,6 +25,38 @@
 namespace stdgpu
 {
 
+namespace detail
+{
+
+template <typename T, bool>
+struct hash_base
+{
+    using is_disabled = void;
+
+    hash_base() = delete;
+    ~hash_base() = default;
+
+    hash_base(const hash_base&) = delete;
+    hash_base&
+    operator=(const hash_base&) = delete;
+
+    hash_base(hash_base&&) = delete;
+    hash_base&
+    operator=(hash_base&&) = delete;
+};
+
+template <typename T>
+struct hash_base<T, true>
+{
+    inline STDGPU_HOST_DEVICE std::size_t
+    operator()(const T& key) const
+    {
+        return hash<std::underlying_type_t<T>>()(static_cast<std::underlying_type_t<T>>(key));
+    }
+};
+
+} // namespace detail
+
 #define STDGPU_DETAIL_COMPOUND_HASH_BASIC_INTEGER_TYPE(T)                                                              \
     inline STDGPU_HOST_DEVICE std::size_t hash<T>::operator()(const T& key) const                                      \
     {                                                                                                                  \
@@ -65,13 +97,6 @@ inline STDGPU_HOST_DEVICE std::size_t
 hash<long double>::operator()(const long double& key) const
 {
     return hash<double>()(static_cast<double>(key));
-}
-
-template <typename E>
-inline STDGPU_HOST_DEVICE std::size_t
-hash<E>::operator()(const E& key) const
-{
-    return hash<std::underlying_type_t<E>>()(static_cast<std::underlying_type_t<E>>(key));
 }
 
 template <typename T>

--- a/src/stdgpu/impl/type_traits_detail.h
+++ b/src/stdgpu/impl/type_traits_detail.h
@@ -69,6 +69,8 @@ STDGPU_DETAIL_DEFINE_TRAIT(has_arrow_operator,
                                             .
                                             operator->()))
 
+STDGPU_DETAIL_DEFINE_TRAIT(is_disabled, typename T::is_disabled)
+
 template <typename T>
 struct dependent_false : std::false_type
 {

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -94,6 +94,8 @@ public:
     using iterator = pointer;                  /**< pointer */
     using const_iterator = const_pointer;      /**< const_pointer */
 
+    static_assert(!detail::is_disabled_v<hasher>, "stdgpu::unordered_map: No specialization for std::hash<Key> found");
+
     /**
      * \brief Creates an object of this class on the GPU (device)
      * \param[in] capacity The capacity of the object

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -83,6 +83,8 @@ public:
     using iterator = const_pointer;            /**< const_pointer */
     using const_iterator = const_pointer;      /**< const_pointer */
 
+    static_assert(!detail::is_disabled_v<hasher>, "stdgpu::unordered_set: No specialization for std::hash<Key> found");
+
     /**
      * \brief Creates an object of this class on the GPU (device)
      * \param[in] capacity The capacity of the object

--- a/test/stdgpu/functional.cpp
+++ b/test/stdgpu/functional.cpp
@@ -292,6 +292,19 @@ TEST_F(stdgpu_functional, hash_enum_class)
     EXPECT_GT(static_cast<stdgpu::index_t>(hashes.size()), 4 * 90 / 100);
 }
 
+class NoHashSpecialization
+{
+};
+
+TEST_F(stdgpu_functional, hash_no_specialization)
+{
+    EXPECT_FALSE(std::is_default_constructible_v<stdgpu::hash<NoHashSpecialization>>);
+    EXPECT_FALSE(std::is_copy_constructible_v<stdgpu::hash<NoHashSpecialization>>);
+    EXPECT_FALSE(std::is_copy_assignable_v<stdgpu::hash<NoHashSpecialization>>);
+    EXPECT_FALSE(std::is_move_constructible_v<stdgpu::hash<NoHashSpecialization>>);
+    EXPECT_FALSE(std::is_move_assignable_v<stdgpu::hash<NoHashSpecialization>>);
+}
+
 template <typename T>
 void
 identity_check_integer_random()


### PR DESCRIPTION
The `hash` function object from `functional` is currently only defined for specializations and will result in a compile error otherwise. However, this compiler error is not very informative (see #374) and does not provide any hints about a missing specialization when used with custom types. Make `hash` always and disable all constructors for non-specialized types to follow the C++ standard more closely. Furthermore, improve the error messages in such cases by adding additional compile-time checks in `unordered_map` and `unordered_set`.