### PR TITLE
build: Add NOMINMAX definition for MSVC compatibility

### DIFF
--- a/benchmarks/stdgpu/CMakeLists.txt
+++ b/benchmarks/stdgpu/CMakeLists.txt
@@ -11,6 +11,8 @@ target_compile_options(benchmarkstdgpu PRIVATE ${STDGPU_DEVICE_FLAGS}
                                                ${STDGPU_TEST_DEVICE_FLAGS}
                                                ${STDGPU_TEST_HOST_FLAGS})
 
+target_compile_definitions(benchmarkstdgpu PRIVATE $<$<PLATFORM_ID:Windows>:NOMINMAX>)
+
 target_link_libraries(benchmarkstdgpu PRIVATE
                                       stdgpu::stdgpu
                                       benchmark::benchmark)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,6 +8,7 @@ macro(stdgpu_detail_add_example)
     target_compile_options(${STDGPU_EXAMPLES_NAME} PRIVATE ${STDGPU_DEVICE_FLAGS}
                                                            ${STDGPU_HOST_FLAGS})
     target_link_libraries(${STDGPU_EXAMPLES_NAME} PRIVATE stdgpu::stdgpu)
+    target_compile_definitions(${STDGPU_EXAMPLES_NAME} PRIVATE $<$<PLATFORM_ID:Windows>:NOMINMAX>)
     set_target_properties(${STDGPU_EXAMPLES_NAME} PROPERTIES CXX_CLANG_TIDY "${STDGPU_PROPERTY_CLANG_TIDY}")
     set_target_properties(${STDGPU_EXAMPLES_NAME} PROPERTIES CXX_CPPCHECK "${STDGPU_PROPERTY_CPPCHECK}")
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)

--- a/src/stdgpu/CMakeLists.txt
+++ b/src/stdgpu/CMakeLists.txt
@@ -132,6 +132,8 @@ target_compile_features(stdgpu PUBLIC cxx_std_17)
 target_compile_options(stdgpu PRIVATE ${STDGPU_DEVICE_FLAGS}
                                       ${STDGPU_HOST_FLAGS})
 
+target_compile_definitions(stdgpu PRIVATE $<$<PLATFORM_ID:Windows>:NOMINMAX>)
+
 target_link_libraries(stdgpu PUBLIC thrust::thrust)
 
 set_target_properties(stdgpu PROPERTIES CXX_CLANG_TIDY "${STDGPU_PROPERTY_CLANG_TIDY}")

--- a/tests/stdgpu/CMakeLists.txt
+++ b/tests/stdgpu/CMakeLists.txt
@@ -22,7 +22,7 @@ target_compile_options(teststdgpu PRIVATE ${STDGPU_DEVICE_FLAGS}
                                           ${STDGPU_HOST_FLAGS}
                                           ${STDGPU_TEST_DEVICE_FLAGS}
                                           ${STDGPU_TEST_HOST_FLAGS})
-
+target_compile_definitions(teststdgpu PRIVATE $<$<PLATFORM_ID:Windows>:NOMINMAX>)
 target_link_libraries(teststdgpu PRIVATE
                                  stdgpu::stdgpu
                                  GTest::gtest)


### PR DESCRIPTION
- Build system improvement:
  * Added #pragma push_macro/#pragma pop_macro to prevent conflicts with the `min` and `max` macros defined in Windows headers.