### PR TITLE
tests: Upgrade googletest to 1.14

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,8 +3,8 @@ include(FetchContent)
 FetchContent_Declare(
     googletest
     PREFIX googletest
-    URL https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip
-    URL_HASH SHA256=ffa17fbc5953900994e2deec164bb8949879ea09b411e07f215bfbb1f87f4632
+    URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+    URL_HASH SHA256=1f357c27ca988c3f7c6b4bf68a9395005ac6761f034046e9dde0896e3aba00e4
     DOWNLOAD_DIR "${STDGPU_EXTERNAL_DIR}/googletest"
 )
 


### PR DESCRIPTION
A new release of googletest is available. Pull in this new version to benefit from the major improvements and cleanups.