### PR TITLE
unordered_map,unordered_set: Increase excess size

### DIFF
--- a/src/stdgpu/impl/unordered_base_detail.cuh
+++ b/src/stdgpu/impl/unordered_base_detail.cuh
@@ -1203,9 +1203,9 @@ unordered_base<Key, Value, KeyFromValue, Hash, KeyEqual, Allocator>::createDevic
             bit_ceil(static_cast<std::size_t>(std::ceil(static_cast<float>(capacity) / default_max_load_factor()))));
 
     // excess count is estimated by the expected collision count:
-    // - Conservatively lower the amount since entries falling into regular buckets are already included here
+    // - Keep the amount although it also counts bucket elements as this is based on assuming a uniform distribution
     // - Increase amount by 1 since insertion expects a non-empty excess list also in case of no collision
-    index_t excess_count = expected_collisions(bucket_count, capacity) * 2 / 3 + 1;
+    index_t excess_count = expected_collisions(bucket_count, capacity) + 1;
 
     index_t total_count = bucket_count + excess_count;
 

--- a/tests/stdgpu/unordered_datastructure.inc
+++ b/tests/stdgpu/unordered_datastructure.inc
@@ -1430,7 +1430,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_multiple_while_full)
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_while_excess_empty)
 {
-    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(2);
+    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1);
 
     // Fill tiny hash table
     const test_unordered_datastructure::key_type position_1(1, 2, 3);
@@ -1592,7 +1592,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_one_free
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_parallel_while_excess_empty)
 {
-    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(2);
+    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1);
 
     // Fill tiny hash table
     const test_unordered_datastructure::key_type position_1(1, 2, 3);
@@ -1688,7 +1688,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, emplace_parallel_while_one_fre
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, emplace_parallel_while_excess_empty)
 {
-    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(2);
+    test_unordered_datastructure tiny_hash_datastructure = test_unordered_datastructure::createDeviceObject(1);
 
     // Fill tiny hash table
     const test_unordered_datastructure::key_type position_1(1, 2, 3);


### PR DESCRIPTION
The excess size of `unordered_map` and `unordered_set` have been estimated based on the birthday paradox and then conservatively lowered as some amount of estimated collisions also includes entries sitting in a bucket instead of the excess list. This size adjustment has been performed to save memory. However, the underlying assumption of this estimate is a perfect uniform distribution of the hashes which is the best case scenario. With common hash functions, that distribution may be worse leading to a larger amount of required excess entries, especially at high load factors. Use the estimated number directly as it overestimates the excess list size by a factor close to 2 (about 90% collisions will typically be between exactly 2 entries). This has been tested to work better with high load factors up to 100%.