### PR TITLE
General: Upgrade to clang-format 18 style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,6 @@ BasedOnStyle:  Mozilla
 Standard: c++17
 AccessModifierOffset: -4
 AllowAllArgumentsOnNextLine: false
-AllowAllConstructorInitializersOnNextLine: false
 AlwaysBreakAfterReturnType: All
 BreakBeforeBraces: Allman
 ColumnLimit:     120
@@ -13,6 +12,7 @@ ContinuationIndentWidth: 8
 FixNamespaceComments: true
 IndentPPDirectives: BeforeHash
 IndentWidth:     4
+PackConstructorInitializers: Never
 ReflowComments:  true
 SpaceAfterTemplateKeyword: true
 SpaceInEmptyBlock: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   clangformat:
     name: "Clang-Format"
-    runs-on: ubuntu-20.04 # Keep Ubuntu 20.04 until raising the requirements to clang-format > 10
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/benchmarks/stdgpu/unordered_datastructure.inc
+++ b/benchmarks/stdgpu/unordered_datastructure.inc
@@ -80,9 +80,10 @@ create_values(const stdgpu::index_t N)
     benchmark_unordered_datastructure::key_type* host_keys =
             createHostArray<benchmark_unordered_datastructure::key_type>(N);
 
-    std::generate(host_keys, host_keys + N, [&dist, &rng]() {
-        return benchmark_unordered_datastructure::key_type(dist(rng), dist(rng), dist(rng));
-    });
+    std::generate(host_keys,
+                  host_keys + N,
+                  [&dist, &rng]()
+                  { return benchmark_unordered_datastructure::key_type(dist(rng), dist(rng), dist(rng)); });
 
     benchmark_unordered_datastructure::key_type* keys =
             copyCreateHost2DeviceArray<benchmark_unordered_datastructure::key_type>(host_keys, N);
@@ -131,8 +132,9 @@ extract_keys(benchmark_unordered_datastructure::value_type* values, const stdgpu
 }
 } // namespace
 
-void STDGPU_DETAIL_CAT2(STDGPU_UNORDERED_DATASTRUCTURE_BENCHMARK_CLASS, _insert)(benchmark::State& state,
-                                                                                 const stdgpu::index_t unordered_size)
+void
+STDGPU_DETAIL_CAT2(STDGPU_UNORDERED_DATASTRUCTURE_BENCHMARK_CLASS, _insert)(benchmark::State& state,
+                                                                            const stdgpu::index_t unordered_size)
 {
     // Use larger container to avoid unlikely but possible overflow of excess list
     benchmark_unordered_datastructure u = benchmark_unordered_datastructure::createDeviceObject(2 * unordered_size);
@@ -154,8 +156,9 @@ void STDGPU_DETAIL_CAT2(STDGPU_UNORDERED_DATASTRUCTURE_BENCHMARK_CLASS, _insert)
     destroyDeviceArray<benchmark_unordered_datastructure::value_type>(values);
 }
 
