### PR TITLE
Fix thrust namespace for CUDA 12.6

### DIFF
--- a/src/stdgpu/impl/iterator_detail.h
+++ b/src/stdgpu/impl/iterator_detail.h
@@ -387,7 +387,8 @@ inserter(Container& c)
 
 } // namespace stdgpu
 
-namespace thrust::detail
+THRUST_NAMESPACE_BEGIN
+namespace detail
 {
 
 template <typename Container>
@@ -405,6 +406,7 @@ struct is_proxy_reference<stdgpu::detail::insert_iterator_proxy<Container>> : pu
 {
 };
 
-} // namespace thrust::detail
+} // namespace detail
+THRUST_NAMESPACE_END
 
 #endif // STDGPU_ITERATORDETAIL_H


### PR DESCRIPTION
Affecting compilation issue mentioned here: https://github.com/stotko/stdgpu/issues/417#issuecomment-2286612930. The other device-code compilation errors with CUDA 12.5 mentioned in the issue are not adressed with this PR.

Thrust changed the namespace for its implementations from `thrust::` to `thrust::<<ABI_IDENTIFIER>>::` since thrust 2.3.0.

For the few template specializations in iterator_impl, its necessary to to use the correct namespaces. Using the `THRUST_NAMESPACE_BEGIN/END` marcos should make sure that we always use the correct namespace, even with older CUDA Toolkit versions, but I did not exhaustively test that.