### PR TITLE
CI: Upgrade to Ubuntu 24.04 image

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   compute:
     name: "Compute"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04 # Keep Ubuntu 22.04 until compatibility with lcov has been improved
 
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
 
   publish:
     name: Upload coverage report to Codecov
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     needs:
       - compute
@@ -87,7 +87,7 @@ jobs:
       - publish
 
     name: "Check Coverage"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: re-actors/alls-green@release/v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
 
   publish:
     name: Upload latest docs to GitHub Pages
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event_name != 'pull_request'
 
     needs:
@@ -83,7 +83,7 @@ jobs:
       - publish
 
     name: "Check Docs"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: re-actors/alls-green@release/v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
 
   clangtidy:
     name: "Clang-Tidy"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
 
   cppcheck:
     name: "Cppcheck"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -118,7 +118,7 @@ jobs:
       - cppcheck
 
     name: "Check Lint"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: re-actors/alls-green@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
   ubuntu:
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-22.04']
+        os: ['ubuntu-22.04', 'ubuntu-24.04']
         build_type: [Debug, Release]
         shared_libs: [ON, OFF]
         use_32bit_index: [ON, OFF]
@@ -145,7 +145,7 @@ jobs:
       - windows
 
     name: "Check Tests"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: re-actors/alls-green@release/v1


### PR DESCRIPTION
The CI image for Ubuntu 24.04 has been released a few months ago and has matured until now. Upgrade most jobs to this version and drop the old Ubuntu 20.04.