### PR TITLE
unordered_map,unordered_set: Extend support for custom execution policies

### DIFF
--- a/src/stdgpu/impl/unordered_base.cuh
+++ b/src/stdgpu/impl/unordered_base.cuh
@@ -409,6 +409,17 @@ public:
     empty() const;
 
     /**
+     * \brief Checks if the object is empty
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if the object is empty, false otherwise
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    [[nodiscard]] bool
+    empty(ExecutionPolicy&& policy) const;
+
+    /**
      * \brief Checks if the object is full
      * \return True if the object is full, false otherwise
      */
@@ -416,11 +427,33 @@ public:
     full() const;
 
     /**
+     * \brief Checks if the object is full
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if the object is full, false otherwise
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    bool
+    full(ExecutionPolicy&& policy) const;
+
+    /**
      * \brief The size
      * \return The size of the object
      */
     STDGPU_HOST_DEVICE index_t
     size() const;
+
+    /**
+     * \brief The size
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return The size of the object
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    index_t
+    size(ExecutionPolicy&& policy) const;
 
     /**
      * \brief The maximum size
@@ -442,6 +475,17 @@ public:
      */
     STDGPU_HOST_DEVICE float
     load_factor() const;
+
+    /**
+     * \brief The average number of elements per bucket
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return The average number of elements per bucket
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    float
+    load_factor(ExecutionPolicy&& policy) const;
 
     /**
      * \brief The maximum number of elements per bucket

--- a/src/stdgpu/impl/unordered_map_detail.cuh
+++ b/src/stdgpu/impl/unordered_map_detail.cuh
@@ -271,6 +271,15 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::empty() const
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+inline bool
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::empty(ExecutionPolicy&& policy) const
+{
+    return _base.empty(std::forward<ExecutionPolicy>(policy));
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_HOST_DEVICE bool
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::full() const
 {
@@ -278,10 +287,28 @@ unordered_map<Key, T, Hash, KeyEqual, Allocator>::full() const
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+inline bool
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::full(ExecutionPolicy&& policy) const
+{
+    return _base.full(std::forward<ExecutionPolicy>(policy));
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::size() const
 {
     return _base.size();
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+inline index_t
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::size(ExecutionPolicy&& policy) const
+{
+    return _base.size(std::forward<ExecutionPolicy>(policy));
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
@@ -303,6 +330,15 @@ inline STDGPU_HOST_DEVICE float
 unordered_map<Key, T, Hash, KeyEqual, Allocator>::load_factor() const
 {
     return _base.load_factor();
+}
+
+template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+inline float
+unordered_map<Key, T, Hash, KeyEqual, Allocator>::load_factor(ExecutionPolicy&& policy) const
+{
+    return _base.load_factor(std::forward<ExecutionPolicy>(policy));
 }
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>

--- a/src/stdgpu/impl/unordered_set_detail.cuh
+++ b/src/stdgpu/impl/unordered_set_detail.cuh
@@ -253,6 +253,15 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::empty() const
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+inline bool
+unordered_set<Key, Hash, KeyEqual, Allocator>::empty(ExecutionPolicy&& policy) const
+{
+    return _base.empty(std::forward<ExecutionPolicy>(policy));
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_HOST_DEVICE bool
 unordered_set<Key, Hash, KeyEqual, Allocator>::full() const
 {
@@ -260,10 +269,28 @@ unordered_set<Key, Hash, KeyEqual, Allocator>::full() const
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+inline bool
+unordered_set<Key, Hash, KeyEqual, Allocator>::full(ExecutionPolicy&& policy) const
+{
+    return _base.full(std::forward<ExecutionPolicy>(policy));
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
 inline STDGPU_HOST_DEVICE index_t
 unordered_set<Key, Hash, KeyEqual, Allocator>::size() const
 {
     return _base.size();
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+inline index_t
+unordered_set<Key, Hash, KeyEqual, Allocator>::size(ExecutionPolicy&& policy) const
+{
+    return _base.size(std::forward<ExecutionPolicy>(policy));
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
@@ -285,6 +312,15 @@ inline STDGPU_HOST_DEVICE float
 unordered_set<Key, Hash, KeyEqual, Allocator>::load_factor() const
 {
     return _base.load_factor();
+}
+
+template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
+template <typename ExecutionPolicy,
+          STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+inline float
+unordered_set<Key, Hash, KeyEqual, Allocator>::load_factor(ExecutionPolicy&& policy) const
+{
+    return _base.load_factor(std::forward<ExecutionPolicy>(policy));
 }
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>

--- a/src/stdgpu/unordered_map.cuh
+++ b/src/stdgpu/unordered_map.cuh
@@ -429,6 +429,17 @@ public:
     empty() const;
 
     /**
+     * \brief Checks if the object is empty
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if the object is empty, false otherwise
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    [[nodiscard]] bool
+    empty(ExecutionPolicy&& policy) const;
+
+    /**
      * \brief Checks if the object is full
      * \return True if the object is full, false otherwise
      */
@@ -436,11 +447,33 @@ public:
     full() const;
 
     /**
+     * \brief Checks if the object is full
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if the object is full, false otherwise
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    bool
+    full(ExecutionPolicy&& policy) const;
+
+    /**
      * \brief The size
      * \return The size of the object
      */
     STDGPU_HOST_DEVICE index_t
     size() const;
+
+    /**
+     * \brief The size
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return The size of the object
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    index_t
+    size(ExecutionPolicy&& policy) const;
 
     /**
      * \brief The maximum size
@@ -462,6 +495,17 @@ public:
      */
     STDGPU_HOST_DEVICE float
     load_factor() const;
