### PR TITLE
docs: Fix link to pitchfork layout convention

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -79,7 +79,7 @@ After the review is complete and all tests pass, your pull request will be accep
 
 ## Project Structure
 
-stdgpu is structured according to common [project layout conventions](https://api.csswg.org/bikeshed/?force=1&url=https://raw.githubusercontent.com/vector-of-bool/pitchfork/spec/data/spec.bs) which includes the following directories:
+stdgpu is structured according to common <a href="https://api.csswg.org/bikeshed/?force=1&url=https://raw.githubusercontent.com/vector-of-bool/pitchfork/spec/data/spec.bs">project layout conventions</a> which includes the following directories:
 
 - `benchmarks/stdgpu/`: The benchmarks of the library. The actual code lies in the `*.inc` files which are then included and compiled in backend-specific source files.
 - `cmake/`: Additional CMake scripts used for building and development. Backend-specific code lies in the respective subdirectories.


### PR DESCRIPTION
The contributing guide has been overhauled in #398 which also introduced a reference to the pitchfork layout convention. However, the link to this convention contains an ampersand symbol `&` which gets transformed to `&amp;` breaking the link. Fix this bug by using a HTML link instead of a Markdown link which preserves the ampersand.