### PR TITLE
Let the compiler determine char signedness

### DIFF
--- a/src/stdgpu/limits.h
+++ b/src/stdgpu/limits.h
@@ -253,7 +253,7 @@ struct numeric_limits<char>
      * \brief Whether the type is signed
      * \note implementation-defined
      */
-    static constexpr bool is_signed = ((char)(-1) < 0);
+    static constexpr bool is_signed = (static_cast<char>(-1) < 0);
 
     /**
      * \brief Whether the type is an integer
@@ -495,7 +495,7 @@ struct numeric_limits<wchar_t>
  * \brief Whether the type is signed
  * \note implementation-defined
  */
-    static constexpr bool is_signed = ((wchar_t)(-1) < 0);
+    static constexpr bool is_signed = (static_cast<wchar_t>(-1) < 0);
 
     /**
      * \brief Whether the type is an integer

--- a/src/stdgpu/limits.h
+++ b/src/stdgpu/limits.h
@@ -253,7 +253,7 @@ struct numeric_limits<char>
      * \brief Whether the type is signed
      * \note implementation-defined
      */
-    static constexpr bool is_signed = true;
+    static constexpr bool is_signed = ((char)(-1) < 0);
 
     /**
      * \brief Whether the type is an integer
@@ -495,11 +495,7 @@ struct numeric_limits<wchar_t>
  * \brief Whether the type is signed
  * \note implementation-defined
  */
-#if STDGPU_HOST_COMPILER == STDGPU_HOST_COMPILER_MSVC
-    static constexpr bool is_signed = false;
-#else
-    static constexpr bool is_signed = true;
-#endif
+    static constexpr bool is_signed = ((wchar_t)(-1) < 0);
 
     /**
      * \brief Whether the type is an integer

--- a/src/stdgpu/limits.h
+++ b/src/stdgpu/limits.h
@@ -490,11 +490,11 @@ struct numeric_limits<wchar_t>
      */
     static constexpr bool is_specialized = true;
 
-/**
- * \var is_signed
- * \brief Whether the type is signed
- * \note implementation-defined
- */
+    /**
+     * \var is_signed
+     * \brief Whether the type is signed
+     * \note implementation-defined
+     */
     static constexpr bool is_signed = (static_cast<wchar_t>(-1) < 0);
 
     /**


### PR DESCRIPTION
Instead of special-casing or assuming a particular signedness, you can
use the boolean expression ((T)(-1) < 0) to determine signedness of an
integer type at compile time.
