### PR TITLE
cmake: Update support for CMake 3.28

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.26)
+cmake_minimum_required(VERSION 3.18...3.28)
 message(STATUS "Configuring with CMake ${CMAKE_VERSION}")
 
 

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -9,10 +9,9 @@ string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
   message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
   if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
-    exec_program(
-      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
-      OUTPUT_VARIABLE rm_out
-      RETURN_VALUE rm_retval
+    execute_process(
+      COMMAND "@CMAKE_COMMAND@" "-E" "rm" "$ENV{DESTDIR}${file}"
+      RESULT_VARIABLE rm_retval
       )
     if(NOT "${rm_retval}" STREQUAL 0)
       message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")


### PR DESCRIPTION
CMake 3.28 has been recently released. Keep up with the pace of introduced behavioral changes by bumping the maximum supported policy version.