### PR TITLE
algorithm,memory,numeric: Improve thrust compatibility via ADL barriers

### DIFF
--- a/src/stdgpu/algorithm.h
+++ b/src/stdgpu/algorithm.h
@@ -86,6 +86,8 @@ template <typename IndexType,
 void
 for_each_index(ExecutionPolicy&& policy, IndexType size, UnaryFunction f);
 
+#ifdef STDGPU_RUN_DOXYGEN
+
 /**
  * \ingroup algorithm
  * \brief Writes the given value into the given range using the copy assignment operator
@@ -164,6 +166,47 @@ template <typename ExecutionPolicy,
           STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 OutputIt
 copy_n(ExecutionPolicy&& policy, InputIt begin, Size n, OutputIt output_begin);
+
+#endif
+
+//! @cond Doxygen_Suppress
+namespace adl_barrier
+{
+
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+void
+fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const T& value);
+
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename Size,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+Iterator
+fill_n(ExecutionPolicy&& policy, Iterator begin, Size n, const T& value);
+
+template <typename ExecutionPolicy,
+          typename InputIt,
+          typename OutputIt,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+OutputIt
+copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputIt output_begin);
+
+template <typename ExecutionPolicy,
+          typename InputIt,
+          typename Size,
+          typename OutputIt,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+OutputIt
+copy_n(ExecutionPolicy&& policy, InputIt begin, Size n, OutputIt output_begin);
+
+} // namespace adl_barrier
+
+using namespace adl_barrier;
+//! @endcond
 
 } // namespace stdgpu
 

--- a/src/stdgpu/impl/algorithm_detail.h
+++ b/src/stdgpu/impl/algorithm_detail.h
@@ -85,6 +85,8 @@ private:
 };
 } // namespace detail
 
+namespace adl_barrier
+{
 template <typename ExecutionPolicy,
           typename Iterator,
           typename T,
@@ -106,6 +108,7 @@ fill_n(ExecutionPolicy&& policy, Iterator begin, Size n, const T& value)
     for_each_index(std::forward<ExecutionPolicy>(policy), n, detail::fill_functor<Iterator, T>(begin, value));
     return begin + n;
 }
+} // namespace adl_barrier
 
 namespace detail
 {
@@ -131,6 +134,8 @@ private:
 };
 } // namespace detail
 
+namespace adl_barrier
+{
 template <typename ExecutionPolicy,
           typename InputIt,
           typename OutputIt,
@@ -154,6 +159,7 @@ copy_n(ExecutionPolicy&& policy, InputIt begin, Size n, OutputIt output_begin)
                    detail::copy_functor<InputIt, OutputIt>(begin, output_begin));
     return output_begin + n;
 }
+} // namespace adl_barrier
 
 } // namespace stdgpu
 

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -705,6 +705,8 @@ destroy_at(T* p)
     p->~T();
 }
 
+namespace adl_barrier
+{
 template <typename ExecutionPolicy,
           typename Iterator,
           typename T,
@@ -781,6 +783,7 @@ destroy_n(ExecutionPolicy&& policy, Iterator first, Size n)
 
     return last;
 }
+} // namespace adl_barrier
 
 template <>
 dynamic_memory_type

--- a/src/stdgpu/impl/numeric_detail.h
+++ b/src/stdgpu/impl/numeric_detail.h
@@ -49,6 +49,8 @@ private:
 };
 } // namespace detail
 
+namespace adl_barrier
+{
 template <typename ExecutionPolicy,
           typename Iterator,
           typename T,
@@ -60,6 +62,7 @@ iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value)
                    static_cast<index_t>(end - begin),
                    detail::iota_functor<Iterator, T>(begin, value));
 }
+} // namespace adl_barrier
 
 template <typename IndexType,
           typename ExecutionPolicy,

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -770,6 +770,8 @@ template <typename T>
 STDGPU_HOST_DEVICE void
 destroy_at(T* p);
 
+#ifdef STDGPU_RUN_DOXYGEN
+
 /**
  * \ingroup memory
  * \brief Writes the given value to into the given range using the copy constructor
@@ -881,6 +883,60 @@ template <typename ExecutionPolicy,
           STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 Iterator
 destroy_n(ExecutionPolicy&& policy, Iterator first, Size n);
+
+#endif
+
+//! @cond Doxygen_Suppress
+namespace adl_barrier
+{
+
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+void
+uninitialized_fill(ExecutionPolicy&& policy, Iterator begin, Iterator end, const T& value);
+
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename Size,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+Iterator
+uninitialized_fill_n(ExecutionPolicy&& policy, Iterator begin, Size n, const T& value);
+
+template <typename ExecutionPolicy,
+          typename InputIt,
+          typename OutputIt,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+OutputIt
+uninitialized_copy(ExecutionPolicy&& policy, InputIt begin, InputIt end, OutputIt output_begin);
+
+template <typename ExecutionPolicy,
+          typename InputIt,
+          typename Size,
+          typename OutputIt,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+OutputIt
+uninitialized_copy_n(ExecutionPolicy&& policy, InputIt begin, Size n, OutputIt output_begin);
+
+template <typename ExecutionPolicy,
+          typename Iterator,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+void
+destroy(ExecutionPolicy&& policy, Iterator first, Iterator last);
+
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename Size,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+Iterator
+destroy_n(ExecutionPolicy&& policy, Iterator first, Size n);
+
+} // namespace adl_barrier
+
+using namespace adl_barrier;
+//! @endcond
 
 /**
  * \ingroup memory

--- a/src/stdgpu/numeric.h
+++ b/src/stdgpu/numeric.h
@@ -30,6 +30,8 @@
 namespace stdgpu
 {
 
+#ifdef STDGPU_RUN_DOXYGEN
+
 /**
  * \ingroup numeric
  * \brief Writes ascending values {values + i} to the i-th position of the given range
@@ -47,6 +49,24 @@ template <typename ExecutionPolicy,
           STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 void
 iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value);
+
+#endif
+
+//! @cond Doxygen_Suppress
+namespace adl_barrier
+{
+
+template <typename ExecutionPolicy,
+          typename Iterator,
+          typename T,
+          STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+void
+iota(ExecutionPolicy&& policy, Iterator begin, Iterator end, T value);
+
+} // namespace adl_barrier
+
+using namespace adl_barrier;
+//! @endcond
 
 /**
  * \ingroup numeric


### PR DESCRIPTION
The recently introduced custom `pair` implementation in #425 resulted in regressions when using thrust's algorithms that have also been implemented by us, e.g. `thrust::copy(...)`. This is caused by ADL since `pair` now is a member of the stdgpu namespace rather than thrust as before. Use ADL barriers to ensure that calling any algorithm from thrust will not accidentally delegate to our implementation.

Fixes #432 