### PR TITLE
scripts: Use absolute path for thrust_ROOT

### DIFF
--- a/tools/backend/check_install_openmp.sh
+++ b/tools/backend/check_install_openmp.sh
@@ -13,5 +13,5 @@ sh tools/backend/helper/create_empty_directory.sh build_install_test
 
 # Compile dependent project
 cmake -E cmake_echo_color --blue ">>>>> Check installation ($CONFIG)"
-cmake -B build_install_test -S tests/install_test -DCMAKE_BUILD_TYPE=$CONFIG -Dstdgpu_ROOT=bin -Dthrust_ROOT=external/cccl/thrust $@
+cmake -B build_install_test -S tests/install_test -DCMAKE_BUILD_TYPE=$CONFIG -Dstdgpu_ROOT=bin -Dthrust_ROOT=$(pwd)/external/cccl/thrust $@
 cmake --build build_install_test --config ${CONFIG} --parallel 13

--- a/tools/backend/configure_openmp.sh
+++ b/tools/backend/configure_openmp.sh
@@ -12,4 +12,4 @@ fi
 sh tools/backend/helper/create_empty_directory.sh build
 
 # Configure project
-sh tools/backend/helper/configure.sh $CONFIG -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/cccl/thrust -DCMAKE_VERIFY_INTERFACE_HEADER_SETS=ON $@
+sh tools/backend/helper/configure.sh $CONFIG -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=$(pwd)/external/cccl/thrust -DCMAKE_VERIFY_INTERFACE_HEADER_SETS=ON $@

--- a/tools/backend/configure_openmp_clang_tidy.sh
+++ b/tools/backend/configure_openmp_clang_tidy.sh
@@ -5,4 +5,4 @@ set -e
 sh tools/backend/helper/create_empty_directory.sh build
 
 # Configure project
-sh tools/backend/helper/configure.sh Debug -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_ANALYZE_WITH_CLANG_TIDY=ON -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/cccl/thrust
+sh tools/backend/helper/configure.sh Debug -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_ANALYZE_WITH_CLANG_TIDY=ON -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=$(pwd)/external/cccl/thrust

--- a/tools/backend/configure_openmp_cppcheck.sh
+++ b/tools/backend/configure_openmp_cppcheck.sh
@@ -5,4 +5,4 @@ set -e
 sh tools/backend/helper/create_empty_directory.sh build
 
 # Configure project
-sh tools/backend/helper/configure.sh Debug -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_ANALYZE_WITH_CPPCHECK=ON -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/cccl/thrust
+sh tools/backend/helper/configure.sh Debug -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_ANALYZE_WITH_CPPCHECK=ON -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=$(pwd)/external/cccl/thrust

--- a/tools/backend/configure_openmp_documentation.sh
+++ b/tools/backend/configure_openmp_documentation.sh
@@ -5,4 +5,4 @@ set -e
 sh tools/backend/helper/create_empty_directory.sh build
 
 # Configure project
-sh tools/backend/helper/configure.sh Release -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_BUILD_DOCUMENTATION=ON -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=external/cccl/thrust
+sh tools/backend/helper/configure.sh Release -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_BUILD_DOCUMENTATION=ON -DSTDGPU_COMPILE_WARNING_AS_ERROR=ON -Dthrust_ROOT=$(pwd)/external/cccl/thrust

--- a/tools/backend/configure_openmp_lcov.sh
+++ b/tools/backend/configure_openmp_lcov.sh
@@ -5,4 +5,4 @@ set -e
 sh tools/backend/helper/create_empty_directory.sh build
 
 # Configure project
-sh tools/backend/helper/configure.sh Debug -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_BUILD_TEST_COVERAGE=ON -Dthrust_ROOT=external/cccl/thrust
+sh tools/backend/helper/configure.sh Debug -DSTDGPU_BACKEND=STDGPU_BACKEND_OPENMP -DSTDGPU_BUILD_TEST_COVERAGE=ON -Dthrust_ROOT=$(pwd)/external/cccl/thrust


### PR DESCRIPTION
The recent update of the CI runner images resulted in configure failures with thrust not being correctly detected. The helper scripts specify a relative `thrust_ROOT` path which was previously interpreted relative to the project root directly, but now resolves relative to the call site of `find_package(thrust)`. Specify the root directory as an absolute path to avoid different interpretations of the base directory as it is intended to be a search prefix anyways.