### PR TITLE
memory: Simplify names of backend functions

### DIFF
--- a/src/stdgpu/cuda/impl/memory.cpp
+++ b/src/stdgpu/cuda/impl/memory.cpp
@@ -23,7 +23,7 @@ namespace stdgpu::cuda
 {
 
 void
-dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes)
+malloc(const dynamic_memory_type type, void** array, index64_t bytes)
 {
     switch (type)
     {
@@ -48,14 +48,14 @@ dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes)
         case dynamic_memory_type::invalid:
         default:
         {
-            printf("stdgpu::cuda::dispatch_malloc : Unsupported dynamic memory type\n");
+            printf("stdgpu::cuda::malloc : Unsupported dynamic memory type\n");
             return;
         }
     }
 }
 
 void
-dispatch_free(const dynamic_memory_type type, void* array)
+free(const dynamic_memory_type type, void* array)
 {
     switch (type)
     {
@@ -80,18 +80,18 @@ dispatch_free(const dynamic_memory_type type, void* array)
         case dynamic_memory_type::invalid:
         default:
         {
-            printf("stdgpu::cuda::dispatch_free : Unsupported dynamic memory type\n");
+            printf("stdgpu::cuda::free : Unsupported dynamic memory type\n");
             return;
         }
     }
 }
 
 void
-dispatch_memcpy(void* destination,
-                const void* source,
-                index64_t bytes,
-                dynamic_memory_type destination_type,
-                dynamic_memory_type source_type)
+memcpy(void* destination,
+       const void* source,
+       index64_t bytes,
+       dynamic_memory_type destination_type,
+       dynamic_memory_type source_type)
 {
     cudaMemcpyKind kind;
 
@@ -116,7 +116,7 @@ dispatch_memcpy(void* destination,
     }
     else
     {
-        printf("stdgpu::cuda::dispatch_memcpy : Unsupported dynamic source or destination memory type\n");
+        printf("stdgpu::cuda::memcpy : Unsupported dynamic source or destination memory type\n");
         return;
     }
 

--- a/src/stdgpu/cuda/memory.h
+++ b/src/stdgpu/cuda/memory.h
@@ -29,7 +29,7 @@ namespace stdgpu::cuda
  * \param[in] bytes The size of the allocated array
  */
 void
-dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes);
+malloc(const dynamic_memory_type type, void** array, index64_t bytes);
 
 /**
  * \brief Performs platform-specific memory deallocation
@@ -37,7 +37,7 @@ dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes);
  * \param[in] array The allocated array
  */
 void
-dispatch_free(const dynamic_memory_type type, void* array);
+free(const dynamic_memory_type type, void* array);
 
 /**
  * \brief Performs platform-specific memory copy
@@ -48,11 +48,11 @@ dispatch_free(const dynamic_memory_type type, void* array);
  * \param[in] source_type The type of the source array
  */
 void
