### PR TITLE
examples,src: Handle and fix more recent clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,7 @@ hicpp-*,\
 misc-*,\
 -misc-const-correctness,\
 -misc-include-cleaner,\
+-misc-use-internal-linkage,\
 modernize-*,\
 -modernize-avoid-c-arrays,\
 -modernize-use-auto,\

--- a/examples/createAndDestroyDeviceObject.cpp
+++ b/examples/createAndDestroyDeviceObject.cpp
@@ -69,7 +69,7 @@ public:
     STDGPU_HOST_DEVICE std::uint8_t&
     operator()(const stdgpu::index_t x, const stdgpu::index_t y)
     {
-        return _values[y * _width + x];
+        return _values[(y * _width) + x];
     }
 
     STDGPU_HOST_DEVICE stdgpu::index_t

--- a/src/stdgpu/impl/algorithm_detail.h
+++ b/src/stdgpu/impl/algorithm_detail.h
@@ -29,14 +29,14 @@ template <class T>
 constexpr STDGPU_HOST_DEVICE const T&
 min(const T& a, const T& b)
 {
-    return (b < a) ? b : a;
+    return (b < a) ? b : a; // NOLINT(bugprone-return-const-ref-from-parameter)
 }
 
 template <class T>
 constexpr STDGPU_HOST_DEVICE const T&
 max(const T& a, const T& b)
 {
-    return (a < b) ? b : a;
+    return (a < b) ? b : a; // NOLINT(bugprone-return-const-ref-from-parameter)
 }
 
 template <class T>
@@ -45,7 +45,8 @@ clamp(const T& v, const T& lower, const T& upper)
 {
     STDGPU_EXPECTS(!(upper < lower));
 
-    return v < lower ? lower : upper < v ? upper : v; // NOLINT(readability-avoid-nested-conditional-operator)
+    // NOLINTNEXTLINE(bugprone-return-const-ref-from-parameter,readability-avoid-nested-conditional-operator)
+    return v < lower ? lower : upper < v ? upper : v;
 }
 
 template <typename IndexType,
@@ -58,7 +59,7 @@ for_each_index(ExecutionPolicy&& policy, IndexType size, UnaryFunction f)
     thrust::for_each(std::forward<ExecutionPolicy>(policy),
                      thrust::counting_iterator<IndexType>(0),
                      thrust::counting_iterator<IndexType>(size),
-                     f);
+                     std::move(f));
 }
 
 namespace detail

--- a/src/stdgpu/impl/bitset_detail.cuh
+++ b/src/stdgpu/impl/bitset_detail.cuh
@@ -17,6 +17,7 @@
 #define STDGPU_BITSET_DETAIL_H
 
 #include <limits>
+#include <type_traits>
 
 #include <stdgpu/algorithm.h>
 #include <stdgpu/atomic.cuh>
@@ -119,7 +120,7 @@ div_up(const index_t a, const index_t b) noexcept
     STDGPU_EXPECTS(a >= 0);
     STDGPU_EXPECTS(b > 0);
 
-    index_t result = (a % b != 0) ? (a / b + 1) : (a / b);
+    index_t result = (a % b != 0) ? ((a / b) + 1) : (a / b);
 
     STDGPU_ENSURES(result * b >= a);
 
@@ -146,7 +147,7 @@ private:
     STDGPU_HOST_DEVICE Block
     block_mask(const index_t i) const
     {
-        index_t remaining_bits = _size - i * _bits_per_block;
+        index_t remaining_bits = _size - (i * _bits_per_block);
         return (remaining_bits >= _bits_per_block)
                        ? ~static_cast<Block>(0)
                        : (static_cast<Block>(1) << static_cast<Block>(remaining_bits)) - static_cast<Block>(1);
@@ -256,7 +257,7 @@ template <typename ExecutionPolicy,
 inline void
 bitset<Block, Allocator>::set(ExecutionPolicy&& policy)
 {
-    fill(std::forward<ExecutionPolicy>(policy), device_begin(_bit_blocks), device_end(_bit_blocks), ~block_type(0));
+    fill(std::decay_t<ExecutionPolicy>{ policy }, device_begin(_bit_blocks), device_end(_bit_blocks), ~block_type(0));
 
     STDGPU_ENSURES(count(std::forward<ExecutionPolicy>(policy)) == size());
 }
@@ -284,7 +285,7 @@ template <typename ExecutionPolicy,
 inline void
 bitset<Block, Allocator>::reset(ExecutionPolicy&& policy)
 {
-    fill(std::forward<ExecutionPolicy>(policy), device_begin(_bit_blocks), device_end(_bit_blocks), block_type(0));
+    fill(std::decay_t<ExecutionPolicy>{ policy }, device_begin(_bit_blocks), device_end(_bit_blocks), block_type(0));
 
     STDGPU_ENSURES(count(std::forward<ExecutionPolicy>(policy)) == 0);
 }

--- a/src/stdgpu/impl/memory_detail.h
+++ b/src/stdgpu/impl/memory_detail.h
@@ -174,7 +174,7 @@ unoptimized_destroy(ExecutionPolicy&& policy, Iterator first, Iterator last)
 
 template <typename T>
 T*
-createDeviceArray(const stdgpu::index64_t count, const T default_value)
+createDeviceArray(const stdgpu::index64_t count, const T default_value) // NOLINT(performance-unnecessary-value-param)
 {
     T* device_array = nullptr;
 
@@ -441,8 +441,8 @@ template <typename ExecutionPolicy,
           typename... Args,
           STDGPU_DETAIL_OVERLOAD_DEFINITION_IF(is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>)>
 device_unique_object<T>::device_unique_object(ExecutionPolicy&& policy, Args&&... args)
-  : _object(new T(T::createDeviceObject(std::forward<ExecutionPolicy>(policy), std::forward<Args>(args)...)),
-            [_policy = std::forward<ExecutionPolicy>(policy)](T* ptr)
+  : _object(new T(T::createDeviceObject(std::decay_t<ExecutionPolicy>{ policy }, std::forward<Args>(args)...)),
+            [_policy = std::decay_t<ExecutionPolicy>{ policy }](T* ptr)
             {
                 T::destroyDeviceObject(_policy, *ptr);
                 delete ptr;


### PR DESCRIPTION
clang-tidy 20 introduced more warnings to consider. In particular, it exposed unsafe usage of perfect forwarding which - in this case - should be mostly unproblematic but may still break. Handle these warnings by either suppressing or fixing them.