### PR TITLE
memory: Make backend interface more low level

### DIFF
--- a/src/stdgpu/cuda/impl/error.h
+++ b/src/stdgpu/cuda/impl/error.h
@@ -16,6 +16,7 @@
 #ifndef STDGPU_CUDA_ERROR_H
 #define STDGPU_CUDA_ERROR_H
 
+#include <cstdio>
 #include <cuda_runtime_api.h>
 #include <exception>
 

--- a/src/stdgpu/cuda/impl/memory.cpp
+++ b/src/stdgpu/cuda/impl/memory.cpp
@@ -15,97 +15,57 @@
 
 #include <stdgpu/cuda/memory.h>
 
-#include <cstdio>
-
 #include <stdgpu/cuda/impl/error.h>
 
 namespace stdgpu::cuda
 {
 
 void
-malloc(const dynamic_memory_type type, void** array, index64_t bytes)
+malloc_device(void** array, index64_t bytes)
 {
-    switch (type)
-    {
-        case dynamic_memory_type::device:
-        {
-            STDGPU_CUDA_SAFE_CALL(cudaMalloc(array, static_cast<std::size_t>(bytes)));
-        }
-        break;
-
-        case dynamic_memory_type::host:
-        {
-            STDGPU_CUDA_SAFE_CALL(cudaMallocHost(array, static_cast<std::size_t>(bytes)));
-        }
-        break;
-
-        case dynamic_memory_type::invalid:
-        default:
-        {
-            printf("stdgpu::cuda::malloc : Unsupported dynamic memory type\n");
-            return;
-        }
-    }
+    STDGPU_CUDA_SAFE_CALL(cudaMalloc(array, static_cast<std::size_t>(bytes)));
 }
 
 void
-free(const dynamic_memory_type type, void* array)
+malloc_host(void** array, index64_t bytes)
 {
-    switch (type)
-    {
-        case dynamic_memory_type::device:
-        {
-            STDGPU_CUDA_SAFE_CALL(cudaFree(array));
-        }
-        break;
-
-        case dynamic_memory_type::host:
-        {
-            STDGPU_CUDA_SAFE_CALL(cudaFreeHost(array));
-        }
-        break;
-
-        case dynamic_memory_type::invalid:
-        default:
-        {
-            printf("stdgpu::cuda::free : Unsupported dynamic memory type\n");
-            return;
-        }
-    }
+    STDGPU_CUDA_SAFE_CALL(cudaMallocHost(array, static_cast<std::size_t>(bytes)));
 }
 
 void
-memcpy(void* destination,
-       const void* source,
-       index64_t bytes,
-       dynamic_memory_type destination_type,
-       dynamic_memory_type source_type)
+free_device(void* array)
 {
-    cudaMemcpyKind kind;
+    STDGPU_CUDA_SAFE_CALL(cudaFree(array));
+}
 
-    if (destination_type == dynamic_memory_type::device && source_type == dynamic_memory_type::device)
-    {
-        kind = cudaMemcpyDeviceToDevice;
-    }
-    else if (destination_type == dynamic_memory_type::device && source_type == dynamic_memory_type::host)
-    {
-        kind = cudaMemcpyHostToDevice;
-    }
-    else if (destination_type == dynamic_memory_type::host && source_type == dynamic_memory_type::device)
-    {
-        kind = cudaMemcpyDeviceToHost;
-    }
-    else if (destination_type == dynamic_memory_type::host && source_type == dynamic_memory_type::host)
-    {
-        kind = cudaMemcpyHostToHost;
-    }
-    else
-    {
-        printf("stdgpu::cuda::memcpy : Unsupported dynamic source or destination memory type\n");
-        return;
-    }
+void
+free_host(void* array)
+{
+    STDGPU_CUDA_SAFE_CALL(cudaFreeHost(array));
+}
 
-    STDGPU_CUDA_SAFE_CALL(cudaMemcpy(destination, source, static_cast<std::size_t>(bytes), kind));
+void
+memcpy_device_to_device(void* destination, const void* source, index64_t bytes)
+{
+    STDGPU_CUDA_SAFE_CALL(cudaMemcpy(destination, source, static_cast<std::size_t>(bytes), cudaMemcpyDeviceToDevice));
+}
+
+void
+memcpy_device_to_host(void* destination, const void* source, index64_t bytes)
+{
+    STDGPU_CUDA_SAFE_CALL(cudaMemcpy(destination, source, static_cast<std::size_t>(bytes), cudaMemcpyDeviceToHost));
+}
+
+void
+memcpy_host_to_device(void* destination, const void* source, index64_t bytes)
+{
+    STDGPU_CUDA_SAFE_CALL(cudaMemcpy(destination, source, static_cast<std::size_t>(bytes), cudaMemcpyHostToDevice));
+}
+
+void
+memcpy_host_to_host(void* destination, const void* source, index64_t bytes)
+{
+    STDGPU_CUDA_SAFE_CALL(cudaMemcpy(destination, source, static_cast<std::size_t>(bytes), cudaMemcpyHostToHost));
 }
 
 } // namespace stdgpu::cuda