-dispatch_memcpy(void* destination,
-                const void* source,
-                index64_t bytes,
-                dynamic_memory_type destination_type,
-                dynamic_memory_type source_type);
+memcpy(void* destination,
+       const void* source,
+       index64_t bytes,
+       dynamic_memory_type destination_type,
+       dynamic_memory_type source_type);
 
 /**
  * \brief Workarounds a synchronization issue with older GPUs

--- a/src/stdgpu/hip/impl/memory.cpp
+++ b/src/stdgpu/hip/impl/memory.cpp
@@ -23,7 +23,7 @@ namespace stdgpu::hip
 {
 
 void
-dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes)
+malloc(const dynamic_memory_type type, void** array, index64_t bytes)
 {
     switch (type)
     {
@@ -48,14 +48,14 @@ dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes)
         case dynamic_memory_type::invalid:
         default:
         {
-            printf("stdgpu::hip::dispatch_malloc : Unsupported dynamic memory type\n");
+            printf("stdgpu::hip::malloc : Unsupported dynamic memory type\n");
             return;
         }
     }
 }
 
 void
-dispatch_free(const dynamic_memory_type type, void* array)
+free(const dynamic_memory_type type, void* array)
 {
     switch (type)
     {
@@ -80,18 +80,18 @@ dispatch_free(const dynamic_memory_type type, void* array)
         case dynamic_memory_type::invalid:
         default:
         {
-            printf("stdgpu::hip::dispatch_free : Unsupported dynamic memory type\n");
+            printf("stdgpu::hip::free : Unsupported dynamic memory type\n");
             return;
         }
     }
 }
 
 void
-dispatch_memcpy(void* destination,
-                const void* source,
-                index64_t bytes,
-                dynamic_memory_type destination_type,
-                dynamic_memory_type source_type)
+memcpy(void* destination,
+       const void* source,
+       index64_t bytes,
+       dynamic_memory_type destination_type,
+       dynamic_memory_type source_type)
 {
     hipMemcpyKind kind;
 
@@ -116,7 +116,7 @@ dispatch_memcpy(void* destination,
     }
     else
     {
-        printf("stdgpu::hip::dispatch_memcpy : Unsupported dynamic source or destination memory type\n");
+        printf("stdgpu::hip::memcpy : Unsupported dynamic source or destination memory type\n");
         return;
     }
 

--- a/src/stdgpu/hip/memory.h
+++ b/src/stdgpu/hip/memory.h
@@ -29,7 +29,7 @@ namespace stdgpu::hip
  * \param[in] bytes The size of the allocated array
  */
 void
-dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes);
+malloc(const dynamic_memory_type type, void** array, index64_t bytes);
 
 /**
  * \brief Performs platform-specific memory deallocation
@@ -37,7 +37,7 @@ dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes);
  * \param[in] array The allocated array
  */
 void
-dispatch_free(const dynamic_memory_type type, void* array);
+free(const dynamic_memory_type type, void* array);
 
 /**
  * \brief Performs platform-specific memory copy
@@ -48,11 +48,11 @@ dispatch_free(const dynamic_memory_type type, void* array);
  * \param[in] source_type The type of the source array
  */
 void
