### PR TITLE
deque: Extend support for custom execution policies

### DIFF
--- a/src/stdgpu/deque.cuh
+++ b/src/stdgpu/deque.cuh
@@ -246,6 +246,17 @@ public:
     empty() const;
 
     /**
+     * \brief Checks if the object is empty
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if the object is empty, false otherwise
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    [[nodiscard]] bool
+    empty(ExecutionPolicy&& policy) const;
+
+    /**
      * \brief Checks if the object is full
      * \return True if the object is full, false otherwise
      */
@@ -253,11 +264,33 @@ public:
     full() const;
 
     /**
+     * \brief Checks if the object is full
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if the object is full, false otherwise
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    bool
+    full(ExecutionPolicy&& policy) const;
+
+    /**
      * \brief Returns the current size
      * \return The size
      */
     STDGPU_HOST_DEVICE index_t
     size() const;
+
+    /**
+     * \brief Returns the current size
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return The size
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    index_t
+    size(ExecutionPolicy&& policy) const;
 
     /**
      * \brief Returns the maximal size
@@ -373,8 +406,10 @@ private:
     bool
     occupied_count_valid(ExecutionPolicy&& policy) const;
 
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
     bool
-    size_valid() const;
+    size_valid(ExecutionPolicy&& policy) const;
 
     using mutex_array_allocator_type =
             typename stdgpu::allocator_traits<allocator_type>::template rebind_alloc<mutex_default_type>;

--- a/tests/stdgpu/deque.inc
+++ b/tests/stdgpu/deque.inc
@@ -1365,10 +1365,10 @@ TEST_F(stdgpu_deque, clear_custom_execution_policy)
 
     pool.clear(policy);
 
-    ASSERT_EQ(pool.size(), 0);
-    ASSERT_TRUE(pool.empty());
-    ASSERT_FALSE(pool.full());
-    ASSERT_TRUE(pool.valid());
+    ASSERT_EQ(pool.size(policy), 0);
+    ASSERT_TRUE(pool.empty(policy));
+    ASSERT_FALSE(pool.full(policy));
+    ASSERT_TRUE(pool.valid(policy));
 
     stdgpu::deque<int>::destroyDeviceObject(pool);
 }


### PR DESCRIPTION
Although all containers received support for custom `execution_policy`s, this support is complete due to a left-over synchronous memcpy. Fortunately, this limitation has been resolved. Extend the support for `deque` accordingly to fill some of the remaining holes.

Partially addresses #351