### PR TITLE
atomic: Add non-member functions for fetch_min and fetch_max

### DIFF
--- a/src/stdgpu/atomic.cuh
+++ b/src/stdgpu/atomic.cuh
@@ -283,6 +283,26 @@ public:
     fetch_sub(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
+     * \brief Atomically computes and stores the minimum of the stored value and the given argument
+     * \param[in] arg The other argument of minimum
+     * \param[in] order The memory order
+     * \return The old value
+     */
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
+    STDGPU_DEVICE_ONLY T
+    fetch_min(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
+
+    /**
+     * \brief Atomically computes and stores the maximum of the stored value and the given argument
+     * \param[in] arg The other argument of maximum
+     * \param[in] order The memory order
+     * \return The old value
+     */
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
+    STDGPU_DEVICE_ONLY T
+    fetch_max(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
+
+    /**
      * \brief Atomically computes and stores the bitwise AND of the stored value and the given argument
      * \param[in] arg The other argument of bitwise AND
      * \param[in] order The memory order
@@ -311,26 +331,6 @@ public:
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_xor(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
-
-    /**
-     * \brief Atomically computes and stores the minimum of the stored value and the given argument
-     * \param[in] arg The other argument of minimum
-     * \param[in] order The memory order
-     * \return The old value
-     */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
-    STDGPU_DEVICE_ONLY T
-    fetch_min(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
-
-    /**
-     * \brief Atomically computes and stores the maximum of the stored value and the given argument
-     * \param[in] arg The other argument of maximum
-     * \param[in] order The memory order
-     * \return The old value
-     */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
-    STDGPU_DEVICE_ONLY T
-    fetch_max(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the incrementation of the value and modulus with arg
@@ -571,6 +571,26 @@ public:
     fetch_sub(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
+     * \brief Atomically computes and stores the minimum of the stored value and the given argument
+     * \param[in] arg The other argument of minimum
+     * \param[in] order The memory order
+     * \return The old value
+     */
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
+    STDGPU_DEVICE_ONLY T
+    fetch_min(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
+
+    /**
+     * \brief Atomically computes and stores the maximum of the stored value and the given argument
+     * \param[in] arg The other argument of maximum
+     * \param[in] order The memory order
+     * \return The old value
+     */
+    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
+    STDGPU_DEVICE_ONLY T
+    fetch_max(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
+
+    /**
      * \brief Atomically computes and stores the bitwise AND of the stored value and the given argument
      * \param[in] arg The other argument of bitwise AND
      * \param[in] order The memory order
@@ -599,26 +619,6 @@ public:
     template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T>)>
     STDGPU_DEVICE_ONLY T
     fetch_xor(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
-
-    /**
-     * \brief Atomically computes and stores the minimum of the stored value and the given argument
-     * \param[in] arg The other argument of minimum
-     * \param[in] order The memory order
-     * \return The old value
-     */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
-    STDGPU_DEVICE_ONLY T
-    fetch_min(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
-
-    /**
-     * \brief Atomically computes and stores the maximum of the stored value and the given argument
-     * \param[in] arg The other argument of maximum
-     * \param[in] order The memory order
-     * \return The old value
-     */
-    template <STDGPU_DETAIL_OVERLOAD_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
-    STDGPU_DEVICE_ONLY T
-    fetch_max(const T arg, const memory_order order = memory_order_seq_cst) noexcept;
 
     /**
      * \brief Atomically computes and stores the incrementation of the value and modulus with arg
@@ -884,6 +884,56 @@ atomic_fetch_sub_explicit(atomic<T, Allocator>* obj,
 
 /**
  * \ingroup atomic
+ * \brief Atomically computes and stores the minimum of the stored value and the given argument
+ * \param[in] obj The atomic object
+ * \param[in] arg The other argument of minimum
+ * \return The old value
+ */
+template <typename T, typename Allocator>
+STDGPU_DEVICE_ONLY T
+atomic_fetch_min(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type arg) noexcept;
+
+/**
+ * \ingroup atomic
+ * \brief Atomically computes and stores the minimum of the stored value and the given argument
+ * \param[in] obj The atomic object
+ * \param[in] arg The other argument of minimum
+ * \param[in] order The memory order
+ * \return The old value
+ */
+template <typename T, typename Allocator>
+STDGPU_DEVICE_ONLY T
+atomic_fetch_min_explicit(atomic<T, Allocator>* obj,
+                          const typename atomic<T, Allocator>::value_type arg,
+                          const memory_order order) noexcept;
+
+/**
+ * \ingroup atomic
+ * \brief Atomically computes and stores the maximum of the stored value and the given argument
+ * \param[in] obj The atomic object
+ * \param[in] arg The other argument of maximum
+ * \return The old value
+ */
+template <typename T, typename Allocator>
+STDGPU_DEVICE_ONLY T
+atomic_fetch_max(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type arg) noexcept;
+
+/**
+ * \ingroup atomic
+ * \brief Atomically computes and stores the maximum of the stored value and the given argument
+ * \param[in] obj The atomic object
+ * \param[in] arg The other argument of maximum
+ * \param[in] order The memory order
+ * \return The old value
+ */
+template <typename T, typename Allocator>
+STDGPU_DEVICE_ONLY T
+atomic_fetch_max_explicit(atomic<T, Allocator>* obj,
+                          const typename atomic<T, Allocator>::value_type arg,
+                          const memory_order order) noexcept;
+
+/**
+ * \ingroup atomic
  * \brief Atomically computes and stores the addition of the stored value and the given argument
  * \param[in] obj The atomic object
  * \param[in] arg The other argument of addition
@@ -891,7 +941,7 @@ atomic_fetch_sub_explicit(atomic<T, Allocator>* obj,
  */
 template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_and(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept;
+atomic_fetch_and(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type arg) noexcept;
 
 /**
  * \ingroup atomic
@@ -904,7 +954,7 @@ atomic_fetch_and(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>:
 template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_and_explicit(atomic<T, Allocator>* obj,
-                          const typename atomic<T, Allocator>::difference_type arg,
+                          const typename atomic<T, Allocator>::value_type arg,
                           const memory_order order) noexcept;
 
 /**
@@ -916,7 +966,7 @@ atomic_fetch_and_explicit(atomic<T, Allocator>* obj,
  */
 template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_or(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept;
+atomic_fetch_or(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type arg) noexcept;
 
 /**
  * \ingroup atomic
@@ -929,7 +979,7 @@ atomic_fetch_or(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::
 template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_or_explicit(atomic<T, Allocator>* obj,
-                         const typename atomic<T, Allocator>::difference_type arg,
+                         const typename atomic<T, Allocator>::value_type arg,
                          const memory_order order) noexcept;
 
 /**
@@ -941,7 +991,7 @@ atomic_fetch_or_explicit(atomic<T, Allocator>* obj,
  */
 template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
-atomic_fetch_xor(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept;
+atomic_fetch_xor(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type arg) noexcept;
 
 /**
  * \ingroup atomic
@@ -954,7 +1004,7 @@ atomic_fetch_xor(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>:
 template <typename T, typename Allocator>
 STDGPU_DEVICE_ONLY T
 atomic_fetch_xor_explicit(atomic<T, Allocator>* obj,
-                          const typename atomic<T, Allocator>::difference_type arg,
+                          const typename atomic<T, Allocator>::value_type arg,
                           const memory_order order) noexcept;
 
 } // namespace stdgpu

--- a/src/stdgpu/impl/atomic_detail.cuh
+++ b/src/stdgpu/impl/atomic_detail.cuh
@@ -265,6 +265,22 @@ atomic<T, Allocator>::fetch_sub(const T arg, const memory_order order) noexcept
 }
 
 template <typename T, typename Allocator>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
+inline STDGPU_DEVICE_ONLY T
+atomic<T, Allocator>::fetch_min(const T arg, const memory_order order) noexcept
+{
+    return _value_ref.fetch_min(arg, order);
+}
+
+template <typename T, typename Allocator>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
+inline STDGPU_DEVICE_ONLY T
+atomic<T, Allocator>::fetch_max(const T arg, const memory_order order) noexcept
+{
+    return _value_ref.fetch_max(arg, order);
+}
+
+template <typename T, typename Allocator>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::fetch_and(const T arg, const memory_order order) noexcept
@@ -286,22 +302,6 @@ inline STDGPU_DEVICE_ONLY T
 atomic<T, Allocator>::fetch_xor(const T arg, const memory_order order) noexcept
 {
     return _value_ref.fetch_xor(arg, order);
-}
-
-template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
-inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::fetch_min(const T arg, const memory_order order) noexcept
-{
-    return _value_ref.fetch_min(arg, order);
-}
-
-template <typename T, typename Allocator>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
-inline STDGPU_DEVICE_ONLY T
-atomic<T, Allocator>::fetch_max(const T arg, const memory_order order) noexcept
-{
-    return _value_ref.fetch_max(arg, order);
 }
 
 template <typename T, typename Allocator>
@@ -541,6 +541,34 @@ atomic_ref<T>::fetch_sub(const T arg, const memory_order order) noexcept
 }
 
 template <typename T>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
+inline STDGPU_DEVICE_ONLY T
+atomic_ref<T>::fetch_min(const T arg, const memory_order order) noexcept
+{
+    detail::atomic_load_thread_fence(order);
+
+    T result = stdgpu::STDGPU_BACKEND_NAMESPACE::atomic_fetch_min(_value, arg);
+
+    detail::atomic_store_thread_fence(order);
+
+    return result;
+}
+
+template <typename T>
+template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
+inline STDGPU_DEVICE_ONLY T
+atomic_ref<T>::fetch_max(const T arg, const memory_order order) noexcept
+{
+    detail::atomic_load_thread_fence(order);
+
+    T result = stdgpu::STDGPU_BACKEND_NAMESPACE::atomic_fetch_max(_value, arg);
+
+    detail::atomic_store_thread_fence(order);
+
+    return result;
+}
+
+template <typename T>
 template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T>)>
 inline STDGPU_DEVICE_ONLY T
 atomic_ref<T>::fetch_and(const T arg, const memory_order order) noexcept
@@ -576,34 +604,6 @@ atomic_ref<T>::fetch_xor(const T arg, const memory_order order) noexcept
     detail::atomic_load_thread_fence(order);
 
     T result = stdgpu::STDGPU_BACKEND_NAMESPACE::atomic_fetch_xor(_value, arg);
-
-    detail::atomic_store_thread_fence(order);
-
-    return result;
-}
-
-template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
-inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::fetch_min(const T arg, const memory_order order) noexcept
-{
-    detail::atomic_load_thread_fence(order);
-
-    T result = stdgpu::STDGPU_BACKEND_NAMESPACE::atomic_fetch_min(_value, arg);
-
-    detail::atomic_store_thread_fence(order);
-
-    return result;
-}
-
-template <typename T>
-template <STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(std::is_integral_v<T> || std::is_floating_point_v<T>)>
-inline STDGPU_DEVICE_ONLY T
-atomic_ref<T>::fetch_max(const T arg, const memory_order order) noexcept
-{
-    detail::atomic_load_thread_fence(order);
-
-    T result = stdgpu::STDGPU_BACKEND_NAMESPACE::atomic_fetch_max(_value, arg);
 
     detail::atomic_store_thread_fence(order);
 
@@ -815,7 +815,39 @@ atomic_fetch_sub_explicit(atomic<T, Allocator>* obj,
 
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
-atomic_fetch_and(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept
+atomic_fetch_min(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type arg) noexcept
+{
+    return obj->fetch_min(arg);
+}
+
+template <typename T, typename Allocator>
+inline STDGPU_DEVICE_ONLY T
+atomic_fetch_min_explicit(atomic<T, Allocator>* obj,
+                          const typename atomic<T, Allocator>::value_type arg,
+                          const memory_order order) noexcept
+{
+    return obj->fetch_min(arg, order);
+}
+
+template <typename T, typename Allocator>
+inline STDGPU_DEVICE_ONLY T
+atomic_fetch_max(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type arg) noexcept
+{
+    return obj->fetch_max(arg);
+}
+
+template <typename T, typename Allocator>
+inline STDGPU_DEVICE_ONLY T
+atomic_fetch_max_explicit(atomic<T, Allocator>* obj,
+                          const typename atomic<T, Allocator>::value_type arg,
+                          const memory_order order) noexcept
+{
+    return obj->fetch_max(arg, order);
+}
+
+template <typename T, typename Allocator>
+inline STDGPU_DEVICE_ONLY T
+atomic_fetch_and(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type arg) noexcept
 {
     return obj->fetch_and(arg);
 }
@@ -823,7 +855,7 @@ atomic_fetch_and(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>:
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
 atomic_fetch_and_explicit(atomic<T, Allocator>* obj,
-                          const typename atomic<T, Allocator>::difference_type arg,
+                          const typename atomic<T, Allocator>::value_type arg,
                           const memory_order order) noexcept
 {
     return obj->fetch_and(arg, order);
@@ -831,7 +863,7 @@ atomic_fetch_and_explicit(atomic<T, Allocator>* obj,
 
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
-atomic_fetch_or(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept
+atomic_fetch_or(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type arg) noexcept
 {
     return obj->fetch_or(arg);
 }
@@ -839,7 +871,7 @@ atomic_fetch_or(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
 atomic_fetch_or_explicit(atomic<T, Allocator>* obj,
-                         const typename atomic<T, Allocator>::difference_type arg,
+                         const typename atomic<T, Allocator>::value_type arg,
                          const memory_order order) noexcept
 {
     return obj->fetch_or(arg, order);
@@ -847,7 +879,7 @@ atomic_fetch_or_explicit(atomic<T, Allocator>* obj,
 
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
-atomic_fetch_xor(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::difference_type arg) noexcept
+atomic_fetch_xor(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>::value_type arg) noexcept
 {
     return obj->fetch_xor(arg);
 }
@@ -855,7 +887,7 @@ atomic_fetch_xor(atomic<T, Allocator>* obj, const typename atomic<T, Allocator>:
 template <typename T, typename Allocator>
 inline STDGPU_DEVICE_ONLY T
 atomic_fetch_xor_explicit(atomic<T, Allocator>* obj,
-                          const typename atomic<T, Allocator>::difference_type arg,
+                          const typename atomic<T, Allocator>::value_type arg,
                           const memory_order order) noexcept
 {
     return obj->fetch_xor(arg, order);

--- a/tests/stdgpu/atomic.inc
+++ b/tests/stdgpu/atomic.inc
@@ -1126,6 +1126,260 @@ TEST_F(stdgpu_atomic, operator_sub_equals_unsigned_long_long_int)
 }
 
 template <typename T>
+class min_sequence
+{
+public:
+    min_sequence(const stdgpu::atomic<T>& value, T* sequence)
+      : _value(value)
+      , _sequence(sequence)
+    {
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const stdgpu::index_t i)
+    {
+        _value.fetch_min(_sequence[i]);
+    }
+
+private:
+    stdgpu::atomic<T> _value;
+    T* _sequence;
+};
+
+template <typename T>
+class min_sequence_nonmember
+{
+public:
+    min_sequence_nonmember(const stdgpu::atomic<T>& value, T* sequence)
+      : _value(value)
+      , _sequence(sequence)
+    {
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const stdgpu::index_t i)
+    {
+        stdgpu::atomic_fetch_min(&_value, _sequence[i]);
+    }
+
+private:
+    stdgpu::atomic<T> _value;
+    T* _sequence;
+};
+
+template <typename T>
+class min_sequence_nonmember_explicit
+{
+public:
+    min_sequence_nonmember_explicit(const stdgpu::atomic<T>& value, T* sequence)
+      : _value(value)
+      , _sequence(sequence)
+    {
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const stdgpu::index_t i)
+    {
+        stdgpu::atomic_fetch_min_explicit(&_value, _sequence[i], stdgpu::memory_order_relaxed);
+    }
+
+private:
+    stdgpu::atomic<T> _value;
+    T* _sequence;
+};
+
+template <typename T, template <typename> class Function>
+void
+sequence_fetch_min()
+{
+    const stdgpu::index_t N = 40000;
+    T* sequence = createDeviceArray<T>(N);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+
+    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+    value.store(std::numeric_limits<T>::max());
+
+    stdgpu::for_each_index(stdgpu::execution::device, N, Function<T>(value, sequence));
+
+    EXPECT_EQ(value.load(), T(1));
+
+    destroyDeviceArray<T>(sequence);
+    stdgpu::atomic<T>::destroyDeviceObject(value);
+}
+
+TEST_F(stdgpu_atomic, fetch_min_int)
+{
+    sequence_fetch_min<int, min_sequence>();
+}
+
+TEST_F(stdgpu_atomic, fetch_min_unsigned_int)
+{
+    sequence_fetch_min<unsigned int, min_sequence>();
+}
+
+TEST_F(stdgpu_atomic, fetch_min_unsigned_long_long_int)
+{
+    sequence_fetch_min<unsigned long long int, min_sequence>();
+}
+
+TEST_F(stdgpu_atomic, fetch_min_nonmember_int)
+{
+    sequence_fetch_min<int, min_sequence_nonmember>();
+}
+
+TEST_F(stdgpu_atomic, fetch_min_nonmember_unsigned_int)
+{
+    sequence_fetch_min<unsigned int, min_sequence_nonmember>();
+}
+
+TEST_F(stdgpu_atomic, fetch_min_nonmember_unsigned_long_long_int)
+{
+    sequence_fetch_min<unsigned long long int, min_sequence_nonmember>();
+}
+
+TEST_F(stdgpu_atomic, fetch_min_nonmember_explicit_int)
+{
+    sequence_fetch_min<int, min_sequence_nonmember_explicit>();
+}
+
+TEST_F(stdgpu_atomic, fetch_min_nonmember_explicit_unsigned_int)
+{
+    sequence_fetch_min<unsigned int, min_sequence_nonmember_explicit>();
+}
+
+TEST_F(stdgpu_atomic, fetch_min_nonmember_explicit_unsigned_long_long_int)
+{
+    sequence_fetch_min<unsigned long long int, min_sequence_nonmember_explicit>();
+}
+
+template <typename T>
+class max_sequence
+{
+public:
+    max_sequence(const stdgpu::atomic<T>& value, T* sequence)
+      : _value(value)
+      , _sequence(sequence)
+    {
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const stdgpu::index_t i)
+    {
+        _value.fetch_max(_sequence[i]);
+    }
+
+private:
+    stdgpu::atomic<T> _value;
+    T* _sequence;
+};
+
+template <typename T>
+class max_sequence_nonmember
+{
+public:
+    max_sequence_nonmember(const stdgpu::atomic<T>& value, T* sequence)
+      : _value(value)
+      , _sequence(sequence)
+    {
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const stdgpu::index_t i)
+    {
+        stdgpu::atomic_fetch_max(&_value, _sequence[i]);
+    }
+
+private:
+    stdgpu::atomic<T> _value;
+    T* _sequence;
+};
+
+template <typename T>
+class max_sequence_nonmember_explicit
+{
+public:
+    max_sequence_nonmember_explicit(const stdgpu::atomic<T>& value, T* sequence)
+      : _value(value)
+      , _sequence(sequence)
+    {
+    }
+
+    STDGPU_DEVICE_ONLY void
+    operator()(const stdgpu::index_t i)
+    {
+        stdgpu::atomic_fetch_max_explicit(&_value, _sequence[i], stdgpu::memory_order_relaxed);
+    }
+
+private:
+    stdgpu::atomic<T> _value;
+    T* _sequence;
+};
+
+template <typename T, template <typename> class Function>
+void
+sequence_fetch_max()
+{
+    const stdgpu::index_t N = 40000;
+    T* sequence = createDeviceArray<T>(N);
+    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
+
+    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
+    value.store(std::numeric_limits<T>::lowest());
+
+    stdgpu::for_each_index(stdgpu::execution::device, N, Function<T>(value, sequence));
+
+    EXPECT_EQ(value.load(), T(N));
+
+    destroyDeviceArray<T>(sequence);
+    stdgpu::atomic<T>::destroyDeviceObject(value);
+}
+
+TEST_F(stdgpu_atomic, fetch_max_int)
+{
+    sequence_fetch_max<int, max_sequence>();
+}
+
+TEST_F(stdgpu_atomic, fetch_max_unsigned_int)
+{
+    sequence_fetch_max<unsigned int, max_sequence>();
+}
+
+TEST_F(stdgpu_atomic, fetch_max_unsigned_long_long_int)
+{
+    sequence_fetch_max<unsigned long long int, max_sequence>();
+}
+
+TEST_F(stdgpu_atomic, fetch_max_nonmember_int)
+{
+    sequence_fetch_max<int, max_sequence_nonmember>();
+}
+
+TEST_F(stdgpu_atomic, fetch_max_nonmember_unsigned_int)
+{
+    sequence_fetch_max<unsigned int, max_sequence_nonmember>();
+}
+
+TEST_F(stdgpu_atomic, fetch_max_nonmember_unsigned_long_long_int)
+{
+    sequence_fetch_max<unsigned long long int, max_sequence_nonmember>();
+}
+
+TEST_F(stdgpu_atomic, fetch_max_nonmember_explicit_int)
+{
+    sequence_fetch_max<int, max_sequence_nonmember_explicit>();
+}
+
+TEST_F(stdgpu_atomic, fetch_max_nonmember_explicit_unsigned_int)
+{
+    sequence_fetch_max<unsigned int, max_sequence_nonmember_explicit>();
+}
+
+TEST_F(stdgpu_atomic, fetch_max_nonmember_explicit_unsigned_long_long_int)
+{
+    sequence_fetch_max<unsigned long long int, max_sequence_nonmember_explicit>();
+}
+
+template <typename T>
 bool
 bit_set(const T value, const stdgpu::index_t bit_position)
 {
@@ -1704,116 +1958,6 @@ TEST_F(stdgpu_atomic, operator_xor_equals_unsigned_int)
 TEST_F(stdgpu_atomic, operator_xor_equals_unsigned_long_long_int)
 {
     sequence_operator_xor_equals<unsigned long long int>();
-}
-
-template <typename T>
-class min_sequence
-{
-public:
-    min_sequence(const stdgpu::atomic<T>& value, T* sequence)
-      : _value(value)
-      , _sequence(sequence)
-    {
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
-    {
-        _value.fetch_min(_sequence[i]);
-    }
-
-private:
-    stdgpu::atomic<T> _value;
-    T* _sequence;
-};
-
-template <typename T>
-void
-sequence_fetch_min()
-{
-    const stdgpu::index_t N = 40000;
-    T* sequence = createDeviceArray<T>(N);
-    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
-
-    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
-    value.store(std::numeric_limits<T>::max());
-
-    stdgpu::for_each_index(stdgpu::execution::device, N, min_sequence<T>(value, sequence));
-
-    EXPECT_EQ(value.load(), T(1));
-
-    destroyDeviceArray<T>(sequence);
-    stdgpu::atomic<T>::destroyDeviceObject(value);
-}
-
-TEST_F(stdgpu_atomic, fetch_min_int)
-{
-    sequence_fetch_min<int>();
-}
-
-TEST_F(stdgpu_atomic, fetch_min_unsigned_int)
-{
-    sequence_fetch_min<unsigned int>();
-}
-
-TEST_F(stdgpu_atomic, fetch_min_unsigned_long_long_int)
-{
-    sequence_fetch_min<unsigned long long int>();
-}
-
-template <typename T>
-class max_sequence
-{
-public:
-    max_sequence(const stdgpu::atomic<T>& value, T* sequence)
-      : _value(value)
-      , _sequence(sequence)
-    {
-    }
-
-    STDGPU_DEVICE_ONLY void
-    operator()(const stdgpu::index_t i)
-    {
-        _value.fetch_max(_sequence[i]);
-    }
-
-private:
-    stdgpu::atomic<T> _value;
-    T* _sequence;
-};
-
-template <typename T>
-void
-sequence_fetch_max()
-{
-    const stdgpu::index_t N = 40000;
-    T* sequence = createDeviceArray<T>(N);
-    stdgpu::iota(stdgpu::execution::device, stdgpu::device_begin(sequence), stdgpu::device_end(sequence), T(1));
-
-    stdgpu::atomic<T> value = stdgpu::atomic<T>::createDeviceObject();
-    value.store(std::numeric_limits<T>::lowest());
-
-    stdgpu::for_each_index(stdgpu::execution::device, N, max_sequence<T>(value, sequence));
-
-    EXPECT_EQ(value.load(), T(N));
-
-    destroyDeviceArray<T>(sequence);
-    stdgpu::atomic<T>::destroyDeviceObject(value);
-}
-
-TEST_F(stdgpu_atomic, fetch_max_int)
-{
-    sequence_fetch_max<int>();
-}
-
-TEST_F(stdgpu_atomic, fetch_max_unsigned_int)
-{
-    sequence_fetch_max<unsigned int>();
-}
-
-TEST_F(stdgpu_atomic, fetch_max_unsigned_long_long_int)
-{
-    sequence_fetch_max<unsigned long long int>();
 }
 
 template <typename T>


### PR DESCRIPTION
The upcoming C++26 standard will introduce `fetch_min` and `fetch_max`  functions in the `atomic` module. We already expose them for `atomic` and `atomic_ref`  but lack the respective non-member functions. Add an implementation of these and update he signature of the remaining ones to more closely match the C++ standard.