### PR TITLE
cmake,scripts: Improve thrust detection and upgrade used version in CI

### DIFF
--- a/tools/backend/check_install_openmp.sh
+++ b/tools/backend/check_install_openmp.sh
@@ -13,5 +13,5 @@ sh tools/backend/helper/create_empty_directory.sh build_install_test
 
 # Compile dependent project
 cmake -E cmake_echo_color --blue ">>>>> Check installation ($CONFIG)"
-cmake -B build_install_test -S tests/install_test -DCMAKE_BUILD_TYPE=$CONFIG -Dstdgpu_ROOT=bin -Dthrust_ROOT=external/thrust $@
+cmake -B build_install_test -S tests/install_test -DCMAKE_BUILD_TYPE=$CONFIG -Dstdgpu_ROOT=bin -Dthrust_ROOT=external/cccl/thrust $@
 cmake --build build_install_test --config ${CONFIG} --parallel 13

--- a/tools/backend/configure_openmp.sh
+++ b/tools/backend/configure_openmp.sh
@@ -12,4 +12,4 @@ fi
 sh tools/backend/helper/create_empty_directory.sh build
 
 # Configure project
-sh tools/backend/helper/configure.sh $CONFIG -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/thrust -DCMAKE_VERIFY_INTERFACE_HEADER_SETS=ON $@
+sh tools/backend/helper/configure.sh $CONFIG -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/cccl/thrust -DCMAKE_VERIFY_INTERFACE_HEADER_SETS=ON $@

--- a/tools/backend/configure_openmp_clang_tidy.sh
+++ b/tools/backend/configure_openmp_clang_tidy.sh
@@ -5,4 +5,4 @@ set -e
 sh tools/backend/helper/create_empty_directory.sh build
 
 # Configure project
-sh tools/backend/helper/configure.sh Debug -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_ANALYZE_WITH_CLANG_TIDY=ON -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/thrust
+sh tools/backend/helper/configure.sh Debug -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_ANALYZE_WITH_CLANG_TIDY=ON -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/cccl/thrust

--- a/tools/backend/configure_openmp_cppcheck.sh
+++ b/tools/backend/configure_openmp_cppcheck.sh
@@ -5,4 +5,4 @@ set -e
 sh tools/backend/helper/create_empty_directory.sh build
 
 # Configure project
-sh tools/backend/helper/configure.sh Debug -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_ANALYZE_WITH_CPPCHECK=ON -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/thrust
+sh tools/backend/helper/configure.sh Debug -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_ANALYZE_WITH_CPPCHECK=ON -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/cccl/thrust

--- a/tools/backend/configure_openmp_documentation.sh
+++ b/tools/backend/configure_openmp_documentation.sh
@@ -5,4 +5,4 @@ set -e
 sh tools/backend/helper/create_empty_directory.sh build
 
 # Configure project
-sh tools/backend/helper/configure.sh Release -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_BUILD_DOCUMENTATION=ON -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/thrust
+sh tools/backend/helper/configure.sh Release -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_BUILD_DOCUMENTATION=ON -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/cccl/thrust

--- a/tools/backend/configure_openmp_lcov.sh
+++ b/tools/backend/configure_openmp_lcov.sh
@@ -5,4 +5,4 @@ set -e
 sh tools/backend/helper/create_empty_directory.sh build
 
 # Configure project
-sh tools/backend/helper/configure.sh Debug -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_BUILD_TEST_COVERAGE=ON -Dthrust_ROOT=external/thrust
+sh tools/backend/helper/configure.sh Debug -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_BUILD_TEST_COVERAGE=ON -Dthrust_ROOT=external/cccl/thrust

--- a/tools/dev/download_thrust.sh
+++ b/tools/dev/download_thrust.sh
@@ -2,6 +2,6 @@
 set -e
 
 cmake -E cmake_echo_color --blue ">>>>> Download thrust"
-cmake -E chdir external git clone https://github.com/NVIDIA/thrust
-cmake -E chdir external/thrust git fetch --all --tags --prune
-cmake -E chdir external/thrust git checkout tags/1.17.2
+cmake -E chdir external git clone https://github.com/NVIDIA/cccl
+cmake -E chdir external/cccl git fetch --all --tags --prune
+cmake -E chdir external/cccl git checkout tags/v2.2.0


### PR DESCRIPTION
Thrust has been merged together with libcudacxx and CUB into the [CUDA C++ Core Libraries (CCCL)](https://github.com/NVIDIA/cccl). Furthermore, thrust 2.X now requires libcudacxx, so our current way of detecting thrust may be incomplete. Extend `Findthrust.cmake` to account for this new scenario and upgrade the thrust version used in the CI to stay up to date.

Although CCCL 2.4.0 is the newest version, we employ 2.2.0 as there are some outstanding compiler issues with CUDA 12.4+ (which comes with such a more recent version).