### PR TITLE
docs: Use author field for Sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,8 @@ import pathlib
 project = "stdgpu"
 version = "Latest"
 release = version
-copyright = "2019, Patrick Stotko"
-# author = "Patrick Stotko"
+copyright = "2019"
+author = "Patrick Stotko"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Previously, the `author` field was not used such that this information was provided in the `copyright` field. With the more recent versions of Sphinx and other related libraries, the `author` field became mandatory. Use it to avoid the default "Author not set" text.