### PR TITLE
add `occupied(n)` for unordered set and map

### DIFF
--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -359,6 +359,13 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::clear(ExecutionPolicy&& policy
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+inline STDGPU_DEVICE_ONLY bool
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::occupied(const index_t n) const
+{
+    return _base.occupied(n);
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 unordered_map<Key, T, Hash, KeyEqual, Allocator>
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::createDeviceObject(const index_t& capacity,
                                                                      const Allocator& allocator)

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -341,6 +341,13 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::clear(ExecutionPolicy&& policy)
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+inline STDGPU_DEVICE_ONLY bool
+unordered_set<Key, Hash, KeyEqual, Allocator>::occupied(const index_t n) const
+{
+    return _base.occupied(n);
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 unordered_set<Key, Hash, KeyEqual, Allocator>
 unordered_set<Key, Hash, KeyEqual, Allocator>::createDeviceObject(const index_t& capacity, const Allocator& allocator)
 {

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -484,6 +484,14 @@ public:
     STDGPU_HOST_DEVICE key_equal
     key_eq() const;
 
+    /**
+     * \brief Checks if the given bucket is occupied
+     * \param[in] n The bucket index
+     * \return True if the bucket is occupied, false otherwise
+     */
+    STDGPU_DEVICE_ONLY bool
+    occupied(const index_t n) const;
+
 private:
     using base_type =
             detail::unordered_base<key_type, value_type, detail::select1st<value_type>, hasher, key_equal, Allocator>;

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -473,6 +473,14 @@ public:
     STDGPU_HOST_DEVICE key_equal
     key_eq() const;
 
+    /**
+     * \brief Checks if the given bucket is occupied
+     * \param[in] n The bucket index
+     * \return True if the bucket is occupied, false otherwise
+     */
+    STDGPU_DEVICE_ONLY bool
+    occupied(const index_t n) const;
+
 private:
     using base_type = detail::unordered_base<key_type, value_type, identity, hasher, key_equal, Allocator>;
 


### PR DESCRIPTION
Add `bool occupied(index n)` function for unordered_set and unordered_map. So that we can:

```cu
struct AllocateNewBlocks {
  AllocateNewBlocks(stdgpu::unorderd_map<xx> block_map,
                    BlockBuffer buffer_buffer,
                    stdgpu::unorderd_set<xx> not_exist_block_indices)
      : buffer_buffer(buffer_buffer),
        block_map(block_map),
        not_exist_block_indices(not_exist_block_indices) {}

  __device__ void operator()(const stdgpu::index_t index) {
    if (!not_exist_block_indices.occupied(index)) { // Used here.
      return;
    }
    const BlockIndex block_index = *(not_exist_block_indices.begin() + index);
    if (const auto& [iter, is_inserted] = block_map.emplace(block_index, 0); is_inserted) {
      iter->second = buffer_view.AllocateBlock();
    }
  }

  BlockBuffer buffer_buffer;
  stdgpu::unorderd_map<xx> block_map;
  stdgpu::unorderd_set<xx> not_exist_block_indices;
}; 


stdgpu::for_each_index(thrust::cuda::par.on(stream()),
                       not_exist_block_indices().max_size(),
                       AllocateNewBlocks(block_map, block_buffer, not_exist_block_indices);
```

It skips the need for getting `device_range`.
