### PR TITLE
General: Bump required thrust version to 1.13.1

### DIFF
--- a/docs/getting_started/building_from_source.md
+++ b/docs/getting_started/building_from_source.md
@@ -24,7 +24,7 @@ Before building the library, please make sure that all required development tool
 - CUDA compiler
     - NVCC (Already included in CUDA Toolkit)
     - Clang 10: `sudo apt install clang`
-- CUDA Toolkit 11.0: <https://developer.nvidia.com/cuda-downloads>
+- CUDA Toolkit 11.5: <https://developer.nvidia.com/cuda-downloads>
 - CMake 3.18: `sudo apt install cmake`
 
 :::
@@ -36,7 +36,7 @@ Before building the library, please make sure that all required development tool
     - GCC 9: `sudo apt install g++`
     - Clang 10: `sudo apt install clang libomp-dev`
 - CMake 3.18: `sudo apt install cmake`
-- thrust 1.9.9: <https://github.com/NVIDIA/thrust>
+- thrust 1.13.1: <https://github.com/NVIDIA/thrust>
 
 :::
 
@@ -69,7 +69,7 @@ Before building the library, please make sure that all required development tool
     - MSVC 19.20 (Visual Studio 2019) <https://visualstudio.microsoft.com/downloads/>
 - CUDA compiler
     - NVCC (Already included in CUDA Toolkit)
-- CUDA Toolkit 11.0: <https://developer.nvidia.com/cuda-downloads>
+- CUDA Toolkit 11.5: <https://developer.nvidia.com/cuda-downloads>
 - CMake 3.18: <https://cmake.org/download>
 
 :::
@@ -80,7 +80,7 @@ Before building the library, please make sure that all required development tool
 - C++17 compiler including OpenMP 2.0
     - MSVC 19.20 (Visual Studio 2019) <https://visualstudio.microsoft.com/downloads/>
 - CMake 3.18: <https://cmake.org/download>
-- thrust 1.9.9: <https://github.com/NVIDIA/thrust>
+- thrust 1.13.1: <https://github.com/NVIDIA/thrust>
 
 :::
 

--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -4,10 +4,10 @@ set(STDGPU_BUILD_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")
 set(STDGPU_BUILD_CMAKE_DIR "${CMAKE_CURRENT_BINARY_DIR}/cmake")
 
 # Setup dependencies
-find_package(thrust 1.9.9 REQUIRED MODULE)
+find_package(thrust 1.13.1 REQUIRED MODULE)
 
 set(STDGPU_DEPENDENCIES_INIT "
-find_dependency(thrust 1.9.9 REQUIRED MODULE)
+find_dependency(thrust 1.13.1 REQUIRED MODULE)
 ")
 
 

--- a/src/stdgpu/cuda/CMakeLists.txt
+++ b/src/stdgpu/cuda/CMakeLists.txt
@@ -1,8 +1,8 @@
 
-find_package(CUDAToolkit 11.0 REQUIRED MODULE)
+find_package(CUDAToolkit 11.5 REQUIRED MODULE)
 
 set(STDGPU_DEPENDENCIES_BACKEND_INIT "
-find_dependency(CUDAToolkit 11.0 REQUIRED MODULE)
+find_dependency(CUDAToolkit 11.5 REQUIRED MODULE)
 " PARENT_SCOPE)
 
 target_sources(stdgpu PRIVATE impl/device.cpp


### PR DESCRIPTION
Fixing a compilation issue with thrust on CUDA 12.6 required leveraging a macro that was introduced in thrust 1.13.1 (and CUDA 11.5), see #428. Although we technically support version down to CUDA 11.0 (released March 2020), such an old version will very likely not be used as support for the current GPU generations (RTX 30XX and 40XX) was not present at that time. Thus, bump to the requirements to thrust 1.13.1 and CUDA 11.5 (released October 2021). This may also unblock some further cleanups in the future.