+
+    /**
+     * \brief The average number of elements per bucket
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return The average number of elements per bucket
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    float
+    load_factor(ExecutionPolicy&& policy) const;
 
     /**
      * \brief The maximum number of elements per bucket

--- a/src/stdgpu/unordered_set.cuh
+++ b/src/stdgpu/unordered_set.cuh
@@ -418,6 +418,17 @@ public:
     empty() const;
 
     /**
+     * \brief Checks if the object is empty
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if the object is empty, false otherwise
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    [[nodiscard]] bool
+    empty(ExecutionPolicy&& policy) const;
+
+    /**
      * \brief Checks if the object is full
      * \return True if the object is full, false otherwise
      */
@@ -425,11 +436,33 @@ public:
     full() const;
 
     /**
+     * \brief Checks if the object is full
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return True if the object is full, false otherwise
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    bool
+    full(ExecutionPolicy&& policy) const;
+
+    /**
      * \brief The size
      * \return The size of the object
      */
     STDGPU_HOST_DEVICE index_t
     size() const;
+
+    /**
+     * \brief The size
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return The size of the object
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    index_t
+    size(ExecutionPolicy&& policy) const;
 
     /**
      * \brief The maximum size
@@ -451,6 +484,17 @@ public:
      */
     STDGPU_HOST_DEVICE float
     load_factor() const;
+
+    /**
+     * \brief The average number of elements per bucket
+     * \tparam ExecutionPolicy The type of the execution policy
+     * \param[in] policy The execution policy, e.g. host or device, corresponding to the allocator
+     * \return The average number of elements per bucket
+     */
+    template <typename ExecutionPolicy,
+              STDGPU_DETAIL_OVERLOAD_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
+    float
+    load_factor(ExecutionPolicy&& policy) const;
 
     /**
      * \brief The maximum number of elements per bucket

--- a/tests/stdgpu/unordered_datastructure.inc
+++ b/tests/stdgpu/unordered_datastructure.inc
@@ -248,8 +248,20 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, bucket_number_collisions)
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, empty_size_limits)
 {
+    EXPECT_TRUE(hash_datastructure.empty());
+    EXPECT_FALSE(hash_datastructure.full());
     EXPECT_LE(hash_datastructure.size(), hash_datastructure.max_size());
     EXPECT_LE(hash_datastructure.load_factor(), hash_datastructure.max_load_factor());
+}
+
+TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, empty_size_limits_custom_execution_policy)
+{
+    stdgpu::execution::device_policy policy;
+
+    EXPECT_TRUE(hash_datastructure.empty(policy));
+    EXPECT_FALSE(hash_datastructure.full(policy));
+    EXPECT_LE(hash_datastructure.size(policy), hash_datastructure.max_size());
+    EXPECT_LE(hash_datastructure.load_factor(policy), hash_datastructure.max_load_factor());
 }
 
 TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, hash_objects)
@@ -1935,8 +1947,8 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, insert_range_unique_parallel_c
     stdgpu::device_ptr<test_unordered_datastructure::value_type> values_end = stdgpu::device_end(values);
     hash_datastructure.insert(policy, values_begin, values_end);
 
-    EXPECT_FALSE(hash_datastructure.empty());
-    EXPECT_EQ(hash_datastructure.size(), N);
+    EXPECT_FALSE(hash_datastructure.empty(policy));
+    EXPECT_EQ(hash_datastructure.size(policy), N);
     EXPECT_TRUE(hash_datastructure.valid(policy));
 
     destroyDeviceArray<test_unordered_datastructure::value_type>(values);
@@ -2017,16 +2029,16 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, erase_range_unique_parallel_cu
     stdgpu::device_ptr<test_unordered_datastructure::value_type> values_end = stdgpu::device_end(values);
     hash_datastructure.insert(policy, values_begin, values_end);
 
-    EXPECT_FALSE(hash_datastructure.empty());
-    EXPECT_EQ(hash_datastructure.size(), N);
-    EXPECT_TRUE(hash_datastructure.valid());
+    EXPECT_FALSE(hash_datastructure.empty(policy));
+    EXPECT_EQ(hash_datastructure.size(policy), N);
+    EXPECT_TRUE(hash_datastructure.valid(policy));
 
     stdgpu::device_ptr<test_unordered_datastructure::key_type> positions_begin = stdgpu::device_begin(positions);
     stdgpu::device_ptr<test_unordered_datastructure::key_type> positions_end = stdgpu::device_end(positions);
     hash_datastructure.erase(policy, positions_begin, positions_end);
 
-    EXPECT_TRUE(hash_datastructure.empty());
-    EXPECT_EQ(hash_datastructure.size(), 0);
+    EXPECT_TRUE(hash_datastructure.empty(policy));
+    EXPECT_EQ(hash_datastructure.size(policy), 0);
     EXPECT_TRUE(hash_datastructure.valid(policy));
 
     destroyDeviceArray<test_unordered_datastructure::value_type>(values);
@@ -2489,7 +2501,7 @@ TEST_F(STDGPU_UNORDERED_DATASTRUCTURE_TEST_CLASS, clear_custom_execution_policy)
 
     hash_datastructure.clear(policy);
 
-    EXPECT_EQ(hash_datastructure.size(), 0);
+    EXPECT_EQ(hash_datastructure.size(policy), 0);
     EXPECT_TRUE(hash_datastructure.valid(policy));
 
     destroyHostArray<test_unordered_datastructure::key_type>(host_positions);


### PR DESCRIPTION
Although all containers received support for custom `execution_policy`s, this support is complete due to a left-over synchronous memcpy. Fortunately, this limitation has been resolved. Extend the support for `unordered_map` and `unordered_set` accordingly to fill some of the remaining holes.

Partially addresses #351