--- a/src/stdgpu/cuda/memory.h
+++ b/src/stdgpu/cuda/memory.h
@@ -17,42 +17,78 @@
 #define STDGPU_CUDA_MEMORY_H
 
 #include <stdgpu/cstddef.h>
-#include <stdgpu/memory.h>
 
 namespace stdgpu::cuda
 {
 
 /**
- * \brief Performs platform-specific memory allocation
+ * \brief Performs platform-specific memory allocation on the device
+ * \param[in] array A pointer to the allocated array
+ * \param[in] bytes The size of the allocated array
+ */
+void
+malloc_device(void** array, index64_t bytes);
+
+/**
+ * \brief Performs platform-specific memory allocation on the host
  * \param[in] type The type of the memory to allocate
  * \param[in] array A pointer to the allocated array
  * \param[in] bytes The size of the allocated array
  */
 void
-malloc(const dynamic_memory_type type, void** array, index64_t bytes);
+malloc_host(void** array, index64_t bytes);
 
 /**
- * \brief Performs platform-specific memory deallocation
+ * \brief Performs platform-specific memory deallocation on the device
  * \param[in] type The type of the memory to deallocate
  * \param[in] array The allocated array
  */
 void
-free(const dynamic_memory_type type, void* array);
+free_device(void* array);
 
 /**
- * \brief Performs platform-specific memory copy
+ * \brief Performs platform-specific memory deallocation on the host
+ * \param[in] type The type of the memory to deallocate
+ * \param[in] array The allocated array
+ */
+void
+free_host(void* array);
+
+/**
+ * \brief Performs platform-specific memory copy from device to device
  * \param[in] destination The destination array
  * \param[in] source The source array
  * \param[in] bytes The size of the allocated array
- * \param[in] destination_type The type of the destination array
- * \param[in] source_type The type of the source array
  */
 void
-memcpy(void* destination,
-       const void* source,
-       index64_t bytes,
-       dynamic_memory_type destination_type,
-       dynamic_memory_type source_type);
+memcpy_device_to_device(void* destination, const void* source, index64_t bytes);
+
+/**
+ * \brief Performs platform-specific memory copy from device to host
+ * \param[in] destination The destination array
+ * \param[in] source The source array
+ * \param[in] bytes The size of the allocated array
+ */
+void
+memcpy_device_to_host(void* destination, const void* source, index64_t bytes);
+
+/**
+ * \brief Performs platform-specific memory copy from host to device
+ * \param[in] destination The destination array
+ * \param[in] source The source array
+ * \param[in] bytes The size of the allocated array
+ */
+void
+memcpy_host_to_device(void* destination, const void* source, index64_t bytes);
+
+/**
+ * \brief Performs platform-specific memory copy from host to host
+ * \param[in] destination The destination array
+ * \param[in] source The source array
+ * \param[in] bytes The size of the allocated array
+ */
+void
+memcpy_host_to_host(void* destination, const void* source, index64_t bytes);
 
 } // namespace stdgpu::cuda
 

--- a/src/stdgpu/hip/impl/error.h
+++ b/src/stdgpu/hip/impl/error.h
@@ -16,6 +16,7 @@
 #ifndef STDGPU_HIP_ERROR_H
 #define STDGPU_HIP_ERROR_H
 
+#include <cstdio>
 #include <exception>
 #include <hip/hip_runtime_api.h>
 

--- a/src/stdgpu/hip/impl/memory.cpp
+++ b/src/stdgpu/hip/impl/memory.cpp
@@ -15,97 +15,57 @@
 
 #include <stdgpu/hip/memory.h>
 
