### PR TITLE
General: Add nodiscard attribute to create* API

### DIFF
--- a/docs/api/object.md
+++ b/docs/api/object.md
@@ -55,7 +55,7 @@ class MyHostDeviceObjectClass
             this->_size = 0;
         }
 
-        static MyHostDeviceObjectClass createDeviceObject(const int size)
+        [[nodiscard]] static MyHostDeviceObjectClass createDeviceObject(const int size)
         {
             MyHostDeviceObjectClass result;
 
@@ -71,7 +71,7 @@ class MyHostDeviceObjectClass
             device_object._size = 0;
         }
 
-        static MyHostDeviceObjectClass createHostObject(const int size)
+        [[nodiscard]] static MyHostDeviceObjectClass createHostObject(const int size)
         {
             MyHostDeviceObjectClass result;
 

--- a/examples/createAndDestroyDeviceObject.cpp
+++ b/examples/createAndDestroyDeviceObject.cpp
@@ -22,7 +22,7 @@ class Image
 public:
     Image() = default;
 
-    static Image
+    [[nodiscard]] static Image
     createDeviceObject(const stdgpu::index_t width, const stdgpu::index_t height)
     {
         Image result;
@@ -43,7 +43,7 @@ public:
         device_object._height = 0;
     }
 
-    static Image
+    [[nodiscard]] static Image
     createHostObject(const stdgpu::index_t width, const stdgpu::index_t height)
     {
         Image result;

--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -112,7 +112,7 @@ public:
      * \return A newly created object of this class allocated on the GPU (device)
      * \note The size is implicitly set to 1 (and not needed as a parameter) as the object only manages a single value
      */
-    static atomic
+    [[nodiscard]] static atomic
     createDeviceObject(const Allocator& allocator = Allocator());
 
     /**
@@ -125,7 +125,7 @@ public:
      */
     template <typename ExecutionPolicy,
               STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
-    static atomic
+    [[nodiscard]] static atomic
     createDeviceObject(ExecutionPolicy&& policy, const Allocator& allocator = Allocator());
 
     /**

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -161,7 +161,7 @@ public:
      * \param[in] allocator The allocator instance to use
      * \return A newly created object of this class allocated on the GPU (device)
      */
-    static bitset
+    [[nodiscard]] static bitset
     createDeviceObject(const index_t& size, const Allocator& allocator = Allocator());
 
     /**
@@ -174,7 +174,7 @@ public:
      */
     template <typename ExecutionPolicy,
               STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
-    static bitset
+    [[nodiscard]] static bitset
     createDeviceObject(ExecutionPolicy&& policy, const index_t& size, const Allocator& allocator = Allocator());
 
     /**

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -55,7 +55,7 @@ enum class Initialization
  * \post get_dynamic_memory_type(result) == dynamic_memory_type::device if count > 0
  */
 template <typename T>
-T*
+[[nodiscard]] T*
 createDeviceArray(const stdgpu::index64_t count, const T default_value = T());
 
 /**
@@ -68,7 +68,7 @@ createDeviceArray(const stdgpu::index64_t count, const T default_value = T());
  * \post get_dynamic_memory_type(result) == dynamic_memory_type::device if count > 0
  */
 template <typename T>
-T*
+[[nodiscard]] T*
 createHostArray(const stdgpu::index64_t count, const T default_value = T());
 
 /**
@@ -82,7 +82,7 @@ createHostArray(const stdgpu::index64_t count, const T default_value = T());
  * \post get_dynamic_memory_type(result) == dynamic_memory_type::managed if count > 0
  */
 template <typename T>
-T*
+[[nodiscard]] T*
 createManagedArray(const stdgpu::index64_t count,
                    const T default_value = T(),
                    const Initialization initialize_on = Initialization::DEVICE);
@@ -139,7 +139,7 @@ enum class MemoryCopy
  * \note The source array might also be a managed array
  */
 template <typename T>
-T*
+[[nodiscard]] T*
 copyCreateDevice2HostArray(const T* device_array,
                            const stdgpu::index64_t count,
                            const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
@@ -155,7 +155,7 @@ copyCreateDevice2HostArray(const T* device_array,
  * \note The source array might also be a managed array
  */
 template <typename T>
-T*
+[[nodiscard]] T*
 copyCreateHost2DeviceArray(const T* host_array,
                            const stdgpu::index64_t count,
                            const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
@@ -171,7 +171,7 @@ copyCreateHost2DeviceArray(const T* host_array,
  * \note The source array might also be a managed array
  */
 template <typename T>
-T*
+[[nodiscard]] T*
 copyCreateHost2HostArray(const T* host_array,
                          const stdgpu::index64_t count,
                          const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);
@@ -187,7 +187,7 @@ copyCreateHost2HostArray(const T* host_array,
  * \note The source array might also be a managed array
  */
 template <typename T>
-T*
+[[nodiscard]] T*
 copyCreateDevice2DeviceArray(const T* device_array,
                              const stdgpu::index64_t count,
                              const MemoryCopy check_safety = MemoryCopy::RANGE_CHECK);

--- a/src/stdgpu/mutex.cuh
+++ b/src/stdgpu/mutex.cuh
@@ -107,7 +107,7 @@ public:
      * \param[in] allocator The allocator instance to use
      * \return A newly created object of this class allocated on the GPU (device)
      */
-    static mutex_array
+    [[nodiscard]] static mutex_array
     createDeviceObject(const index_t& size, const Allocator& allocator = Allocator());
 
     /**
@@ -120,7 +120,7 @@ public:
      */
     template <typename ExecutionPolicy,
               STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
-    static mutex_array
+    [[nodiscard]] static mutex_array
     createDeviceObject(ExecutionPolicy&& policy, const index_t& size, const Allocator& allocator = Allocator());
 
     /**

--- a/src/stdgpu/queue.cuh
+++ b/src/stdgpu/queue.cuh
@@ -65,7 +65,7 @@ public:
      * \param[in] size The size of managed array
      * \return A newly created object of this class allocated on the GPU (device)
      */
-    static queue<T, ContainerT>
+    [[nodiscard]] static queue<T, ContainerT>
     createDeviceObject(const index_t& size);
 
     /**

--- a/src/stdgpu/stack.cuh
+++ b/src/stdgpu/stack.cuh
@@ -65,7 +65,7 @@ public:
      * \param[in] size The size of managed array
      * \return A newly created object of this class allocated on the GPU (device)
      */
-    static stack<T, ContainerT>
+    [[nodiscard]] static stack<T, ContainerT>
     createDeviceObject(const index_t& size);
 
     /**

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -103,7 +103,7 @@ public:
      * \pre capacity > 0
      * \return A newly created object of this class allocated on the GPU (device)
      */
-    static unordered_map
+    [[nodiscard]] static unordered_map
     createDeviceObject(const index_t& capacity, const Allocator& allocator = Allocator());
 
     /**
@@ -116,7 +116,7 @@ public:
      */
     template <typename ExecutionPolicy,
               STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
-    static unordered_map
+    [[nodiscard]] static unordered_map
     createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator = Allocator());
 
     /**

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -92,7 +92,7 @@ public:
      * \pre capacity > 0
      * \return A newly created object of this class allocated on the GPU (device)
      */
-    static unordered_set
+    [[nodiscard]] static unordered_set
     createDeviceObject(const index_t& capacity, const Allocator& allocator = Allocator());
 
     /**
@@ -105,7 +105,7 @@ public:
      */
     template <typename ExecutionPolicy,
               STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
-    static unordered_set
+    [[nodiscard]] static unordered_set
     createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator = Allocator());
 
     /**

--- a/src/stdgpu/vector.cuh
+++ b/src/stdgpu/vector.cuh
@@ -100,7 +100,7 @@ public:
      * \return A newly created object of this class allocated on the GPU (device)
      * \pre capacity > 0
      */
-    static vector<T, Allocator>
+    [[nodiscard]] static vector<T, Allocator>
     createDeviceObject(const index_t& capacity, const Allocator& allocator = Allocator());
 
     /**
@@ -113,7 +113,7 @@ public:
      */
     template <typename ExecutionPolicy,
               STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
-    static vector<T, Allocator>
+    [[nodiscard]] static vector<T, Allocator>
     createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator = Allocator());
 
     /**

--- a/tests/stdgpu/memory.inc
+++ b/tests/stdgpu/memory.inc
@@ -1209,7 +1209,7 @@ class TestContainer
 public:
     TestContainer() = default;
 
-    static TestContainer
+    [[nodiscard]] static TestContainer
     createDeviceObject(const stdgpu::index_t size, const Allocator& allocator = Allocator())
     {
         TestContainer result;
@@ -1225,7 +1225,7 @@ public:
 
     template <typename ExecutionPolicy,
               STDGPU_DETAIL_OVERLOAD_IF(stdgpu::is_execution_policy_v<stdgpu::remove_cvref_t<ExecutionPolicy>>)>
-    static TestContainer
+    [[nodiscard]] static TestContainer
     createDeviceObject([[maybe_unused]] ExecutionPolicy&& policy,
                        const stdgpu::index_t size,
                        const Allocator& allocator = Allocator())


### PR DESCRIPTION
The `create*` API returns the newly constructed and initialized object that can then be used. However, ignoring the return value will result in loosing access to that object and thus will lead not only to a likely crash but also to a memory leak. Add the `[[nodiscard]]` attribute to these functions to better warn users of this issue and indicate the correct usage of these functions.