-dispatch_memcpy(void* destination,
-                const void* source,
-                index64_t bytes,
-                dynamic_memory_type destination_type,
-                dynamic_memory_type source_type);
+memcpy(void* destination,
+       const void* source,
+       index64_t bytes,
+       dynamic_memory_type destination_type,
+       dynamic_memory_type source_type);
 
 /**
  * \brief Workarounds a synchronization issue with older GPUs

--- a/src/stdgpu/impl/memory.cpp
+++ b/src/stdgpu/impl/memory.cpp
@@ -256,28 +256,6 @@ dispatch_allocation_manager(const dynamic_memory_type type)
 }
 
 void
-dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes)
-{
-    stdgpu::STDGPU_BACKEND_NAMESPACE::dispatch_malloc(type, array, bytes);
-}
-
-void
-dispatch_free(const dynamic_memory_type type, void* array)
-{
-    stdgpu::STDGPU_BACKEND_NAMESPACE::dispatch_free(type, array);
-}
-
-void
-dispatch_memcpy(void* destination,
-                const void* source,
-                index64_t bytes,
-                dynamic_memory_type destination_type,
-                dynamic_memory_type source_type)
-{
-    stdgpu::STDGPU_BACKEND_NAMESPACE::dispatch_memcpy(destination, source, bytes, destination_type, source_type);
-}
-
-void
 workaround_synchronize_managed_memory()
 {
     stdgpu::STDGPU_BACKEND_NAMESPACE::workaround_synchronize_managed_memory();
@@ -294,7 +272,7 @@ allocate(index64_t bytes, dynamic_memory_type type)
 
     void* array = nullptr;
 
-    dispatch_malloc(type, &array, bytes);
+    stdgpu::STDGPU_BACKEND_NAMESPACE::malloc(type, &array, bytes);
 
     // Update pointer management after allocation
     dispatch_allocation_manager(type).register_memory(array, bytes);
@@ -319,7 +297,7 @@ deallocate(void* p, index64_t bytes, dynamic_memory_type type)
     // Update pointer management before freeing
     dispatch_allocation_manager(type).deregister_memory(p, bytes);
 
-    dispatch_free(type, p);
+    stdgpu::STDGPU_BACKEND_NAMESPACE::free(type, p);
 }
 
 void
@@ -347,7 +325,7 @@ memcpy(void* destination,
         }
     }
 
-    dispatch_memcpy(destination, source, bytes, destination_type, source_type);
+    stdgpu::STDGPU_BACKEND_NAMESPACE::memcpy(destination, source, bytes, destination_type, source_type);
 }
 
 memory_manager&

--- a/src/stdgpu/openmp/impl/memory.cpp
+++ b/src/stdgpu/openmp/impl/memory.cpp
@@ -23,7 +23,7 @@ namespace stdgpu::openmp
 {
 
 void
-dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes)
+malloc(const dynamic_memory_type type, void** array, index64_t bytes)
 {
     switch (type)
     {
@@ -39,14 +39,14 @@ dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes)
         case dynamic_memory_type::invalid:
         default:
         {
-            printf("stdgpu::openmp::dispatch_malloc : Unsupported dynamic memory type\n");
+            printf("stdgpu::openmp::malloc : Unsupported dynamic memory type\n");
             return;
         }
     }
 }
 
 void
-dispatch_free(const dynamic_memory_type type, void* array)
+free(const dynamic_memory_type type, void* array)
 {
     switch (type)
     {
@@ -61,22 +61,22 @@ dispatch_free(const dynamic_memory_type type, void* array)
         case dynamic_memory_type::invalid:
         default:
         {
-            printf("stdgpu::openmp::dispatch_free : Unsupported dynamic memory type\n");
+            printf("stdgpu::openmp::free : Unsupported dynamic memory type\n");
             return;
         }
     }
 }
 
 void
-dispatch_memcpy(void* destination,
-                const void* source,
-                index64_t bytes,
-                dynamic_memory_type destination_type,
-                dynamic_memory_type source_type)
+memcpy(void* destination,
+       const void* source,
+       index64_t bytes,
+       dynamic_memory_type destination_type,
+       dynamic_memory_type source_type)
 {
     if (destination_type == dynamic_memory_type::invalid || source_type == dynamic_memory_type::invalid)
     {
-        printf("stdgpu::openmp::dispatch_memcpy : Unsupported dynamic source or destination memory type\n");
+        printf("stdgpu::openmp::memcpy : Unsupported dynamic source or destination memory type\n");
         return;
     }
 

--- a/src/stdgpu/openmp/memory.h
+++ b/src/stdgpu/openmp/memory.h
@@ -29,7 +29,7 @@ namespace stdgpu::openmp
  * \param[in] bytes The size of the allocated array
  */
 void
-dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes);
+malloc(const dynamic_memory_type type, void** array, index64_t bytes);
 
 /**
  * \brief Performs platform-specific memory deallocation
@@ -37,7 +37,7 @@ dispatch_malloc(const dynamic_memory_type type, void** array, index64_t bytes);
  * \param[in] array The allocated array
  */
 void
-dispatch_free(const dynamic_memory_type type, void* array);
+free(const dynamic_memory_type type, void* array);
 
 /**
  * \brief Performs platform-specific memory copy
@@ -48,11 +48,11 @@ dispatch_free(const dynamic_memory_type type, void* array);
  * \param[in] source_type The type of the source array
  */
 void
-dispatch_memcpy(void* destination,
-                const void* source,
-                index64_t bytes,
-                dynamic_memory_type destination_type,
-                dynamic_memory_type source_type);
+memcpy(void* destination,
+       const void* source,
+       index64_t bytes,
+       dynamic_memory_type destination_type,
+       dynamic_memory_type source_type);
 
 /**
  * \brief Workarounds a synchronization issue with older GPUs


### PR DESCRIPTION
The backend implementation of `memory` used the term "dispatch" to indicate that the backend is performing the operation based on the passed memory type. However, this just makes the names more complex. Furthermore, auxiliary functions for actually calling the backend implementation are defined as well which, however, are never exposed outside and just add another layer of indirection. Simplify the name and call convention to reduce bloat and prepare the backends for future feature additions.