-#include <cstdio>
-
 #include <stdgpu/hip/impl/error.h>
 
 namespace stdgpu::hip
 {
 
 void
-malloc(const dynamic_memory_type type, void** array, index64_t bytes)
+malloc_device(void** array, index64_t bytes)
 {
-    switch (type)
-    {
-        case dynamic_memory_type::device:
-        {
-            STDGPU_HIP_SAFE_CALL(hipMalloc(array, static_cast<std::size_t>(bytes)));
-        }
-        break;
-
-        case dynamic_memory_type::host:
-        {
-            STDGPU_HIP_SAFE_CALL(hipHostMalloc(array, static_cast<std::size_t>(bytes)));
-        }
-        break;
-
-        case dynamic_memory_type::invalid:
-        default:
-        {
-            printf("stdgpu::hip::malloc : Unsupported dynamic memory type\n");
-            return;
-        }
-    }
+    STDGPU_HIP_SAFE_CALL(hipMalloc(array, static_cast<std::size_t>(bytes)));
 }
 
 void
-free(const dynamic_memory_type type, void* array)
+malloc_host(void** array, index64_t bytes)
 {
-    switch (type)
-    {
-        case dynamic_memory_type::device:
-        {
-            STDGPU_HIP_SAFE_CALL(hipFree(array));
-        }
-        break;
-
-        case dynamic_memory_type::host:
-        {
-            STDGPU_HIP_SAFE_CALL(hipHostFree(array));
-        }
-        break;
-
-        case dynamic_memory_type::invalid:
-        default:
-        {
-            printf("stdgpu::hip::free : Unsupported dynamic memory type\n");
-            return;
-        }
-    }
+    STDGPU_HIP_SAFE_CALL(hipHostMalloc(array, static_cast<std::size_t>(bytes)));
 }
 
 void
-memcpy(void* destination,
-       const void* source,
-       index64_t bytes,
-       dynamic_memory_type destination_type,
-       dynamic_memory_type source_type)
+free_device(void* array)
 {
-    hipMemcpyKind kind;
+    STDGPU_HIP_SAFE_CALL(hipFree(array));
+}
 
-    if (destination_type == dynamic_memory_type::device && source_type == dynamic_memory_type::device)
-    {
-        kind = hipMemcpyDeviceToDevice;
-    }
-    else if (destination_type == dynamic_memory_type::device && source_type == dynamic_memory_type::host)
-    {
-        kind = hipMemcpyHostToDevice;
-    }
-    else if (destination_type == dynamic_memory_type::host && source_type == dynamic_memory_type::device)
-    {
-        kind = hipMemcpyDeviceToHost;
-    }
-    else if (destination_type == dynamic_memory_type::host && source_type == dynamic_memory_type::host)
-    {
-        kind = hipMemcpyHostToHost;
-    }
-    else
-    {
-        printf("stdgpu::hip::memcpy : Unsupported dynamic source or destination memory type\n");
-        return;
-    }
+void
+free_host(void* array)
+{
+    STDGPU_HIP_SAFE_CALL(hipHostFree(array));
+}
 
-    STDGPU_HIP_SAFE_CALL(hipMemcpy(destination, source, static_cast<std::size_t>(bytes), kind));
+void
+memcpy_device_to_device(void* destination, const void* source, index64_t bytes)
+{
+    STDGPU_HIP_SAFE_CALL(hipMemcpy(destination, source, static_cast<std::size_t>(bytes), hipMemcpyDeviceToDevice));
+}
+
+void
+memcpy_device_to_host(void* destination, const void* source, index64_t bytes)
+{
+    STDGPU_HIP_SAFE_CALL(hipMemcpy(destination, source, static_cast<std::size_t>(bytes), hipMemcpyDeviceToHost));
+}
+
+void
+memcpy_host_to_device(void* destination, const void* source, index64_t bytes)
+{
+    STDGPU_HIP_SAFE_CALL(hipMemcpy(destination, source, static_cast<std::size_t>(bytes), hipMemcpyHostToDevice));
+}
+
+void
+memcpy_host_to_host(void* destination, const void* source, index64_t bytes)
+{
+    STDGPU_HIP_SAFE_CALL(hipMemcpy(destination, source, static_cast<std::size_t>(bytes), hipMemcpyHostToHost));
 }
 
 } // namespace stdgpu::hip

--- a/src/stdgpu/hip/memory.h
+++ b/src/stdgpu/hip/memory.h
@@ -17,42 +17,78 @@
 #define STDGPU_HIP_MEMORY_H
 
 #include <stdgpu/cstddef.h>
