### PR TITLE
ranges: Fix access in indexed range

### DIFF
--- a/src/stdgpu/impl/ranges_detail.h
+++ b/src/stdgpu/impl/ranges_detail.h
@@ -196,7 +196,7 @@ public:
     {
     }
 
-    STDGPU_HOST_DEVICE T
+    STDGPU_HOST_DEVICE T&
     operator()(const index_t i) const
     {
         return _values[i];


### PR DESCRIPTION
With the recent addition of non-const `device_range()` functions for `unordered_map` and `unordered_set` in #385, a bug in the internal access of the respective indexed ranges has been exposed. While for the const versions, the created copy of the indexed constant value has the same semantics as a reference, this is no longer the case in the non-const version where the e.g. the mapped value of a pair should be updated. Fix this bug by properly returning a reference instead of a value to prevent the accidental copy. 