### PR TITLE
Fix search directories for clang-format

### DIFF
--- a/cmake/setup_clang_format.cmake
+++ b/cmake/setup_clang_format.cmake
@@ -10,7 +10,7 @@ function(stdgpu_setup_clang_format)
     endif()
 
     foreach(FILE_EXT IN ITEMS ".h" ".cuh" ".cpp" ".cu" ".hip" ".inc")
-        foreach(FILE_DIR IN ITEMS "src/stdgpu" "examples" "benchmark/stdgpu" "test/stdgpu" "test/install_test")
+        foreach(FILE_DIR IN ITEMS "src" "examples" "benchmarks" "tests")
             file(GLOB_RECURSE SOURCE_FILES_PART LIST_DIRECTORIES FALSE "${FILE_DIR}/*${FILE_EXT}")
             list(APPEND SOURCE_FILES ${SOURCE_FILES_PART})
         endforeach()


### PR DESCRIPTION
After adopting the pitchfork layout in #394, the search directories used to collect all files applicable for clang-format were not updated. Thus, the formatting script as well as the accompanying check script missed half of the project since then. Fix this issue and also include helper files.