### PR TITLE
examples: Fix deprecation warnings with CUDA 13.1+

### DIFF
--- a/examples/cuda/deque.cu
+++ b/examples/cuda/deque.cu
@@ -57,6 +57,15 @@ insert_neighbors_with_duplicates(const int* d_input, const stdgpu::index_t n, st
     }
 }
 
+// thrust 3.1 (CUDA 13.1) encourages using C++ standard conforming functors
+#if THRUST_MAJOR_VERSION >= 3 && THRUST_MINOR_VERSION >= 1
+template <class T = void>
+using plus = cuda::std::plus<T>;
+#else
+template <class T = void>
+using plus = thrust::plus<T>;
+#endif
+
 int
 main()
 {
@@ -87,7 +96,7 @@ main()
     // deq : 0, 1, 1, 2, 2, 2, 3, 3, 3,  ..., 99, 99, 99, 100, 100, 101
 
     auto range_deq = deq.device_range();
-    int sum = thrust::reduce(range_deq.begin(), range_deq.end(), 0, thrust::plus<int>());
+    int sum = thrust::reduce(range_deq.begin(), range_deq.end(), 0, plus<int>());
 
     const int sum_closed_form = 3 * (n * (n + 1) / 2);
 

--- a/examples/cuda/iterator.cu
+++ b/examples/cuda/iterator.cu
@@ -32,6 +32,15 @@ struct is_odd
     }
 };
 
+// thrust 3.1 (CUDA 13.1) encourages using C++ standard conforming functors
+#if THRUST_MAJOR_VERSION >= 3 && THRUST_MINOR_VERSION >= 1
+template <class T = void>
+using plus = cuda::std::plus<T>;
+#else
+template <class T = void>
+using plus = thrust::plus<T>;
+#endif
+
 int
 main()
 {
@@ -54,7 +63,7 @@ main()
 
     // vec : 1, 3, 5, ..., 99
 
-    int sum = thrust::reduce(stdgpu::device_cbegin(vec), stdgpu::device_cend(vec), 0, thrust::plus<int>());
+    int sum = thrust::reduce(stdgpu::device_cbegin(vec), stdgpu::device_cend(vec), 0, plus<int>());
 
     const int sum_closed_form = n * n / 4;
 

--- a/examples/cuda/mutex_array.cu
+++ b/examples/cuda/mutex_array.cu
@@ -64,6 +64,15 @@ try_partial_sum(const int* d_input, const stdgpu::index_t n, stdgpu::mutex_array
     }
 }
 
+// thrust 3.1 (CUDA 13.1) encourages using C++ standard conforming functors
+#if THRUST_MAJOR_VERSION >= 3 && THRUST_MINOR_VERSION >= 1
+template <class T = void>
+using plus = cuda::std::plus<T>;
+#else
+template <class T = void>
+using plus = thrust::plus<T>;
+#endif
+
 int
 main()
 {
@@ -94,7 +103,7 @@ main()
                                                                                                d_result);
     cudaDeviceSynchronize();
 
-    int sum = thrust::reduce(stdgpu::device_cbegin(d_result), stdgpu::device_cend(d_result), 0, thrust::plus<int>());
+    int sum = thrust::reduce(stdgpu::device_cbegin(d_result), stdgpu::device_cend(d_result), 0, plus<int>());
 
     const int sum_closed_form = n * (n + 1) / 2;
 

--- a/examples/cuda/ranges.cu
+++ b/examples/cuda/ranges.cu
@@ -33,6 +33,15 @@ struct square_int
     }
 };
 
+// thrust 3.1 (CUDA 13.1) encourages using C++ standard conforming functors
+#if THRUST_MAJOR_VERSION >= 3 && THRUST_MINOR_VERSION >= 1
+template <class T = void>
+using plus = cuda::std::plus<T>;
+#else
+template <class T = void>
+using plus = thrust::plus<T>;
+#endif
+
 int
 main()
 {
@@ -70,14 +79,14 @@ main()
     // set : 1, 4, 9, ..., 10000
 
     auto range_set = set.device_range();
-    int sum = thrust::reduce(range_set.begin(), range_set.end(), 0, thrust::plus<int>());
+    int sum = thrust::reduce(range_set.begin(), range_set.end(), 0, plus<int>());
 
     // If thrust had a range interface (maybe in a future release), the above call could also be written in a shorter
     // form:
     //
     // int sum = thrust::reduce(set.device_range(),
     //                          0,
-    //                          thrust::plus<int>());
+    //                          plus<int>());
     //
     // Or the call to device_range may also become an implicit operation in the future.
 

--- a/examples/cuda/unordered_set.cu
+++ b/examples/cuda/unordered_set.cu
@@ -49,6 +49,15 @@ insert_neighbors(const int* d_result, const stdgpu::index_t n, stdgpu::unordered
     }
 }
 
+// thrust 3.1 (CUDA 13.1) encourages using C++ standard conforming functors
+#if THRUST_MAJOR_VERSION >= 3 && THRUST_MINOR_VERSION >= 1
+template <class T = void>
+using plus = cuda::std::plus<T>;
+#else
+template <class T = void>
+using plus = thrust::plus<T>;
+#endif
+
 int
 main()
 {
@@ -83,7 +92,7 @@ main()
     // set : 0, 1, 2, 3, ..., 100
 
     auto range_set = set.device_range();
-    int sum = thrust::reduce(range_set.begin(), range_set.end(), 0, thrust::plus<int>());
+    int sum = thrust::reduce(range_set.begin(), range_set.end(), 0, plus<int>());
 
     const int sum_closed_form = n * (n + 1) / 2;
 

--- a/examples/cuda/vector.cu
+++ b/examples/cuda/vector.cu
@@ -40,6 +40,15 @@ insert_neighbors_with_duplicates(const int* d_input, const stdgpu::index_t n, st
     }
 }
 
+// thrust 3.1 (CUDA 13.1) encourages using C++ standard conforming functors
+#if THRUST_MAJOR_VERSION >= 3 && THRUST_MINOR_VERSION >= 1
+template <class T = void>
+using plus = cuda::std::plus<T>;
+#else
+template <class T = void>
+using plus = thrust::plus<T>;
+#endif
+
 int
 main()
 {
@@ -69,7 +78,7 @@ main()
     // vec : 0, 1, 1, 2, 2, 2, 3, 3, 3,  ..., 99, 99, 99, 100, 100, 101
 
     auto range_vec = vec.device_range();
-    int sum = thrust::reduce(range_vec.begin(), range_vec.end(), 0, thrust::plus<int>());
+    int sum = thrust::reduce(range_vec.begin(), range_vec.end(), 0, plus<int>());
 
     const int sum_closed_form = 3 * (n * (n + 1) / 2);
 


### PR DESCRIPTION
In thrust 3.1 (bundled with CUDA 13.1), the functors defined in `functional.h` were deprecated in favor of the C++ standard conforming version provided in libcudacxx. This results in warnings thrown when building the examples. Fix these warnings while ensuring backwards compatibility with older CUDA versions.