### PR TITLE
CI: Fall back to older codecov version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -71,7 +71,7 @@ jobs:
           path: build
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v5.0.3 # Bug in recent versions leading to "Missing Head Commit" error
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: build/stdgpu_coverage.info
@@ -90,6 +90,6 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: re-actors/alls-green@release/v1
-      with:
-        allowed-skips: publish
-        jobs: ${{ toJSON(needs) }}
+      - uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: publish
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -121,6 +121,6 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
   ubuntu:
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'ubuntu-24.04']
+        os: ["ubuntu-22.04", "ubuntu-24.04"]
         build_type: [Debug, Release]
         shared_libs: [ON, OFF]
         use_32bit_index: [ON, OFF]
@@ -86,7 +86,7 @@ jobs:
   windows:
     strategy:
       matrix:
-        os: ['windows-2019', 'windows-2022']
+        os: ["windows-2019", "windows-2022"]
         build_type: [Debug, Release]
         shared_libs: [ON, OFF]
         use_32bit_index: [ON, OFF]
@@ -148,6 +148,6 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Version 5.0.4 which has been released yesterday updated its internal wrapper code which, however, introduced a regression and prevents reports from being displayed. The reason seems that the git commits get messed up but we cannot do much on our side to fix this. Fall back to a slightly older version to workaround this issue until it has been fixed upstream.