### PR TITLE
memory: Add constructor for empty device_unique_object

### DIFF
--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -434,6 +434,12 @@ namespace stdgpu
 {
 
 template <typename T>
+device_unique_object<T>::device_unique_object(null_object_t /*null_object*/)
+  : _object(nullptr)
+{
+}
+
+template <typename T>
 template <typename... Args>
 device_unique_object<T>::device_unique_object(Args&&... args)
   : _object(new T(T::createDeviceObject(std::forward<Args>(args)...)), [](T* ptr) {
@@ -482,6 +488,12 @@ T&
 device_unique_object<T>::operator*()
 {
     return *_object;
+}
+
+template <typename T>
+device_unique_object<T>::operator bool() const
+{
+    return _object.operator bool();
 }
 
 template <typename T>

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -265,6 +265,23 @@ namespace stdgpu
 
 /**
  * \ingroup memory
+ * \brief A type to indicate an uninitialized unique object
+ */
+struct null_object_t
+{
+    //! @cond Doxygen_Suppress
+    constexpr explicit null_object_t(int /* unspecified */) { }
+    //! @endcond
+};
+
+/**
+ * \ingroup memory
+ * \brief A constant to indicate an uninitialized unique object
+ */
+inline constexpr null_object_t null_object{ 0 };
+
+/**
+ * \ingroup memory
  * \brief A resource wrapper for managing device objects with automatic scope-based object destruction
  * \tparam T A type
  */
@@ -272,6 +289,11 @@ template <typename T>
 class device_unique_object
 {
 public:
+    /**
+     * \brief Creates an empty unique object
+     */
+    explicit device_unique_object(null_object_t /*null_object*/);
+
     /**
      * \brief Creates an object on the GPU (device)
      * \tparam Args The argument types
@@ -319,6 +341,12 @@ public:
      */
     T&
     operator*();
+
+    /**
+     * \brief Checks whether the unique object is not empty
+     * \return True if the unique object is not empty, false otherwise
+     */
+    explicit operator bool() const;
 
 private:
     std::unique_ptr<T, std::function<void(T*)>> _object;

--- a/tests/stdgpu/memory.inc
+++ b/tests/stdgpu/memory.inc
@@ -1296,6 +1296,32 @@ device_allocation_balance()
 
 } // namespace
 
+TEST_F(STDGPU_MEMORY_TEST_CLASS, device_unique_object_empty)
+{
+    using T = TestContainer<float>;
+
+    const stdgpu::index64_t old_balance = device_allocation_balance();
+
+    const stdgpu::index_t old_standard_signature_used = T::standard_signature_used;
+    const stdgpu::index_t old_policy_signature_used = T::policy_signature_used;
+    EXPECT_EQ(T::standard_signature_used % 2, 0);
+    EXPECT_EQ(T::policy_signature_used % 2, 0);
+
+    {
+        [[maybe_unused]] auto object = stdgpu::device_unique_object<T>(stdgpu::null_object);
+
+        EXPECT_FALSE(object);
+        EXPECT_EQ(T::standard_signature_used, old_standard_signature_used);
+        EXPECT_EQ(T::policy_signature_used, old_policy_signature_used);
+    }
+
+    const stdgpu::index64_t new_balance = device_allocation_balance();
+    EXPECT_EQ(old_balance, new_balance);
+
+    EXPECT_EQ(T::standard_signature_used, old_standard_signature_used);
+    EXPECT_EQ(T::policy_signature_used, old_policy_signature_used);
+}
+
 TEST_F(STDGPU_MEMORY_TEST_CLASS, device_unique_object)
 {
     using T = TestContainer<float>;
@@ -1310,6 +1336,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, device_unique_object)
 
         [[maybe_unused]] auto object = stdgpu::device_unique_object<T>(N);
 
+        EXPECT_TRUE(object);
         EXPECT_EQ(T::standard_signature_used % 2, 1);
         EXPECT_EQ(T::policy_signature_used, old_policy_signature_used);
     }
@@ -1336,6 +1363,7 @@ TEST_F(STDGPU_MEMORY_TEST_CLASS, device_unique_object_custom_execution_policy)
 
         [[maybe_unused]] auto object = stdgpu::device_unique_object<T>(policy, N);
 
+        EXPECT_TRUE(object);
         EXPECT_EQ(T::policy_signature_used % 2, 1);
         EXPECT_EQ(T::standard_signature_used, old_standard_signature_used);
     }


### PR DESCRIPTION
In #391, a new wrapper class for automatically managing device objects has been introduced. However, empty managed object can not be constructed which prohibits use cases where, e.g., such a managed object is moved. Add a respective constructor that accepts a `null_object` as well as an overload of `operator bool()` to enable testing for empty objects.