-void STDGPU_DETAIL_CAT2(STDGPU_UNORDERED_DATASTRUCTURE_BENCHMARK_CLASS, _erase)(benchmark::State& state,
-                                                                                const stdgpu::index_t unordered_size)
+void
+STDGPU_DETAIL_CAT2(STDGPU_UNORDERED_DATASTRUCTURE_BENCHMARK_CLASS, _erase)(benchmark::State& state,
+                                                                           const stdgpu::index_t unordered_size)
 {
     // Use larger container to avoid unlikely but possible overflow of excess list
     benchmark_unordered_datastructure u = benchmark_unordered_datastructure::createDeviceObject(2 * unordered_size);
@@ -178,8 +181,9 @@ void STDGPU_DETAIL_CAT2(STDGPU_UNORDERED_DATASTRUCTURE_BENCHMARK_CLASS, _erase)(
     destroyDeviceArray<benchmark_unordered_datastructure::key_type>(keys);
 }
 
-void STDGPU_DETAIL_CAT2(STDGPU_UNORDERED_DATASTRUCTURE_BENCHMARK_CLASS, _clear)(benchmark::State& state,
-                                                                                const stdgpu::index_t unordered_size)
+void
+STDGPU_DETAIL_CAT2(STDGPU_UNORDERED_DATASTRUCTURE_BENCHMARK_CLASS, _clear)(benchmark::State& state,
+                                                                           const stdgpu::index_t unordered_size)
 {
     // Use larger container to avoid unlikely but possible overflow of excess list
     benchmark_unordered_datastructure u = benchmark_unordered_datastructure::createDeviceObject(2 * unordered_size);
@@ -200,8 +204,9 @@ void STDGPU_DETAIL_CAT2(STDGPU_UNORDERED_DATASTRUCTURE_BENCHMARK_CLASS, _clear)(
     destroyDeviceArray<benchmark_unordered_datastructure::value_type>(values);
 }
 
-void STDGPU_DETAIL_CAT2(STDGPU_UNORDERED_DATASTRUCTURE_BENCHMARK_CLASS, _valid)(benchmark::State& state,
-                                                                                const stdgpu::index_t vector_size)
+void
+STDGPU_DETAIL_CAT2(STDGPU_UNORDERED_DATASTRUCTURE_BENCHMARK_CLASS, _valid)(benchmark::State& state,
+                                                                           const stdgpu::index_t vector_size)
 {
     benchmark_unordered_datastructure u = benchmark_unordered_datastructure::createDeviceObject(vector_size);
 

--- a/cmake/FindClangFormat.cmake
+++ b/cmake/FindClangFormat.cmake
@@ -1,7 +1,7 @@
 
 find_program(CLANG_FORMAT_EXECUTABLE
              NAMES
-             "clang-format-10" # Prefer exact version
+             "clang-format-18" # Prefer exact version
              "clang-format")
 
 if(CLANG_FORMAT_EXECUTABLE)

--- a/cmake/setup_clang_format.cmake
+++ b/cmake/setup_clang_format.cmake
@@ -1,8 +1,8 @@
 function(stdgpu_setup_clang_format)
     if(STDGPU_ALLOW_NEWER_CLANG_FORMAT_VERSIONS)
-        find_package(ClangFormat 10)
+        find_package(ClangFormat 18)
     else()
-        find_package(ClangFormat 10 EXACT)
+        find_package(ClangFormat 18 EXACT)
     endif()
 
     if (NOT ClangFormat_FOUND)

--- a/src/stdgpu/bitset.cuh
+++ b/src/stdgpu/bitset.cuh
@@ -95,7 +95,7 @@ public:
          * \return The old value of the bit
          */
         STDGPU_DEVICE_ONLY bool // NOLINT(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
-        operator=(const reference& x) noexcept;
+        operator=(const reference & x) noexcept;
 
         /**
          * \brief Deleted move constructor

--- a/src/stdgpu/impl/functional_detail.h
+++ b/src/stdgpu/impl/functional_detail.h
@@ -115,7 +115,7 @@ identity::operator()(T&& t) const noexcept
                                                                                                                        \
     template <typename T, typename U> /* NOLINTNEXTLINE(bugprone-macro-parentheses,misc-macro-parentheses) */          \
     inline STDGPU_HOST_DEVICE auto NAME<void>::operator()(T&& lhs, U&& rhs)                                            \
-            const->decltype(forward<T>(lhs) OP forward<U>(rhs))                                                        \
+            const -> decltype(forward<T>(lhs) OP forward<U>(rhs))                                                      \
     {                                                                                                                  \
         return forward<T>(lhs) OP forward<U>(rhs);                                                                     \
     }

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -454,10 +454,12 @@ device_unique_object<T>::device_unique_object(null_object_t /*null_object*/)
 template <typename T>
 template <typename... Args>
 device_unique_object<T>::device_unique_object(Args&&... args)
-  : _object(new T(T::createDeviceObject(std::forward<Args>(args)...)), [](T* ptr) {
-      T::destroyDeviceObject(*ptr);
-      delete ptr;
-  })
+  : _object(new T(T::createDeviceObject(std::forward<Args>(args)...)),
+            [](T* ptr)
+            {
+                T::destroyDeviceObject(*ptr);
+                delete ptr;
+            })
 {
 }
 
@@ -467,7 +469,8 @@ template <typename ExecutionPolicy,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 device_unique_object<T>::device_unique_object(ExecutionPolicy&& policy, Args&&... args)
   : _object(new T(T::createDeviceObject(std::forward<ExecutionPolicy>(policy), std::forward<Args>(args)...)),
-            [_policy = std::forward<ExecutionPolicy>(policy)](T* ptr) {
+            [_policy = std::forward<ExecutionPolicy>(policy)](T* ptr)
+            {
                 T::destroyDeviceObject(_policy, *ptr);
                 delete ptr;
             })

--- a/src/stdgpu/impl/type_traits_detail.h
+++ b/src/stdgpu/impl/type_traits_detail.h
@@ -64,10 +64,7 @@ STDGPU_DETAIL_DEFINE_TRAIT(is_iterator,
 STDGPU_DETAIL_DEFINE_TRAIT(is_transparent, typename T::is_transparent)
 
 STDGPU_DETAIL_DEFINE_TRAIT(has_get, decltype(std::declval<T>().get()))
-STDGPU_DETAIL_DEFINE_TRAIT(has_arrow_operator,
-                           decltype(std::declval<T>()
-                                            .
-                                            operator->()))
+STDGPU_DETAIL_DEFINE_TRAIT(has_arrow_operator, decltype(std::declval<T>().operator->()))
 
 STDGPU_DETAIL_DEFINE_TRAIT(is_disabled, typename T::is_disabled)
 

--- a/src/stdgpu/memory.h
+++ b/src/stdgpu/memory.h
@@ -347,7 +347,8 @@ public:
      * \brief Checks whether the unique object is not empty
      * \return True if the unique object is not empty, false otherwise
      */
-    explicit operator bool() const;
+    explicit
+    operator bool() const;
 
 private:
     std::unique_ptr<T, std::function<void(T*)>> _object;

--- a/tools/ubuntu/install_clang_format.sh
+++ b/tools/ubuntu/install_clang_format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-# Install clang-format version 10
+# Install clang-format version 18
 sudo apt-get update
-sudo apt-get install clang-format-10
+sudo apt-get install clang-format-18


### PR DESCRIPTION
Since the introduction of `clang-format`  in #275, some time has passed and recent versions have refined and added further options to styling. Upgrade the style to version **18** which comes with Ubuntu 24.04 and will be kept for the next few years.