### PR TITLE
unordered_map,unordered_set: Add non-const device_range function

### DIFF
--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -171,6 +171,24 @@ public:
     cend() const noexcept;
 
     /**
+     * \brief Creates a range of the device container
+     * \return A range of the object
+     */
+    device_indexed_range<value_type>
+    device_range();
+
+    /**
+     * \brief Creates a range of the device container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return A range of the object
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    device_indexed_range<value_type>
+    device_range(ExecutionPolicy&& policy);
+
+    /**
      * \brief Builds a range to the values in the container
      * \return A range of the container
      */

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -90,6 +90,22 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::cend() const noexcept
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+device_indexed_range<typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::value_type>
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::device_range()
+{
+    return _base.device_range();
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+device_indexed_range<typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::value_type>
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::device_range(ExecutionPolicy&& policy)
+{
+    return _base.device_range(std::forward<ExecutionPolicy>(policy));
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 device_indexed_range<const typename unordered_map<Key, T, Hash, KeyEqual, Allocator>::value_type>
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::device_range() const
 {

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -75,6 +75,22 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::cend() const noexcept
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+device_indexed_range<typename unordered_set<Key, Hash, KeyEqual, Allocator>::value_type>
+unordered_set<Key, Hash, KeyEqual, Allocator>::device_range()
+{
+    return _base.device_range();
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+device_indexed_range<typename unordered_set<Key, Hash, KeyEqual, Allocator>::value_type>
+unordered_set<Key, Hash, KeyEqual, Allocator>::device_range(ExecutionPolicy&& policy)
+{
+    return _base.device_range(std::forward<ExecutionPolicy>(policy));
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 device_indexed_range<const typename unordered_set<Key, Hash, KeyEqual, Allocator>::value_type>
 unordered_set<Key, Hash, KeyEqual, Allocator>::device_range() const
 {

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -210,6 +210,24 @@ public:
     cend() const noexcept;
 
     /**
+     * \brief Creates a range of the device container
+     * \return A range of the object
+     */
+    device_indexed_range<value_type>
+    device_range();
+
+    /**
+     * \brief Creates a range of the device container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return A range of the object
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    device_indexed_range<value_type>
+    device_range(ExecutionPolicy&& policy);
+
+    /**
      * \brief Builds a range to the values in the container
      * \return A range of the container
      */

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -199,6 +199,24 @@ public:
     cend() const noexcept;
 
     /**
+     * \brief Creates a range of the device container
+     * \return A range of the object
+     */
+    device_indexed_range<value_type>
+    device_range();
+
+    /**
+     * \brief Creates a range of the device container
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return A range of the object
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    device_indexed_range<value_type>
+    device_range(ExecutionPolicy&& policy);
+
+    /**
      * \brief Builds a range to the values in the container
      * \return A range of the container
      */

--- a/test/stdgpu/unordered_datastructure.inc
+++ b/test/stdgpu/unordered_datastructure.inc
@@ -2287,7 +2287,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, count_sum)
     destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
 }
 
-TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_keys_same)
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, non_const_device_range)
 {
     const stdgpu::index_t N = 100000;
 
@@ -2323,7 +2323,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_keys_same)
     destroyDeviceArray<test_unordered_datastructure::value_type>(values);
 }
 
-TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_keys_same_custom_execution_policy)
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, non_const_device_range_same_custom_execution_policy)
 {
     stdgpu::execution::device_policy policy;
 
@@ -2334,6 +2334,80 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, range_for_each_keys_same_custo
     test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
 
     auto range = hash_datastructure.device_range(policy);
+    // unordered_map's value_type cannot be copied using copy(), so use uninitialized_copy() instead
+    stdgpu::uninitialized_copy(stdgpu::execution::device, range.begin(), range.end(), values);
+
+    test_unordered_datastructure::value_type* host_values =
+            copyCreateDevice2HostArray<test_unordered_datastructure::value_type>(values, N);
+    test_unordered_datastructure::key_type* host_positions_copied =
+            createHostArray<test_unordered_datastructure::key_type>(N);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        host_positions_copied[i] = STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(host_values[i]);
+    }
+
+    std::sort(host_positions, host_positions + N, less());
+    std::sort(host_positions_copied, host_positions_copied + N, less());
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(host_positions[i], host_positions_copied[i]);
+    }
+
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions_copied);
+    destroyHostArray<test_unordered_datastructure::value_type>(host_values);
+    destroyDeviceArray<test_unordered_datastructure::value_type>(values);
+}
+
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, const_device_range)
+{
+    const stdgpu::index_t N = 100000;
+
+    test_unordered_datastructure::key_type* host_positions = insert_unique_parallel(hash_datastructure, N);
+
+    test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
+
+    auto range = static_cast<const test_unordered_datastructure&>(hash_datastructure).device_range();
+    // unordered_map's value_type cannot be copied using copy(), so use uninitialized_copy() instead
+    stdgpu::uninitialized_copy(stdgpu::execution::device, range.begin(), range.end(), values);
+
+    test_unordered_datastructure::value_type* host_values =
+            copyCreateDevice2HostArray<test_unordered_datastructure::value_type>(values, N);
+    test_unordered_datastructure::key_type* host_positions_copied =
+            createHostArray<test_unordered_datastructure::key_type>(N);
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        host_positions_copied[i] = STDGPU_UNORDERED_DATASTRUCTURE_VALUE2KEY(host_values[i]);
+    }
+
+    std::sort(host_positions, host_positions + N, less());
+    std::sort(host_positions_copied, host_positions_copied + N, less());
+
+    for (stdgpu::index_t i = 0; i < N; ++i)
+    {
+        EXPECT_EQ(host_positions[i], host_positions_copied[i]);
+    }
+
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions);
+    destroyHostArray<test_unordered_datastructure::key_type>(host_positions_copied);
+    destroyHostArray<test_unordered_datastructure::value_type>(host_values);
+    destroyDeviceArray<test_unordered_datastructure::value_type>(values);
+}
+
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, const_device_range_same_custom_execution_policy)
+{
+    stdgpu::execution::device_policy policy;
+
+    const stdgpu::index_t N = 100000;
+
+    test_unordered_datastructure::key_type* host_positions = insert_unique_parallel(hash_datastructure, N);
+
+    test_unordered_datastructure::value_type* values = createDeviceArray<test_unordered_datastructure::value_type>(N);
+
+    auto range = static_cast<const test_unordered_datastructure&>(hash_datastructure).device_range(policy);
     // unordered_map's value_type cannot be copied using copy(), so use uninitialized_copy() instead
     stdgpu::uninitialized_copy(stdgpu::execution::device, range.begin(), range.end(), values);
 


### PR DESCRIPTION
In comparison to `vector` and `deque`, the containers `unordered_map` and `unordered_set` only exhibit a const-version of the `device_range()` function. This does not allow for e.g. updating the mapped value in `unordered_map`. Add the respective non-const version to close this gap and enable these use cases.