### PR TITLE
Expose occupied() in unordered map

### DIFF
--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -359,6 +359,13 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::clear(ExecutionPolicy&& policy
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+inline STDGPU_DEVICE_ONLY bool
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::occupied(const index_t n) const
+{
+    return _base.occupied(n);
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 unordered_map<Key, T, Hash, KeyEqual, Allocator>
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::createDeviceObject(const index_t& capacity,
                                                                      const Allocator& allocator)

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -422,6 +422,12 @@ public:
     clear(ExecutionPolicy&& policy);
 
     /**
+     * \brief Checks if the given index in the internal value array is occupied
+     */
+    STDGPU_DEVICE_ONLY bool
+    occupied(const index_t n) const;
+
+    /**
      * \brief Checks if the object is empty
      * \return True if the object is empty, false otherwise
      */


### PR DESCRIPTION
Useful when iterating over the whole hash and copying valid entries. 