### PR TITLE
src,test: Fix more cppcheck warnings

### DIFF
--- a/cmake/setup_cppcheck.cmake
+++ b/cmake/setup_cppcheck.cmake
@@ -2,7 +2,7 @@ function(stdgpu_setup_cppcheck STDGPU_OUTPUT_PROPERTY_CPPCHECK)
     find_package(Cppcheck REQUIRED)
 
     # Do not enable noisy "style" checks
-    set(${STDGPU_OUTPUT_PROPERTY_CPPCHECK} "${CPPCHECK_EXECUTABLE}" "--enable=warning,performance,portability" "--force" "--inline-suppr" "--quiet")
+    set(${STDGPU_OUTPUT_PROPERTY_CPPCHECK} "${CPPCHECK_EXECUTABLE}" "--enable=warning,performance,portability" "--force" "--inline-suppr" "--suppress=preprocessorErrorDirective" "--quiet")
 
     if(NOT DEFINED STDGPU_COMPILE_WARNING_AS_ERROR)
         message(FATAL_ERROR "STDGPU_COMPILE_WARNING_AS_ERROR not defined.")

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -600,7 +600,6 @@ template <typename Allocator>
 typename allocator_traits<Allocator>::pointer
 allocator_traits<Allocator>::allocate(Allocator& a,
                                       typename allocator_traits<Allocator>::index_type n,
-                                      // cppcheck-suppress syntaxError
                                       [[maybe_unused]] typename allocator_traits<Allocator>::const_void_pointer hint)
 {
     return a.allocate(n);
@@ -823,6 +822,7 @@ register_memory(T* p, index64_t n, dynamic_memory_type memory_type)
 {
     // NOLINTNEXTLINE(bugprone-multi-level-implicit-pointer-conversion)
     register_memory<void>(static_cast<void*>(const_cast<std::remove_cv_t<T>*>(p)),
+                          // cppcheck-suppress sizeofVoid
                           n * static_cast<index64_t>(sizeof(T)), // NOLINT(bugprone-sizeof-expression)
                           memory_type);
 }
@@ -837,6 +837,7 @@ deregister_memory(T* p, index64_t n, dynamic_memory_type memory_type)
 {
     // NOLINTNEXTLINE(bugprone-multi-level-implicit-pointer-conversion)
     deregister_memory<void>(static_cast<void*>(const_cast<std::remove_cv_t<T>*>(p)),
+                            // cppcheck-suppress sizeofVoid
                             n * static_cast<index64_t>(sizeof(T)), // NOLINT(bugprone-sizeof-expression)
                             memory_type);
 }

--- a/tests/stdgpu/algorithm.cpp
+++ b/tests/stdgpu/algorithm.cpp
@@ -405,7 +405,7 @@ public:
     }
 
 private:
-    float _f;
+    float _f = {};
 };
 
 TEST_F(stdgpu_algorithm, copy)

--- a/tests/stdgpu/atomic.inc
+++ b/tests/stdgpu/atomic.inc
@@ -1334,7 +1334,6 @@ public:
 
 private:
     stdgpu::atomic<T> _value;
-    T* _sequence;
     T _one_pattern;
 };
 
@@ -1358,7 +1357,6 @@ public:
 
 private:
     stdgpu::atomic<T> _value;
-    T* _sequence;
     T _one_pattern;
 };
 

--- a/tests/stdgpu/functional.cpp
+++ b/tests/stdgpu/functional.cpp
@@ -256,7 +256,6 @@ enum old_enum : std::int8_t
     three = 3
 };
 
-// cppcheck-suppress syntaxError
 TEST_F(stdgpu_functional, hash_enum)
 {
     std::unordered_set<std::size_t> hashes;

--- a/tests/stdgpu/memory.inc
+++ b/tests/stdgpu/memory.inc
@@ -1972,7 +1972,7 @@ public:
     }
 
 private:
-    float _f;
+    float _f = {};
 };
 } // namespace
 


### PR DESCRIPTION
Recent versions of cppcheck have added more diagnostics to detect potential issues. Fix these issues to prepare for CI upgrade.