### PR TITLE
unordered_map,unordered_set: Fix excess list size for very low capacities

### DIFF
--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -1203,9 +1203,10 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::createDevic
     index_t bucket_count = static_cast<index_t>(
             bit_ceil(static_cast<std::size_t>(std::ceil(static_cast<float>(capacity) / default_max_load_factor()))));
 
-    // excess count is estimated by the expected collision count and conservatively lowered since entries falling into
-    // regular buckets are already included here
-    index_t excess_count = std::max<index_t>(1, expected_collisions(bucket_count, capacity) * 2 / 3);
+    // excess count is estimated by the expected collision count:
+    // - Conservatively lower the amount since entries falling into regular buckets are already included here
+    // - Increase amount by 1 since insertion expects a non-empty excess list also in case of no collision
+    index_t excess_count = std::max<index_t>(1, expected_collisions(bucket_count, capacity) * 2 / 3 + 1);
 
     index_t total_count = bucket_count + excess_count;
 


### PR DESCRIPTION
The size of the internal excess list of `unordered_map` and `unordered_set` is determined by the expected amount of collisions, but at least 1. However, insertion as a precaution requires a non-empty excess list to proceed even if the inserted element will not produce a collision. In case of very small capacities, e.g. `n = 4`, this may result in insertion failures if a collision happens. Increase the excess count by 1 to account for this "reserved" element.

Closes #411 