### PR TITLE
memory: Drop workaround for to_address

### DIFF
--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -670,9 +670,6 @@ to_address(T* p) noexcept
     return p;
 }
 
-// Use pre-C++17 SFINAE for dispatching due to wrong missing-return warning caused by NVCC
-// (potentially fixed in CUDA 11.5+)
-/*
 template <typename Ptr>
 STDGPU_HOST_DEVICE auto
 to_address(const Ptr& p) noexcept
@@ -692,22 +689,6 @@ to_address(const Ptr& p) noexcept
         // This reduces the number of compiler errors in calling contexts and makes the failed assertion more apparent.
         return static_cast<void*>(nullptr);
     }
-}
-*/
-
-template <typename Ptr, STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(detail::has_arrow_operator_v<Ptr>)>
-STDGPU_HOST_DEVICE auto
-to_address(const Ptr& p) noexcept
-{
-    return to_address(p.operator->());
-}
-
-template <typename Ptr,
-          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(!detail::has_arrow_operator_v<Ptr> && detail::has_get_v<Ptr>)>
-STDGPU_HOST_DEVICE auto
-to_address(const Ptr& p) noexcept
-{
-    return to_address(p.get());
 }
 
 template <typename T, typename... Args>

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -741,17 +741,11 @@ to_address(T* p) noexcept;
  * \brief Converts a potential fancy pointer to a raw pointer
  * \tparam Ptr The fancy pointer type
  * \param[in] p A fancy pointer
- * \return The raw pointer held by the fancy pointer obtained via operator->()
+ * \return The raw pointer held by the fancy pointer obtained via operator->() or get()
  */
-template <typename Ptr, STDGPU_DETAIL_OVERLOAD_IF(detail::has_arrow_operator_v<Ptr>)>
+template <typename Ptr>
 STDGPU_HOST_DEVICE auto
 to_address(const Ptr& p) noexcept;
-
-//! @cond Doxygen_Suppress
-template <typename Ptr, STDGPU_DETAIL_OVERLOAD_IF(!detail::has_arrow_operator_v<Ptr> && detail::has_get_v<Ptr>)>
-STDGPU_HOST_DEVICE auto
-to_address(const Ptr& p) noexcept;
-//! @endcond
 
 /**
  * \ingroup memory


### PR DESCRIPTION
Due to the recently bumped requirements for CUDA, the workaround for `to_address`  in `memory` to avoid a compiler warning is no longer needed. Drop this pre C++17 SFINAE version in favor of the simpler version leveraging constexpr syntax.