-#include <stdgpu/memory.h>
 
 namespace stdgpu::hip
 {
 
 /**
- * \brief Performs platform-specific memory allocation
+ * \brief Performs platform-specific memory allocation on the device
+ * \param[in] array A pointer to the allocated array
+ * \param[in] bytes The size of the allocated array
+ */
+void
+malloc_device(void** array, index64_t bytes);
+
+/**
+ * \brief Performs platform-specific memory allocation on the host
  * \param[in] type The type of the memory to allocate
  * \param[in] array A pointer to the allocated array
  * \param[in] bytes The size of the allocated array
  */
 void
-malloc(const dynamic_memory_type type, void** array, index64_t bytes);
+malloc_host(void** array, index64_t bytes);
 
 /**
- * \brief Performs platform-specific memory deallocation
+ * \brief Performs platform-specific memory deallocation on the device
  * \param[in] type The type of the memory to deallocate
  * \param[in] array The allocated array
  */
 void
-free(const dynamic_memory_type type, void* array);
+free_device(void* array);
 
 /**
- * \brief Performs platform-specific memory copy
+ * \brief Performs platform-specific memory deallocation on the host
+ * \param[in] type The type of the memory to deallocate
+ * \param[in] array The allocated array
+ */
+void
+free_host(void* array);
+
+/**
+ * \brief Performs platform-specific memory copy from device to device
  * \param[in] destination The destination array
  * \param[in] source The source array
  * \param[in] bytes The size of the allocated array
- * \param[in] destination_type The type of the destination array
- * \param[in] source_type The type of the source array
  */
 void
-memcpy(void* destination,
-       const void* source,
-       index64_t bytes,
-       dynamic_memory_type destination_type,
-       dynamic_memory_type source_type);
+memcpy_device_to_device(void* destination, const void* source, index64_t bytes);
+
+/**
+ * \brief Performs platform-specific memory copy from device to host
+ * \param[in] destination The destination array
+ * \param[in] source The source array
+ * \param[in] bytes The size of the allocated array
+ */
+void
+memcpy_device_to_host(void* destination, const void* source, index64_t bytes);
+
+/**
+ * \brief Performs platform-specific memory copy from host to device
+ * \param[in] destination The destination array
+ * \param[in] source The source array
+ * \param[in] bytes The size of the allocated array
+ */
+void
+memcpy_host_to_device(void* destination, const void* source, index64_t bytes);
+
+/**
+ * \brief Performs platform-specific memory copy from host to host
+ * \param[in] destination The destination array
+ * \param[in] source The source array
+ * \param[in] bytes The size of the allocated array
+ */
+void
+memcpy_host_to_host(void* destination, const void* source, index64_t bytes);
 
 } // namespace stdgpu::hip
 

