### PR TITLE
General: Streamline HIP backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ Before building the library, please make sure that all required tools and depend
 
 **Required for HIP backend (experimental)**
 
+- HIP compiler
+    - Clang
+        - Already included in ROCm
 - ROCm 5.1
     - (Ubuntu) https://github.com/RadeonOpenCompute/ROCm
     - Includes thrust

--- a/cmake/hip/determine_thrust_paths.cmake
+++ b/cmake/hip/determine_thrust_paths.cmake
@@ -2,15 +2,9 @@ function(stdgpu_determine_thrust_paths STDGPU_OUTPUT_THRUST_PATHS)
     # Clear list before appending flags
     unset(${STDGPU_OUTPUT_THRUST_PATHS})
 
-    if(DEFINED ROCM_PATH)
-        set(STDGPU_ROCM_PATH "${ROCM_PATH}")
-    elseif(DEFINED ENV{ROCM_PATH})
-        set(STDGPU_ROCM_PATH "$ENV{ROCM_PATH}")
-    else()
-        set(STDGPU_ROCM_PATH "/opt/rocm")
-    endif()
+    find_package(hip QUIET)
 
-    set(${STDGPU_OUTPUT_THRUST_PATHS} "${STDGPU_ROCM_PATH}/include")
+    set(${STDGPU_OUTPUT_THRUST_PATHS} "${hip_INCLUDE_DIRS}")
 
     # Make output variable visible
     set(${STDGPU_OUTPUT_THRUST_PATHS} ${${STDGPU_OUTPUT_THRUST_PATHS}} PARENT_SCOPE)

--- a/doc/stdgpu/index.md
+++ b/doc/stdgpu/index.md
@@ -206,6 +206,9 @@ Before building the library, please make sure that all required tools and depend
 
 **Required for HIP backend (experimental)**
 
+- HIP compiler
+    - Clang
+        - Already included in ROCm
 - ROCm 5.1
     - (Ubuntu) https://github.com/RadeonOpenCompute/ROCm
     - Includes thrust

--- a/src/stdgpu/hip/CMakeLists.txt
+++ b/src/stdgpu/hip/CMakeLists.txt
@@ -1,15 +1,4 @@
-
-if(DEFINED ROCM_PATH)
-    set(STDGPU_ROCM_PATH "${ROCM_PATH}")
-elseif(DEFINED ENV{ROCM_PATH})
-    set(STDGPU_ROCM_PATH "$ENV{ROCM_PATH}")
-else()
-    set(STDGPU_ROCM_PATH "/opt/rocm")
-endif()
-
-find_package(hip 5.1 REQUIRED
-             PATHS
-             "${STDGPU_ROCM_PATH}/hip")
+find_package(hip 5.1 REQUIRED)
 
 set(STDGPU_DEPENDENCIES_BACKEND_INIT "
 find_dependency(hip 5.1 REQUIRED)
@@ -38,5 +27,11 @@ endif()
 target_compile_features(stdgpu PUBLIC hip_std_17)
 
 target_compile_definitions(stdgpu PUBLIC THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP)
+
+# CMake always links libraries and executables involving HIP with the device linker, even if only host code is used.
+# Suppress the linker warning about unused HIP architectures *globally* via a public linker flag.
+set(STDGPU_HIP_DEVICE_LINKER_FLAGS "$<$<LINK_LANGUAGE:HIP>:-Wno-unused-command-line-argument>")
+message(STATUS "Created HIP device linker flags : ${STDGPU_HIP_DEVICE_LINKER_FLAGS}")
+target_link_options(stdgpu PUBLIC "${STDGPU_HIP_DEVICE_LINKER_FLAGS}")
 
 target_link_libraries(stdgpu PUBLIC hip::host)

--- a/src/stdgpu/hip/impl/device.cpp
+++ b/src/stdgpu/hip/impl/device.cpp
@@ -72,10 +72,14 @@ print_device_information()
     int gpu_name_space_left = std::max<int>(1, (gpu_name_total_width - gpu_name_size) / 2);
     int gpu_name_space_right = std::max<int>(1, gpu_name_total_width - gpu_name_size - gpu_name_space_left);
 
+    std::string arch_name = properties.gcnArchName;
+    int arch_name_size = static_cast<int>(arch_name.size());
+    int arch_name_space_right = std::max<int>(1, 26 - arch_name_size);
+
     printf("+---------------------------------------------------------+\n");
     printf("|%*s%*s%*s|\n", gpu_name_space_left, " ", gpu_name_size, gpu_name.c_str(), gpu_name_space_right, " ");
     printf("+---------------------------------------------------------+\n");
-    printf("| GCN Architecture          :   %4d                      |\n", properties.gcnArch);
+    printf("| GCN Architecture          :   %s%*s|\n", arch_name.c_str(), arch_name_space_right, " ");
     printf("| Clock rate                :   %-6.0f MHz                |\n",
            static_cast<double>(detail::kilo_to_mega_hertz(static_cast<float>(properties.clockRate))));
     printf("| Global Memory             :   %-6.3f GiB / %-6.3f GiB   |\n",

--- a/src/stdgpu/hip/impl/memory.cpp
+++ b/src/stdgpu/hip/impl/memory.cpp
@@ -130,10 +130,9 @@ workaround_synchronize_managed_memory()
     int current_device;
     int has_concurrent_managed_access;
     STDGPU_HIP_SAFE_CALL(hipGetDevice(&current_device));
-    // STDGPU_HIP_SAFE_CALL( hipDeviceGetAttribute( &hash_concurrent_managed_access, hipDevAttrConcurrentManagedAccess,
-    // current_device ) );
-    has_concurrent_managed_access =
-            0; // Assume that synchronization is required although the respective attribute does not exist
+    STDGPU_HIP_SAFE_CALL(hipDeviceGetAttribute(&has_concurrent_managed_access,
+                                               hipDeviceAttributeConcurrentManagedAccess,
+                                               current_device));
     if (has_concurrent_managed_access == 0)
     {
         printf("stdgpu::hip::workaround_synchronize_managed_memory : Synchronizing the whole GPU in order to access "

--- a/test/stdgpu/hip/CMakeLists.txt
+++ b/test/stdgpu/hip/CMakeLists.txt
@@ -2,6 +2,7 @@
 target_sources(teststdgpu PRIVATE atomic.hip
                                   bitset.hip
                                   deque.hip
+                                  memory.hip
                                   mutex.hip
                                   unordered_map.hip
                                   unordered_set.hip

--- a/test/stdgpu/hip/memory.hip
+++ b/test/stdgpu/hip/memory.hip
@@ -1,0 +1,18 @@
+/*
+ *  Copyright 2023 Patrick Stotko
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#define STDGPU_MEMORY_TEST_CLASS stdgpu_memory_hip
+
+#include <stdgpu/memory.inc>


### PR DESCRIPTION
Although AMD's GPU support in terms of their ROCm/HIP framework is still lacking behind CUDA in various aspects, the situation seems to have improved in recent ROCm versions. Thus, streamline our HIP backend to closer match the CUDA backend. This reduces the differences between the backends and, in turn, slightly the maintenance burden.

Note that the HIP backend is still considered **experimental**.