### PR TITLE
CI: Upgrade to Windows 2025 image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
   windows:
     strategy:
       matrix:
-        os: ["windows-2019", "windows-2022"]
+        os: ["windows-2022", "windows-2025"]
         build_type: [Debug, Release]
         shared_libs: [ON, OFF]
         use_32bit_index: [ON, OFF]


### PR DESCRIPTION
The CI image for Windows 2025 has been released a few months ago and has matured until now. Since Windows 2019 will soon be retired (see [announcement](https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/)), upgrade the respective jobs to this version.