### PR TITLE
CI: Update used actions

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install OpenMP
         shell: bash
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install OpenMP
         shell: bash

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install OpenMP
         shell: bash
@@ -46,8 +46,10 @@ jobs:
           bash tools/dev/run_coverage.sh
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: build/stdgpu_coverage.info
           fail_ci_if_error: true
           verbose: true
+          disable_search: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install OpenMP
         shell: bash

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04 # Keep Ubuntu 20.04 until raising the requirements to clang-format > 10
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install OpenMP
         shell: bash

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
             CC: clang
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install OpenMP
         shell: bash
@@ -93,7 +93,7 @@ jobs:
             CC: clang
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install OpenMP
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
         Use32BitIndex: [ON, OFF]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download dependencies
         shell: bash
@@ -71,7 +71,7 @@ jobs:
         Use32BitIndex: [ON, OFF]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download dependencies
         shell: bash


### PR DESCRIPTION
New major releases for the used actions in our CI have been released. Update our jobs to use these and to prepare for an upcoming simplification of the jobs.