### PR TITLE
docs: Disable empty inherited footer

### DIFF
--- a/docs/_static/stdgpu_custom_sphinx.css
+++ b/docs/_static/stdgpu_custom_sphinx.css
@@ -4,6 +4,12 @@ div#rtd-footer-container {
 }
 
 
+/* Remove empty footer inherited from pydata theme */
+footer.bd-footer {
+    display: none;
+}
+
+
 /* Better separator color in dark mode */
 html[data-theme="dark"] {
     --pst-color-border: #38393b;


### PR DESCRIPTION
The sphinx-book-theme is built upon the pydata theme and inherits many useful properties from it. However, the inherited footer is always empty as a dedicated one is already rendered at the bottom of each page. Disable the empty inherited footer to get rid of the page-wide 1px line drawn at the bottom.