### PR TITLE
CI: Allow for recent v5 versions of codecov action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -71,7 +71,7 @@ jobs:
           path: build
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v5.0.3 # Bug in recent versions leading to "Missing Head Commit" error
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: build/stdgpu_coverage.info


### PR DESCRIPTION
According to the triggered auto-update by dependabot in #452, a more recent point release of the codecov action seems to have fixed the regression that prevented reports from being displayed. Thus, revert the workaround from #451.

Supersedes #452 