### PR TITLE
test: Fix shadow warning with half type

### DIFF
--- a/test/stdgpu/algorithm.cpp
+++ b/test/stdgpu/algorithm.cpp
@@ -159,8 +159,8 @@ random_float(std::uniform_real_distribution<T>& dist,
 {
     T result = dist(rng);
 
-    const T half = static_cast<T>(0.5);
-    return flip(rng) < half ? result : -result;
+    const T one_half = static_cast<T>(0.5);
+    return flip(rng) < one_half ? result : -result;
 }
 
 template <typename T>


### PR DESCRIPTION
When compiling with a recent version of CUDA, the `algorithm` test emits a warning that the half data type defined by some CUDA headers is shadowed by a local variable in that test. Fix this warning by renaming the respective variable.