### PR TITLE
General: Add CUDA 13 support

### DIFF
--- a/cmake/cuda/determine_thrust_paths.cmake
+++ b/cmake/cuda/determine_thrust_paths.cmake
@@ -4,7 +4,17 @@ function(stdgpu_determine_thrust_paths STDGPU_OUTPUT_THRUST_PATHS)
 
     find_package(CUDAToolkit QUIET)
 
-    set(${STDGPU_OUTPUT_THRUST_PATHS} "${CUDAToolkit_INCLUDE_DIRS}")
+    if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL 13 AND CMAKE_VERSION VERSION_LESS 3.31.9)
+        set(STDGPU_CUDATOOLKIT_INCLUDE_DIRS "${CUDAToolkit_INCLUDE_DIRS}")
+
+        foreach(dir IN LISTS CUDAToolkit_INCLUDE_DIRS)
+            list(APPEND STDGPU_CUDATOOLKIT_INCLUDE_DIRS "${dir}/cccl")
+        endforeach()
+
+        set(${STDGPU_OUTPUT_THRUST_PATHS} "${STDGPU_CUDATOOLKIT_INCLUDE_DIRS}")
+    else()
+        set(${STDGPU_OUTPUT_THRUST_PATHS} "${CUDAToolkit_INCLUDE_DIRS}")
+    endif()
 
     # Make output variable visible
     set(${STDGPU_OUTPUT_THRUST_PATHS} ${${STDGPU_OUTPUT_THRUST_PATHS}} PARENT_SCOPE)

--- a/src/stdgpu/cuda/impl/device.cpp
+++ b/src/stdgpu/cuda/impl/device.cpp
@@ -50,8 +50,10 @@ namespace stdgpu::cuda
 void
 print_device_information()
 {
+    int device = 0;
+
     cudaDeviceProp properties;
-    if (cudaGetDeviceProperties(&properties, 0) != cudaSuccess)
+    if (cudaGetDeviceProperties(&properties, device) != cudaSuccess)
     {
         printf("+---------------------------------------------------------+\n");
         printf("|                   Invalid CUDA Device                   |\n");
@@ -66,6 +68,9 @@ print_device_information()
     std::size_t total_memory = 0;
     STDGPU_CUDA_SAFE_CALL(cudaMemGetInfo(&free_memory, &total_memory));
 
+    int clock_rate = 0;
+    cudaDeviceGetAttribute(&clock_rate, cudaDevAttrClockRate, device);
+
     std::string gpu_name = properties.name;
     const int gpu_name_total_width = 57;
     int gpu_name_size = static_cast<int>(gpu_name.size());
@@ -77,7 +82,7 @@ print_device_information()
     printf("+---------------------------------------------------------+\n");
     printf("| Compute Capability        :   %1d.%1d                       |\n", properties.major, properties.minor);
     printf("| Clock rate                :   %-6.0f MHz                |\n",
-           static_cast<double>(detail::kilo_to_mega_hertz(static_cast<float>(properties.clockRate))));
+           static_cast<double>(detail::kilo_to_mega_hertz(static_cast<float>(clock_rate))));
     printf("| Global Memory             :   %-6.3f GiB / %-6.3f GiB   |\n",
            static_cast<double>(detail::byte_to_gibi_byte(static_cast<float>(free_memory))),
            static_cast<double>(detail::byte_to_gibi_byte(static_cast<float>(total_memory))));

--- a/src/stdgpu/iterator.h
+++ b/src/stdgpu/iterator.h
@@ -50,38 +50,6 @@ using device_ptr = thrust::pointer<T, thrust::device_system_tag>;
 template <typename T>
 using host_ptr = thrust::pointer<T, thrust::host_system_tag>;
 
-} // namespace stdgpu
-
-//! @cond Doxygen_Suppress
-namespace std // NOLINT(cert-dcl58-cpp)
-{
-
-template <typename T>
-struct iterator_traits<stdgpu::device_ptr<T>> // NOLINT(cert-dcl58-cpp)
-{
-    using difference_type = typename std::iterator_traits<T*>::difference_type;
-    using value_type = typename std::iterator_traits<T*>::value_type;
-    using pointer = typename std::iterator_traits<T*>::pointer;
-    using reference = typename std::iterator_traits<T*>::reference;
-    using iterator_category = typename stdgpu::device_ptr<T>::iterator_category;
-};
-
-template <typename T>
-struct iterator_traits<stdgpu::host_ptr<T>> // NOLINT(cert-dcl58-cpp)
-{
-    using difference_type = typename std::iterator_traits<T*>::difference_type;
-    using value_type = typename std::iterator_traits<T*>::value_type;
-    using pointer = typename std::iterator_traits<T*>::pointer;
-    using reference = typename std::iterator_traits<T*>::reference;
-    using iterator_category = typename stdgpu::host_ptr<T>::iterator_category;
-};
-
-} // namespace std
-//! @endcond
-
-namespace stdgpu
-{
-
 /**
  * \ingroup iterator
  * \brief Constructs a device_ptr object


### PR DESCRIPTION
CUDA 13 introduced several breaking changes that are documented in their [migration guide](https://nvidia.github.io/cccl/cccl/3.0_migration_guide.html). In our case, this affects the `clockRate` member when fetching device properties as well as our iterator API which specializes `std::iterator_traits`. Migrate to the recommended solutions to enable support of CUDA 13.

Fixes #465 