### PR TITLE
docs: Update dependencies and workaround further style issues

### DIFF
--- a/docs/_static/extra_stylesheet.css
+++ b/docs/_static/extra_stylesheet.css
@@ -2496,3 +2496,10 @@ html[data-theme=dark] .doxygen-content doxygen-awesome-dark-mode-toggle:hover {
 html[data-theme=dark] .doxygen-content .tabs-overview button.tab-button:hover .tab-title {
     color: var(--page-foreground-color);
 }
+
+/*
+ Alignment for Doxygen tables (eg: Modules)
+*/
+.doxygen-content .contents {
+    justify-content: left;
+}

--- a/docs/_static/stdgpu_custom_doxygen.css
+++ b/docs/_static/stdgpu_custom_doxygen.css
@@ -77,3 +77,26 @@
 .doxygen-content .contents .memdoc {
     margin-bottom: 10px;
 }
+
+
+/* Remove borders from tables */
+.doxygen-content table,
+.doxygen-content table td,
+.doxygen-content td.mempage {
+    border: 0;
+}
+
+
+/* Fix buggy background color in documentation */
+.doxygen-content table.memberdecls .memSeparator,
+.doxygen-content td.mempage,
+.doxygen-content table.memberdecls tr,
+.doxygen-content table.params tr,
+.doxygen-content table.tparams tr {
+    background-color: var(--pst-color-background) !important;
+}
+
+.doxygen-content table.memname tr,
+.doxygen-content table.mlabels tr {
+    background-color: var(--fragment-background) !important;
+}

--- a/docs/_static/stdgpu_custom_sphinx.css
+++ b/docs/_static/stdgpu_custom_sphinx.css
@@ -31,3 +31,26 @@ footer.bd-footer-content {
     --sd-color-tabs-overline: var(--pst-color-border) !important;
     --sd-color-tabs-underline: var(--pst-color-border) !important;
 }
+
+
+/* Approximately replicated (somehow) broken style of tabs in sphinx-design */
+.sd-tab-set,
+.sd-tab-content,
+.sd-tab-set > label {
+    background-color: var(--pst-color-background) !important;
+}
+
+.bd-content .sd-tab-set .sd-tab-content,
+.bd-content .sd-tab-set > input:checked + label {
+    border: 0;
+}
+
+.sd-tab-content {
+    padding: 0 !important;
+    padding-bottom: .75rem !important;
+    padding-top: .75rem !important;
+}
+
+.bd-content .sd-tab-set > input:checked + label {
+    border-bottom: 0.125rem solid  var(--pst-color-primary);
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,10 @@ myst_enable_extensions = [
 myst_heading_anchors = 3
 
 doxylink = {
-    "stdgpu": (str(pathlib.Path(__file__).parent / "doxygen" / "tagfile.xml"), "doxygen"),
+    "stdgpu": (
+        str(pathlib.Path(__file__).parent / "doxygen" / "tagfile.xml"),
+        "doxygen",
+    ),
 }
 
 
@@ -62,8 +65,8 @@ html_theme_options = {
     # Footer
     "extra_footer": 'Made with <a href="https://www.sphinx-doc.org/">Sphinx</a>, <a href="https://www.doxygen.org/index.html">Doxygen</a>, <a href="https://boschglobal.github.io/doxysphinx/">Doxysphinx</a> and <a href="https://sphinx-book-theme.readthedocs.io/">sphinx-book-theme</a>, <a href="https://jothepro.github.io/doxygen-awesome-css/">Doxygen Awesome</a>',
     # Code fragments
-    "pygment_light_style": "a11y-high-contrast-light", # same as in sphinx-book-theme
-    "pygment_dark_style": "a11y-dark",
+    "pygments_light_style": "a11y-high-contrast-light",  # same as in sphinx-book-theme
+    "pygments_dark_style": "a11y-dark",
 }
 
 html_favicon = "_static/stdgpu_logo.ico"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx
-sphinx-book-theme~=1.0.1
+sphinx-book-theme
 sphinx_copybutton
 sphinx-design
 sphinx-togglebutton


### PR DESCRIPTION
Recently, several of our dependencies for the documentation received some updates. While there seem to be some issues with the styling, it is still better to keep them up to date. Remove the restriction on the Sphinx Book Theme and add some workaround for the style issues.

The doxygen version is kept fixed for the time being as this requires some further testing as well as checking if e.g. doxysphinx is compatible.