### PR TITLE
deque: Add nodiscard attribute to create* API

### DIFF
--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -80,7 +80,7 @@ public:
      * \return A newly created object of this class allocated on the GPU (device)
      * \pre capacity > 0
      */
-    static deque<T, Allocator>
+    [[nodiscard]] static deque<T, Allocator>
     createDeviceObject(const index_t& capacity, const Allocator& allocator = Allocator());
 
     /**
@@ -93,7 +93,7 @@ public:
      */
     template <typename ExecutionPolicy,
               STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
-    static deque<T, Allocator>
+    [[nodiscard]] static deque<T, Allocator>
     createDeviceObject(ExecutionPolicy&& policy, const index_t& capacity, const Allocator& allocator = Allocator());
 
     /**


### PR DESCRIPTION
In #409 the `[[nodiscard]]`  attribute has been added to the `create*` API. However, `deque` has been accidentally missed out. Also add the attribute for this class to fix this oversight.