--- a/src/stdgpu/openmp/impl/memory.cpp
+++ b/src/stdgpu/openmp/impl/memory.cpp
@@ -15,7 +15,6 @@
 
 #include <stdgpu/openmp/memory.h>
 
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 
@@ -23,61 +22,50 @@ namespace stdgpu::openmp
 {
 
 void
-malloc(const dynamic_memory_type type, void** array, index64_t bytes)
+malloc_device(void** array, index64_t bytes)
 {
-    switch (type)
-    {
-        case dynamic_memory_type::device:
-        case dynamic_memory_type::host:
-        {
-            *array =
-                    std::malloc(static_cast<std::size_t>(bytes)); // NOLINT(hicpp-no-malloc,cppcoreguidelines-no-malloc)
-        }
-        break;
-
-        case dynamic_memory_type::invalid:
-        default:
-        {
-            printf("stdgpu::openmp::malloc : Unsupported dynamic memory type\n");
-            return;
-        }
-    }
+    *array = std::malloc(static_cast<std::size_t>(bytes)); // NOLINT(hicpp-no-malloc,cppcoreguidelines-no-malloc)
 }
 
 void
-free(const dynamic_memory_type type, void* array)
+malloc_host(void** array, index64_t bytes)
 {
-    switch (type)
-    {
-        case dynamic_memory_type::device:
-        case dynamic_memory_type::host:
-        {
-            std::free(array); // NOLINT(hicpp-no-malloc,cppcoreguidelines-no-malloc)
-        }
-        break;
-
-        case dynamic_memory_type::invalid:
-        default:
-        {
-            printf("stdgpu::openmp::free : Unsupported dynamic memory type\n");
-            return;
-        }
-    }
+    *array = std::malloc(static_cast<std::size_t>(bytes)); // NOLINT(hicpp-no-malloc,cppcoreguidelines-no-malloc)
 }
 
 void
-memcpy(void* destination,
-       const void* source,
-       index64_t bytes,
-       dynamic_memory_type destination_type,
-       dynamic_memory_type source_type)
+free_device(void* array)
 {
-    if (destination_type == dynamic_memory_type::invalid || source_type == dynamic_memory_type::invalid)
-    {
-        printf("stdgpu::openmp::memcpy : Unsupported dynamic source or destination memory type\n");
-        return;
-    }
+    std::free(array); // NOLINT(hicpp-no-malloc,cppcoreguidelines-no-malloc)
+}
 
+void
+free_host(void* array)
+{
+    std::free(array); // NOLINT(hicpp-no-malloc,cppcoreguidelines-no-malloc)
+}
+
+void
+memcpy_device_to_device(void* destination, const void* source, index64_t bytes)
+{
+    std::memcpy(destination, source, static_cast<std::size_t>(bytes));
+}
+
+void
+memcpy_device_to_host(void* destination, const void* source, index64_t bytes)
+{
+    std::memcpy(destination, source, static_cast<std::size_t>(bytes));
+}
+
+void
+memcpy_host_to_device(void* destination, const void* source, index64_t bytes)
+{
+    std::memcpy(destination, source, static_cast<std::size_t>(bytes));
+}
+
+void
+memcpy_host_to_host(void* destination, const void* source, index64_t bytes)
+{
     std::memcpy(destination, source, static_cast<std::size_t>(bytes));
 }
 

--- a/src/stdgpu/openmp/memory.h
+++ b/src/stdgpu/openmp/memory.h
@@ -17,42 +17,78 @@
 #define STDGPU_OPENMP_MEMORY_H
 
 #include <stdgpu/cstddef.h>
-#include <stdgpu/memory.h>
 
 namespace stdgpu::openmp
 {
 
 /**
- * \brief Performs platform-specific memory allocation
+ * \brief Performs platform-specific memory allocation on the device
+ * \param[in] array A pointer to the allocated array
+ * \param[in] bytes The size of the allocated array
+ */
+void
+malloc_device(void** array, index64_t bytes);
+
+/**
+ * \brief Performs platform-specific memory allocation on the host
  * \param[in] type The type of the memory to allocate
  * \param[in] array A pointer to the allocated array
  * \param[in] bytes The size of the allocated array
  */
 void
-malloc(const dynamic_memory_type type, void** array, index64_t bytes);
+malloc_host(void** array, index64_t bytes);
 
 /**
- * \brief Performs platform-specific memory deallocation
+ * \brief Performs platform-specific memory deallocation on the device
  * \param[in] type The type of the memory to deallocate
  * \param[in] array The allocated array
  */
 void
-free(const dynamic_memory_type type, void* array);
+free_device(void* array);
 
 /**
- * \brief Performs platform-specific memory copy
+ * \brief Performs platform-specific memory deallocation on the host
+ * \param[in] type The type of the memory to deallocate
+ * \param[in] array The allocated array
+ */
+void
+free_host(void* array);
+
+/**
+ * \brief Performs platform-specific memory copy from device to device
  * \param[in] destination The destination array
  * \param[in] source The source array
  * \param[in] bytes The size of the allocated array
- * \param[in] destination_type The type of the destination array
- * \param[in] source_type The type of the source array
  */
 void
-memcpy(void* destination,
-       const void* source,
-       index64_t bytes,
-       dynamic_memory_type destination_type,
-       dynamic_memory_type source_type);
+memcpy_device_to_device(void* destination, const void* source, index64_t bytes);
+
+/**
+ * \brief Performs platform-specific memory copy from device to host
+ * \param[in] destination The destination array
+ * \param[in] source The source array
+ * \param[in] bytes The size of the allocated array
+ */
+void
+memcpy_device_to_host(void* destination, const void* source, index64_t bytes);
+
+/**
+ * \brief Performs platform-specific memory copy from host to device
+ * \param[in] destination The destination array
+ * \param[in] source The source array
+ * \param[in] bytes The size of the allocated array
+ */
+void
+memcpy_host_to_device(void* destination, const void* source, index64_t bytes);
+
+/**
+ * \brief Performs platform-specific memory copy from host to host
+ * \param[in] destination The destination array
+ * \param[in] source The source array
+ * \param[in] bytes The size of the allocated array
+ */
+void
+memcpy_host_to_host(void* destination, const void* source, index64_t bytes);
 
 } // namespace stdgpu::openmp
 


### PR DESCRIPTION
The backend interface of `memory` expects the dynamic memory type to dispatch to the correct platform-specific call. However, this introduces a cyclic dependency to the high-level `memory` interface. Furthermore, dispatching should not be part of the backend logic as the backends should only provide the implementations of small building blocks which, in turn, are used to build the entire business logic. Redesign the backend API by splitting the malloc/free/memcpy functions into low-level pieces tied to a specific memory type configuration and move the respective dispatching logic up to the high-level shared implementation.