### PR TITLE
cmake: Use gtest alias target in tests

### DIFF
--- a/test/stdgpu/CMakeLists.txt
+++ b/test/stdgpu/CMakeLists.txt
@@ -25,7 +25,7 @@ target_compile_options(teststdgpu PRIVATE ${STDGPU_DEVICE_FLAGS}
 
 target_link_libraries(teststdgpu PRIVATE
                                  stdgpu::stdgpu
-                                 gtest)
+                                 GTest::gtest)
 
 set_target_properties(teststdgpu PROPERTIES CXX_CLANG_TIDY "${STDGPU_PROPERTY_CLANG_TIDY}")
 set_target_properties(teststdgpu PROPERTIES CXX_CPPCHECK "${STDGPU_PROPERTY_CPPCHECK}")


### PR DESCRIPTION
The recommended way of linking against third-party dependencies in CMake is to use the respective namespaced target names which will will work for both imported targets as well as locally built, aliased targets. While this best practice is followed for the benchmark library, the gtest library is used without its namespace. Fix this minor inconsistency.